### PR TITLE
Replies

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -74,8 +74,8 @@ module Discordrb::API::Channel
   # https://discordapp.com/developers/docs/resources/channel#create-message
   # @param attachments [Array<File>, nil] Attachments to use with `attachment://` in embeds. See
   #   https://discord.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds
-  def create_message(token, channel_id, message, tts = false, embed = nil, nonce = nil, attachments = nil, allowed_mentions = nil)
-    body = { content: message, tts: tts, embed: embed, nonce: nonce, allowed_mentions: allowed_mentions }
+  def create_message(token, channel_id, message, tts = false, embed = nil, nonce = nil, attachments = nil, allowed_mentions = nil, message_reference = nil)
+    body = { content: message, tts: tts, embed: embed, nonce: nonce, allowed_mentions: allowed_mentions, message_reference: message_reference }
     body = if attachments
              files = [*0...attachments.size].zip(attachments).to_h
              { **files, payload_json: body.to_json }

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -370,8 +370,9 @@ module Discordrb
       channel = channel.resolve_id
       debug("Sending message to #{channel} with content '#{content}'")
       allowed_mentions = { parse: [] } if allowed_mentions == false
+      message_reference = { message_id: message_reference.id } if message_reference
 
-      response = API::Channel.create_message(token, channel, content, tts, embed&.to_hash, nil, attachments, allowed_mentions&.to_hash, message_reference&.id)
+      response = API::Channel.create_message(token, channel, content, tts, embed&.to_hash, nil, attachments, allowed_mentions&.to_hash, message_reference)
       Message.new(JSON.parse(response), self)
     end
 

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -364,13 +364,14 @@ module Discordrb
     # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
     # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
+    # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @return [Message] The message that was sent.
-    def send_message(channel, content, tts = false, embed = nil, attachments = nil, allowed_mentions = nil)
+    def send_message(channel, content, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil)
       channel = channel.resolve_id
       debug("Sending message to #{channel} with content '#{content}'")
       allowed_mentions = { parse: [] } if allowed_mentions == false
 
-      response = API::Channel.create_message(token, channel, content, tts, embed ? embed.to_hash : nil, nil, attachments, allowed_mentions ? allowed_mentions.to_hash : nil)
+      response = API::Channel.create_message(token, channel, content, tts, embed&.to_hash, nil, attachments, allowed_mentions&.to_hash, message_reference&.id)
       Message.new(JSON.parse(response), self)
     end
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'discordrb/allowed_mentions'
 require 'discordrb/permissions'
 require 'discordrb/id_object'
 require 'discordrb/colour_rgb'

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -340,9 +340,10 @@ module Discordrb
     # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
     # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
+    # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @return [Message] the message that was sent.
-    def send_message(content, tts = false, embed = nil, attachments = nil, allowed_mentions = nil)
-      @bot.send_message(@id, content, tts, embed, attachments, allowed_mentions)
+    def send_message(content, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil)
+      @bot.send_message(@id, content, tts, embed, attachments, allowed_mentions, message_reference)
     end
 
     alias_method :send, :send_message
@@ -354,8 +355,9 @@ module Discordrb
     # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
     # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
-    def send_temporary_message(content, timeout, tts = false, embed = nil, attachments = nil, allowed_mentions = nil)
-      @bot.send_temporary_message(@id, content, timeout, tts, embed, attachments, allowed_mentions)
+    # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
+    def send_temporary_message(content, timeout, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil)
+      @bot.send_temporary_message(@id, content, timeout, tts, embed, attachments, allowed_mentions, message_reference)
     end
 
     # Convenience method to send a message with an embed.
@@ -369,13 +371,14 @@ module Discordrb
     # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
     # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
+    # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @yield [embed] Yields the embed to allow for easy building inside a block.
     # @yieldparam embed [Discordrb::Webhooks::Embed] The embed from the parameters, or a new one.
     # @return [Message] The resulting message.
-    def send_embed(message = '', embed = nil, attachments = nil, tts = false, allowed_mentions = nil)
+    def send_embed(message = '', embed = nil, attachments = nil, tts = false, allowed_mentions = nil, message_reference = nil)
       embed ||= Discordrb::Webhooks::Embed.new
       yield(embed) if block_given?
-      send_message(message, tts, embed, attachments, allowed_mentions)
+      send_message(message, tts, embed, attachments, allowed_mentions, message_reference)
     end
 
     # Sends multiple messages to a channel

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -80,6 +80,9 @@ module Discordrb
       @nonce = data['nonce']
       @mention_everyone = data['mention_everyone']
 
+      @referenced_message = Message.new(data['referenced_message'], bot) if data['referenced_message']
+      @message_reference = data['message_reference']
+
       @server = bot.server(data['guild_id'].to_i) if data['guild_id']
 
       @author = if data['author']
@@ -142,9 +145,28 @@ module Discordrb
     end
 
     # Replies to this message with the specified content.
+    # @deprecated Please use {#respond}.
     # @see Channel#send_message
     def reply(content)
       @channel.send_message(content)
+    end
+
+    # Sends a message to this channel.
+    # @param content [String] The content to send. Should not be longer than 2000 characters or it will result in an error.
+    # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
+    # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
+    # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
+    # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
+    # @param mention_user [true, false] Whether the user that is being replied to should be pinged by the reply.
+    # @return [Message] the message that was sent.
+    def reply!(content, tts = false, embed = nil, attachments = nil, allowed_mentions = {}, mention_user: false)
+      allowed_mentions[:replied_user] = mention_user
+      respond(content, tts, embed, attachments, allowed_mentions, self)
+    end
+
+    # (see Channel#send_message)
+    def respond(content, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil)
+      @channel.send_message(content, tts, embed, attachments, allowed_mentions, message_reference)
     end
 
     # Edits this message to have the specified content instead.
@@ -283,5 +305,20 @@ module Discordrb
     end
 
     alias_method :jump_link, :link
+
+    # Whether or not this message was sent in reply to another message
+    # @return [true, false]
+    def reply?
+      !@referenced_message.nil?
+    end
+
+    # @return [Message, nil] the Message this Message was sent in reply to.
+    def referenced_message
+      return @referenced_message if @referenced_message
+      return nil unless @message_reference
+
+      referenced_channel = @bot.channel(@message_reference['channel_id'])
+      @referenced_message = referenced_channel.message(@message_reference['message_id'])
+    end
   end
 end

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -159,7 +159,8 @@ module Discordrb
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
     # @param mention_user [true, false] Whether the user that is being replied to should be pinged by the reply.
     # @return [Message] the message that was sent.
-    def reply!(content, tts = false, embed = nil, attachments = nil, allowed_mentions = {}, mention_user: false)
+    def reply!(content, tts: false, embed: nil, attachments: nil, allowed_mentions: {}, mention_user: false)
+      allowed_mentions = { parse: [] } if allowed_mentions == false
       allowed_mentions = allowed_mentions.to_hash.transform_keys(&:to_sym)
       allowed_mentions[:replied_user] = mention_user
 

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -160,7 +160,9 @@ module Discordrb
     # @param mention_user [true, false] Whether the user that is being replied to should be pinged by the reply.
     # @return [Message] the message that was sent.
     def reply!(content, tts = false, embed = nil, attachments = nil, allowed_mentions = {}, mention_user: false)
+      allowed_mentions = allowed_mentions.to_hash.transform_keys(&:to_sym)
       allowed_mentions[:replied_user] = mention_user
+
       respond(content, tts, embed, attachments, allowed_mentions, self)
     end
 

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -16,9 +16,10 @@ module Discordrb::Events
     # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
     # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
+    # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @return [Discordrb::Message] the message that was sent
-    def send_message(content, tts = false, embed = nil, attachments = nil, allowed_mentions = nil)
-      channel.send_message(content, tts, embed, attachments, allowed_mentions)
+    def send_message(content, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil)
+      channel.send_message(content, tts, embed, attachments, allowed_mentions, message_reference)
     end
 
     # The same as {#send_message}, but yields a {Webhooks::Embed} for easy building of embedded content inside a block.
@@ -28,11 +29,12 @@ module Discordrb::Events
     # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
     # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
+    # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @yield [embed] Yields the embed to allow for easy building inside a block.
     # @yieldparam embed [Discordrb::Webhooks::Embed] The embed from the parameters, or a new one.
     # @return [Message] The resulting message.
-    def send_embed(message = '', embed = nil, attachments = nil, tts = false, allowed_mentions = nil, &block)
-      channel.send_embed(message, embed, attachments, tts, allowed_mentions, &block)
+    def send_embed(message = '', embed = nil, attachments = nil, tts = false, allowed_mentions = nil, message_reference = nil, &block)
+      channel.send_embed(message, embed, attachments, tts, allowed_mentions, message_reference, &block)
     end
 
     # Sends a temporary message to the channel this message was sent in, right now.

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -7,6 +7,29 @@ describe Discordrb::Message do
   let(:channel) { double('channel', server: server) }
   let(:token) { double('token') }
   let(:bot) { double('bot', channel: channel, token: token) }
+  let(:server_id) { instance_double('String', 'server_id') }
+  let(:channel_id) { instance_double('String', 'channel_id') }
+  let(:message_id) { instance_double('String', 'message_id') }
+
+  before do
+    allow(server_id).to receive(:to_i).and_return(server_id)
+    allow(channel_id).to receive(:to_i).and_return(channel_id)
+    allow(message_id).to receive(:to_i).and_return(message_id)
+
+    allow(message_id).to receive(:to_s).and_return('message_id')
+    allow(server_id).to receive(:to_s).and_return('server_id')
+    allow(channel_id).to receive(:to_s).and_return('channel_id')
+
+    allow(server).to receive(:id).and_return(server_id)
+    allow(channel).to receive(:id).and_return(channel_id)
+    allow(bot).to receive(:server).with(server_id).and_return(server)
+    allow(bot).to receive(:channel).with(channel_id).and_return(channel)
+
+    allow(server).to receive(:member)
+    allow(channel).to receive(:private?)
+    allow(channel).to receive(:text?)
+    allow(bot).to receive(:ensure_user).with message_author
+  end
 
   fixture :message_data, %i[message]
   fixture_property :message_author, :message_data, ['author']
@@ -27,28 +50,6 @@ describe Discordrb::Message do
 
   describe '#emoji' do
     it 'caches and returns only emojis from the message' do
-      server_id = double(:server_id)
-      channel_id = double(:channel_id)
-      message_id = double(:message_id)
-
-      allow(server_id).to receive(:to_i).and_return(server_id)
-      allow(channel_id).to receive(:to_i).and_return(channel_id)
-      allow(message_id).to receive(:to_i).and_return(message_id)
-
-      allow(message_id).to receive(:to_s).and_return('message_id')
-      allow(server_id).to receive(:to_s).and_return('server_id')
-      allow(channel_id).to receive(:to_s).and_return('channel_id')
-
-      allow(server).to receive(:id).and_return(server_id)
-      allow(channel).to receive(:id).and_return(channel_id)
-      allow(bot).to receive(:server).with(server_id).and_return(server)
-      allow(bot).to receive(:channel).with(channel_id).and_return(channel)
-
-      allow(server).to receive(:member)
-      allow(channel).to receive(:private?)
-      allow(channel).to receive(:text?)
-      allow(bot).to receive(:ensure_user).with message_author
-
       emoji_a = Discordrb::Emoji.new({ 'name' => 'a', 'id' => 123 }, bot, server)
       emoji_b = Discordrb::Emoji.new({ 'name' => 'b', 'id' => 456 }, bot, server)
 
@@ -68,24 +69,6 @@ describe Discordrb::Message do
     end
 
     it 'calls Bot#parse_mentions once' do
-      server_id = double(:server_id)
-      channel_id = double(:channel_id)
-      message_id = double(:message_id)
-
-      allow(server_id).to receive(:to_i).and_return(server_id)
-      allow(channel_id).to receive(:to_i).and_return(channel_id)
-      allow(message_id).to receive(:to_i).and_return(message_id)
-
-      allow(server).to receive(:id).and_return(server_id)
-      allow(channel).to receive(:id).and_return(channel_id)
-      allow(bot).to receive(:server).with(server_id).and_return(server)
-      allow(bot).to receive(:channel).with(channel_id).and_return(channel)
-
-      allow(server).to receive(:member)
-      allow(channel).to receive(:private?)
-      allow(channel).to receive(:text?)
-      allow(bot).to receive(:ensure_user).with message_author
-
       emoji_a = Discordrb::Emoji.new({ 'name' => 'a', 'id' => 123 }, bot, server)
       emoji_b = Discordrb::Emoji.new({ 'name' => 'b', 'id' => 456 }, bot, server)
 
@@ -104,28 +87,6 @@ describe Discordrb::Message do
 
   describe '#link' do
     it 'links to a server message' do
-      server_id = double(:server_id)
-      channel_id = double(:channel_id)
-      message_id = double(:message_id)
-
-      allow(server_id).to receive(:to_i).and_return(server_id)
-      allow(channel_id).to receive(:to_i).and_return(channel_id)
-      allow(message_id).to receive(:to_i).and_return(message_id)
-
-      allow(message_id).to receive(:to_s).and_return('message_id')
-      allow(server_id).to receive(:to_s).and_return('server_id')
-      allow(channel_id).to receive(:to_s).and_return('channel_id')
-
-      allow(server).to receive(:id).and_return(server_id)
-      allow(channel).to receive(:id).and_return(channel_id)
-      allow(bot).to receive(:server).with(server_id).and_return(server)
-      allow(bot).to receive(:channel).with(channel_id).and_return(channel)
-
-      allow(server).to receive(:member)
-      allow(channel).to receive(:private?)
-      allow(channel).to receive(:text?)
-      allow(bot).to receive(:ensure_user).with message_author
-
       data = message_data
       data['id'] = message_id
       data['guild_id'] = server_id
@@ -136,23 +97,6 @@ describe Discordrb::Message do
     end
 
     it 'links to a private message' do
-      channel_id = double(:channel_id)
-      message_id = double(:message_id)
-
-      allow(channel_id).to receive(:to_i).and_return(channel_id)
-      allow(message_id).to receive(:to_i).and_return(message_id)
-
-      allow(message_id).to receive(:to_s).and_return('message_id')
-      allow(channel_id).to receive(:to_s).and_return('channel_id')
-
-      allow(channel).to receive(:id).and_return(channel_id)
-      allow(bot).to receive(:channel).with(channel_id).and_return(channel)
-
-      allow(server).to receive(:member)
-      allow(channel).to receive(:private?)
-      allow(channel).to receive(:text?)
-      allow(bot).to receive(:ensure_user).with message_author
-
       data = message_data
       data['id'] = message_id
       data['guild_id'] = nil
@@ -160,6 +104,78 @@ describe Discordrb::Message do
 
       message = described_class.new(data, bot)
       expect(message.link).to eq 'https://discord.com/channels/@me/channel_id/message_id'
+    end
+  end
+
+  describe '#reply!' do
+    let(:message) { described_class.new(message_data, bot) }
+    let(:content) { instance_double('String', 'content') }
+    let(:mention) { instance_double('TrueClass', 'mention') }
+
+    it 'responds with a message_reference' do
+      expect(message).to receive(:respond).with(content, false, nil, nil, hash_including(:replied_user), message)
+
+      message.reply!(content)
+    end
+
+    it 'sets replied_user in allowed_mentions' do
+      expect(message).to receive(:respond).with(content, false, nil, nil, { replied_user: mention }, message)
+
+      message.reply!(content, mention_user: mention)
+    end
+
+    context 'when allowed_mentions is false' do
+      let(:mention) { double('mention') }
+
+      it 'sets parse to an empty array add merges the mention_user param' do
+        expect(message).to receive(:respond).with(content, false, nil, nil, { parse: [], replied_user: mention }, message)
+
+        message.reply!(content, allowed_mentions: false, mention_user: mention)
+      end
+    end
+
+    context 'when allowed_mentions is an AllowedMentions' do
+      let(:hash) { instance_double('Hash', 'hash') }
+      let(:allowed_mentions) { instance_double('Discordrb::AllowedMentions', 'allowed_mentions') }
+      let(:mention_user) { instance_double('TrueClass', 'mention_user') }
+
+      before do
+        allow(allowed_mentions).to receive(:to_hash).and_return(hash)
+        allow(hash).to receive(:transform_keys).with(any_args).and_return(hash)
+        allow(hash).to receive(:[]=).with(:replied_user, mention_user)
+      end
+
+      it 'converts it to a hash to set the replied_user key' do
+        expect(message).to receive(:respond).with(content, false, nil, nil, hash, message)
+        message.reply!(content, allowed_mentions: allowed_mentions, mention_user: mention_user)
+      end
+    end
+  end
+
+  describe '#reply' do
+    let(:message) { described_class.new(message_data, bot) }
+    let(:content) { instance_double('String', 'content') }
+
+    it 'sends a message to a channel' do
+      expect(channel).to receive(:send_message).with(content)
+
+      message.reply(content)
+    end
+  end
+
+  describe '#respond' do
+    let(:message) { described_class.new(message_data, bot) }
+    let(:content) { instance_double('String', 'content') }
+    let(:tts) { instance_double('TrueClass', 'tts') }
+    let(:embed) { instance_double('Discordrb::Webhooks::Embed', 'embed') }
+    let(:attachments) { instance_double('Array', 'attachments') }
+    let(:allowed_mentions) { instance_double('Hash', 'allowed_mentions') }
+    let(:message_reference) { instance_double('Discordrb::Message') }
+
+    it 'forwards arguments to Channel#send_message' do
+      expect(channel).to receive(:send_message).with(content, tts, embed, attachments, allowed_mentions, message_reference)
+
+      message.respond(content, tts, embed, attachments, allowed_mentions, message_reference)
     end
   end
 end


### PR DESCRIPTION
# Summary

Add support for inline replies

## Added
`Message#reply!` - Holdover method until the next release where this method will replace `reply`
`Message#reply?` - Check whether this message is a reply to another message
`Message#referenced_message` - The message this message is replying to if any.

## Changed
`API::Channel.create_message` - Add message_reference as an optional parameter
`Bot#send_message`
`Channel#send_message`
`Channel#send_temporary_message`
`Channel#send_embed`
`Events::MessageEvent#send_message`
`Events::MessageEvent#send_embed`

## Deprecated
`Message#reply` - Deprecated in favor of `Message#respond` for the same functionality
