### PR TITLE
Add doc links to API methods

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -331,6 +331,7 @@ module Discordrb::API::Channel
   end
 
   # Create an empty group channel.
+  # https://discord.com/developers/docs/resources/user#create-group-dm
   def create_empty_group(token, bot_user_id)
     Discordrb::API.request(
       :users_uid_channels,
@@ -344,6 +345,7 @@ module Discordrb::API::Channel
   end
 
   # Create a group channel.
+  # https://discord.com/developers/docs/resources/channel#group-dm-add-recipient
   def create_group(token, pm_channel_id, user_id)
     Discordrb::API.request(
       :channels_cid_recipients_uid,
@@ -363,6 +365,7 @@ module Discordrb::API::Channel
   end
 
   # Add a user to a group channel.
+  # https://discord.com/developers/docs/resources/channel#group-dm-add-recipient
   def add_group_user(token, group_channel_id, user_id)
     Discordrb::API.request(
       :channels_cid_recipients_uid,
@@ -376,6 +379,7 @@ module Discordrb::API::Channel
   end
 
   # Remove a user from a group channel.
+  # https://discord.com/developers/docs/resources/channel#group-dm-remove-recipient
   def remove_group_user(token, group_channel_id, user_id)
     Discordrb::API.request(
       :channels_cid_recipients_uid,
@@ -388,6 +392,7 @@ module Discordrb::API::Channel
   end
 
   # Leave a group channel.
+  # https://discord.com/developers/docs/resources/channel#deleteclose-channel
   def leave_group(token, group_channel_id)
     Discordrb::API.request(
       :channels_cid,

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -46,6 +46,7 @@ module Discordrb::API::Server
   end
 
   # Transfer server ownership
+  # https://discord.com/developers/docs/resources/guild#modify-guild
   def transfer_ownership(token, server_id, user_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid,
@@ -498,6 +499,7 @@ module Discordrb::API::Server
   end
 
   # Available voice regions for this server
+  # https://discord.com/developers/docs/resources/guild#get-guild-voice-regions
   def regions(token, server_id)
     Discordrb::API.request(
       :guilds_sid_regions,

--- a/lib/discordrb/api/user.rb
+++ b/lib/discordrb/api/user.rb
@@ -29,6 +29,7 @@ module Discordrb::API::User
   end
 
   # Change the current bot's nickname on a server
+  # https://discord.com/developers/docs/resources/user#modify-current-user
   def change_own_nickname(token, server_id, nick, reason = nil)
     Discordrb::API.request(
       :guilds_sid_members_me_nick,


### PR DESCRIPTION
# Summary

Re: #7, add missing links to Discord API documentation for methods in `lib/discordrb/api/*.rb`.

---

## Added
Links to API documentation for API request methods.