### PR TITLE
Slash command gateway events

### DIFF
--- a/lib/discordrb/api/application.rb
+++ b/lib/discordrb/api/application.rb
@@ -26,7 +26,7 @@ module Discordrb::API::Application
       "#{Discordrb::API.api_base}/applications/#{application_id}/commands",
       { name: name, description: description, options: options }.to_json,
       Authorization: token,
-      content_type: 'application/json'
+      content_type: :json
     )
   end
 
@@ -40,7 +40,7 @@ module Discordrb::API::Application
       "#{Discordrb::API.api_base}/applications/#{application_id}/commands/#{command_id}",
       { name: name, description: description, options: options }.compact.to_json,
       Authorization: token,
-      content_type: 'application/json'
+      content_type: :json
     )
   end
 
@@ -78,7 +78,7 @@ module Discordrb::API::Application
       "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands",
       { name: name, description: description, options: options }.to_json,
       Authorization: token,
-      content_type: 'application/json'
+      content_type: :json
     )
   end
 
@@ -92,7 +92,7 @@ module Discordrb::API::Application
       "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}",
       { name: name, description: description, options: options }.compact.to_json,
       Authorization: token,
-      content_type: 'application/json'
+      content_type: :json
     )
   end
 

--- a/lib/discordrb/api/application.rb
+++ b/lib/discordrb/api/application.rb
@@ -11,21 +11,22 @@ module Discordrb::API::Application
       :applications_aid,
       nil,
       :get,
-      "#{Discordrb::API.api_base}/applications/#{application_id}",
+      "#{Discordrb::API.api_base}/applications/#{application_id}/commands",
       Authorization: token
     )
   end
 
   # Create a global application command.
   # https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
-  def create_global_command(token, application_id, name, description, options = nil)
+  def create_global_command(token, application_id, name, description, options = [])
     Discordrb::API.request(
       :applications_aid_commands,
       nil,
       :post,
       "#{Discordrb::API.api_base}/applications/#{application_id}/commands",
       { name: name, description: description, options: options }.to_json,
-      Authorization: token
+      Authorization: token,
+      content_type: 'application/json'
     )
   end
 
@@ -37,8 +38,9 @@ module Discordrb::API::Application
       nil,
       :patch,
       "#{Discordrb::API.api_base}/applications/#{application_id}/commands/#{command_id}",
-      { name: name, description: description, options: options },
-      Authorization: token
+      { name: name, description: description, options: options }.compact.to_json,
+      Authorization: token,
+      content_type: 'application/json'
     )
   end
 
@@ -75,7 +77,8 @@ module Discordrb::API::Application
       :post,
       "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands",
       { name: name, description: description, options: options }.to_json,
-      Authorization: token
+      Authorization: token,
+      content_type: 'application/json'
     )
   end
 
@@ -87,8 +90,9 @@ module Discordrb::API::Application
       guild_id,
       :patch,
       "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}",
-      { name: name, description: description, options: options }.to_json,
-      Authorization: token
+      { name: name, description: description, options: options }.compact.to_json,
+      Authorization: token,
+      content_type: 'application/json'
     )
   end
 

--- a/lib/discordrb/api/application.rb
+++ b/lib/discordrb/api/application.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+# API calls for slash commands.
+module Discordrb::API::Application
+  module_function
+
+  # Get a list of global application commands.
+  # https://discord.com/developers/docs/interactions/slash-commands#get-global-application-commands
+  def get_global_commands(token, application_id)
+    Discordrb::API.request(
+      :applications_aid,
+      nil,
+      :get,
+      "#{Discordrb::API.api_base}/applications/#{application_id}",
+      Authorization: token
+    )
+  end
+
+  # Create a global application command.
+  # https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
+  def create_global_command(token, application_id, name, description, options = nil)
+    Discordrb::API.request(
+      :applications_aid_commands,
+      nil,
+      :post,
+      "#{Discordrb::API.api_base}/applications/#{application_id}/commands",
+      { name: name, description: description, options: options }.to_json,
+      Authorization: token
+    )
+  end
+
+  # Edit a global application command.
+  # https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command
+  def edit_global_command(token, application_id, command_id, name: nil, description: nil, options: nil)
+    Discordrb::API.request(
+      :applications_aid_commands_cid,
+      nil,
+      :patch,
+      "#{Discordrb::API.api_base}/applications/#{application_id}/commands/#{command_id}",
+      { name: name, description: description, options: options },
+      Authorization: token
+    )
+  end
+
+  # Delete a global application command.
+  # https://discord.com/developers/docs/interactions/slash-commands#delete-global-application-command
+  def delete_global_command(token, application_id, command_id)
+    Discordrb::API.request(
+      :applications_aid_commands_cid,
+      nil,
+      :delete,
+      "#{Discordrb::API.api_base}/applications/#{application_id}/commands/#{command_id}",
+      Authorization: token
+    )
+  end
+
+  # Get a guild's commands for an application.
+  # https://discord.com/developers/docs/interactions/slash-commands#get-guild-application-commands
+  def get_guild_commands(token, application_id, guild_id)
+    Discordrb::API.request(
+      :applications_aid_guilds_gid_commands,
+      guild_id,
+      :get,
+      "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands",
+      Authorization: token
+    )
+  end
+
+  # Create an application command for a guild.
+  # https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command
+  def create_guild_command(token, application_id, guild_id, name, description, options = nil)
+    Discordrb::API.request(
+      :applications_aid_guilds_gid_commands,
+      guild_id,
+      :post,
+      "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands",
+      { name: name, description: description, options: options }.to_json,
+      Authorization: token
+    )
+  end
+
+  # Edit an application command for a guild.
+  # https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
+  def edit_guild_command(token, application_id, guild_id, command_id, name: nil, description: nil, options: nil)
+    Discordrb::API.request(
+      :applications_aid_guilds_gid_commands_cid,
+      guild_id,
+      :patch,
+      "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}",
+      { name: name, description: description, options: options }.to_json,
+      Authorization: token
+    )
+  end
+
+  # Delete an application command for a guild.
+  # https://discord.com/developers/docs/interactions/slash-commands#delete-guild-application-command
+  def delete_guild_command(token, application_id, guild_id, command_id)
+    Discordrb::API.request(
+      :applications_aid_guilds_gid_commands_cid,
+      guild_id,
+      :delete,
+      "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}",
+      Authorization: token
+    )
+  end
+end

--- a/lib/discordrb/api/webhook.rb
+++ b/lib/discordrb/api/webhook.rb
@@ -90,7 +90,7 @@ module Discordrb::API::Webhook
       :patch,
       "#{Discordrb::API.api_base}/webhooks/#{webhooks_id}/#{webhook_token}/messages/#{message_id}",
       { content: content, embeds: embeds, allowed_mentions: allowed_mentions }.to_json,
-      content_type: 'application/json'
+      content_type: :json
     )
   end
 
@@ -118,7 +118,7 @@ module Discordrb::API::Webhook
       :post,
       "#{Discordrb::API.api_base}/interactions/#{interaction_id}/#{interaction_token}/callback",
       { type: type, data: data }.to_json,
-      content_type: 'application/json'
+      content_type: :json
     )
   end
 

--- a/lib/discordrb/api/webhook.rb
+++ b/lib/discordrb/api/webhook.rb
@@ -89,7 +89,8 @@ module Discordrb::API::Webhook
       webhook_id,
       :patch,
       "#{Discordrb::API.api_base}/webhooks/#{webhooks_id}/#{webhook_token}/messages/#{message_id}",
-      { content: content, embeds: embeds, allowed_mentions: allowed_mentions }.to_json
+      { content: content, embeds: embeds, allowed_mentions: allowed_mentions }.to_json,
+      content_type: 'application/json'
     )
   end
 
@@ -100,7 +101,8 @@ module Discordrb::API::Webhook
       :webhooks_id,
       webhook_id,
       :delete,
-      "#{Discordrb::API.api_base}/webhooks/#{webhook_id}/#{webhook_token}/messages/#{message_id}"
+      "#{Discordrb::API.api_base}/webhooks/#{webhook_id}/#{webhook_token}/messages/#{message_id}",
+      {}
     )
   end
 
@@ -115,7 +117,8 @@ module Discordrb::API::Webhook
       interaction_id,
       :post,
       "#{Discordrb::API.api_base}/interactions/#{interaction_id}/#{interaction_token}/callback",
-      { type: type, data: data }.to_json
+      { type: type, data: data }.to_json,
+      content_type: 'application/json'
     )
   end
 

--- a/lib/discordrb/api/webhook.rb
+++ b/lib/discordrb/api/webhook.rb
@@ -80,4 +80,54 @@ module Discordrb::API::Webhook
       'X-Audit-Log-Reason': reason
     )
   end
+
+  # Edit a message created by a specific webhook.
+  # https://discord.com/developers/docs/resources/webhook#edit-webhook-message
+  def edit_webhook_message(webhook_token, webhook_id, message_id, content: nil, embeds: nil, allowed_mentions: nil)
+    Discordrb::API.request(
+      :webhooks_wid,
+      webhook_id,
+      :patch,
+      "#{Discordrb::API.api_base}/webhooks/#{webhooks_id}/#{webhook_token}/messages/#{message_id}",
+      { content: content, embeds: embeds, allowed_mentions: allowed_mentions }.to_json
+    )
+  end
+
+  # Delete a message created by a specific webhook.
+  # https://discord.com/developers/docs/resources/webhook#delete-webhook-message
+  def delete_webhook_message(webhook_token, webhook_id, message_id)
+    Discordrb::API.request(
+      :webhooks_id,
+      webhook_id,
+      :delete,
+      "#{Discordrb::API.api_base}/webhooks/#{webhook_id}/#{webhook_token}/messages/#{message_id}"
+    )
+  end
+
+  # Respond to an interaction.
+  # https://discord.com/developers/docs/interactions/slash-commands#create-interaction-response
+  def create_interaction_response(interaction_token, interaction_id, type, tts: nil, content: nil, embeds: nil, allowed_mentions: nil)
+    data = { tts: tts, content: content, embeds: embeds, allowed_mentions: allowed_mentions }.compact
+    data = nil if data.empty?
+
+    Discordrb::API.request(
+      :interactions_iid_token_callback,
+      interaction_id,
+      :post,
+      "#{Discordrb::API.api_base}/interactions/#{interaction_id}/#{interaction_token}/callback",
+      { type: type, data: data }.to_json
+    )
+  end
+
+  # Edit the original response to an interaction.
+  # https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
+  def edit_original_interaction_response(interaction_token, application_id, content: nil, embeds: nil, allowed_mentions: nil)
+    edit_webhook_message(interaction_token, application_id, '@original', content: content, embeds: embeds, allowed_mentions: allowed_mentions)
+  end
+
+  # Delete the original response to an interaction.
+  # https://discord.com/developers/docs/interactions/slash-commands#delete-original-interaction-response
+  def delete_original_interaction_response(interaction_token, application_id)
+    delete_webhook_message(interaction_token, application_id, '@original')
+  end
 end

--- a/lib/discordrb/api/webhook.rb
+++ b/lib/discordrb/api/webhook.rb
@@ -88,7 +88,7 @@ module Discordrb::API::Webhook
       :webhooks_wid,
       webhook_id,
       :patch,
-      "#{Discordrb::API.api_base}/webhooks/#{webhooks_id}/#{webhook_token}/messages/#{message_id}",
+      "#{Discordrb::API.api_base}/webhooks/#{webhook_id}/#{webhook_token}/messages/#{message_id}",
       { content: content, embeds: embeds, allowed_mentions: allowed_mentions }.to_json,
       content_type: :json
     )
@@ -108,8 +108,8 @@ module Discordrb::API::Webhook
 
   # Respond to an interaction.
   # https://discord.com/developers/docs/interactions/slash-commands#create-interaction-response
-  def create_interaction_response(interaction_token, interaction_id, type, tts: nil, content: nil, embeds: nil, allowed_mentions: nil)
-    data = { tts: tts, content: content, embeds: embeds, allowed_mentions: allowed_mentions }.compact
+  def create_interaction_response(interaction_token, interaction_id, type, tts: nil, content: nil, embeds: nil, allowed_mentions: nil, flags: nil)
+    data = { tts: tts, content: content, embeds: embeds, allowed_mentions: allowed_mentions, flags: flags }.compact
     data = nil if data.empty?
 
     Discordrb::API.request(

--- a/lib/discordrb/application_commands/builder.rb
+++ b/lib/discordrb/application_commands/builder.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module Discordrb::ApplicationCommands
+  class Option
+    attr_accessor :name, :description, :type, :options
+
+    def initialize(name, description, type, required = nil, default = nil, choices = nil)
+      @name = name
+      @description = description
+      @type = type
+      @choices = choices
+      @required = required
+      @default = default
+    end
+
+    def to_h
+      { 
+        name: @name,
+        description: @description,
+        type: @type,
+        choices: @choices,
+        required: @required,
+        default: @default
+      }.compact
+    end
+  end
+
+  class Builder
+    attr_reader :name
+    attr_reader :description
+    attr_reader :options
+
+    TYPES = {
+      subcommand: 1,
+      group: 2,
+      string: 3,
+      integer: 4,
+      bool: 5,
+      user: 6,
+      channel: 7,
+      role: 8
+    }
+
+    def initialize(name, description, &block)
+      @name = name
+      @description = description
+      @options = []
+
+      yield self if block_given?
+    end
+
+    TYPES.slice(*(TYPES.keys - %i[string integer subcommand group])).each do |type_name, type|
+      define_method(type_name) do |name, description, required: nil, default: nil|
+        subcommand_check
+
+        @options << Option.new(name, description, type, required, default)
+      end
+    end
+
+    TYPES.slice(:string, :integer).each do |type_name, type|
+      define_method(type_name) do |name, description, required: nil, default: nil, choices: nil|
+        subcommand_check
+
+        case choices
+        when Hash
+          choices = choices.map {|k,v| {name: k, value: v} }
+        when Array
+          choices = choices.map {|v| { name: v.to_s, value: v } }
+        end
+
+        @options << Option.new(name, description, type, required, default, choices)
+      end
+    end
+
+    def subcommand(name, description, &block)
+      sub_builder = SubcommandBuilder.new(name, description, &block)
+
+      @options << sub_builder
+      sub_builder
+    end
+    
+    def group(name, description, &block)
+      group_builder = GroupBuilder.new(name, description, &block)
+
+      @options << group_builder
+      group_builder
+    end
+
+    def to_h
+      {
+        name: @name,
+        description: @description,
+        options: @options.map(&:to_h)
+      }
+    end
+
+    private
+
+    def subcommand_check
+      return unless @options.any? {|opt| [1, 2].include? opt.type }
+      raise ArgumentError, 'You cannot have subcommands or groups on the same level as other arguments'
+    end
+  end
+
+  class SubcommandBuilder < Builder
+    undef group
+    undef subcommand
+
+    def to_h
+      super.merge(type: TYPES[:subcommand])
+    end
+  end
+
+  class GroupBuilder < Builder
+    undef group
+
+    def to_h
+      super.merge(type: TYPES[:group])
+    end
+  end
+end

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -19,11 +19,13 @@ require 'discordrb/events/raw'
 require 'discordrb/events/reactions'
 require 'discordrb/events/webhooks'
 require 'discordrb/events/invites'
+require 'discordrb/events/interactions'
 
 require 'discordrb/api'
 require 'discordrb/api/channel'
 require 'discordrb/api/server'
 require 'discordrb/api/invite'
+require 'discordrb/api/application'
 require 'discordrb/errors'
 require 'discordrb/data'
 require 'discordrb/await'
@@ -33,6 +35,8 @@ require 'discordrb/cache'
 require 'discordrb/gateway'
 
 require 'discordrb/voice/voice_bot'
+
+require 'discordrb/application_commands/builder'
 
 module Discordrb
   # Represents a Discord bot, including servers, users, etc.
@@ -212,6 +216,12 @@ module Discordrb
       Application.new(JSON.parse(response), self)
     end
 
+    # The both's OAuth application ID.
+    # @return [Integer] The ID of the bot's application.
+    def client_id
+      @client_id ||= bot_application.id
+    end
+
     alias_method :bot_app, :bot_application
 
     # The Discord API token received when logging in. Useful to explicitly call
@@ -286,6 +296,21 @@ module Discordrb
       server_id_str = server ? "&guild_id=#{server.id}" : ''
       permission_bits_str = permission_bits ? "&permissions=#{permission_bits}" : ''
       "https://discord.com/oauth2/authorize?&client_id=#{@client_id}#{server_id_str}#{permission_bits_str}&scope=bot"
+    end
+
+    # Register an application command.
+    # @param name [String]
+    # @param description [String]
+    # @param server_id [String, Integer] Server ID if creating a server specific command
+    # @yieldparam Discordrb::ApplicationCommands::Builder
+    def register_application_command(name, description, server_id: nil, &block)
+      cmd = Discordrb::ApplicationCommands::Builder.new(name, description, &block).to_h
+
+      if server_id
+        Discordrb::API::Application.create_guild_command(@token, client_id, server_id, cmd[:name], cmd[:description], cmd[:options])
+      else
+        Discordrb::API::Application.create_global_command(@token, client_id, cmd[:name], cmd[:description], cmd[:options])
+      end
     end
 
     # @return [Hash<Integer => VoiceBot>] the voice connections this bot currently has, by the server ID to which they are connected.
@@ -1335,6 +1360,15 @@ module Discordrb
         end
       when :WEBHOOKS_UPDATE
         event = WebhookUpdateEvent.new(data, self)
+        raise_event(event)
+      when :INTERACTION_CREATE
+        # TODO: some kind of enum for this would be preferable to literals
+        event = case data['type']
+                when 2 # ApplicationCommand
+                  ApplicationCommandEvent.new(data, self)
+                else
+                  InteractionCreateEvent.new(data, self)
+                end
         raise_event(event)
       else
         # another event that we don't support yet

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -13,6 +13,7 @@ require 'discordrb/events/guilds'
 require 'discordrb/events/await'
 require 'discordrb/events/bans'
 require 'discordrb/events/reactions'
+require 'discordrb/events/interactions'
 
 require 'discordrb/await'
 
@@ -520,6 +521,15 @@ module Discordrb
     # @return [InviteDeleteEventHandler] The event handler that was registered.
     def invite_delete(attributes = {}, &block)
       register_event(InviteDeleteEvent, attributes, block)
+    end
+
+    # TODO: incomplete docs
+    # This **event** is raised when an application command is sent.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Integer, Channel] :channel Matches the channel the command was used in.
+    # @option attributes [String, Integer, Server] :server Matches the server the command was used in.
+    def application_command(command_name, attributes = {}, &block)
+      register_event(ApplicationCommandEvent, attributes.merge(command_name: command_name), block)
     end
 
     # This **event** is raised for every dispatch received over the gateway, whether supported by discordrb or not.

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -68,7 +68,7 @@ module Discordrb
       @server = server || bot.server(data['guild_id'].to_i)
 
       # Initialize the roles by getting the roles from the server one-by-one
-      update_roles(data['roles'])
+      update_roles(data['roles']) unless @server.nil?
 
       @nick = data['nick']
       @joined_at = data['joined_at'] ? Time.parse(data['joined_at']) : nil

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'discordrb/webhooks'
+
+module Discordrb::Events
+  class InteractionEvent
+    # @return [Integer] The interaction's ID.
+    attr_reader :id
+
+    # @return [Integer] The interaction's type (1: Ping, 2: ApplicationCommand).
+    attr_reader :type
+
+    # @return [Integer] The ID of the server where the interaction originates. 
+    attr_reader :server_id
+
+    # @return [Integer] The ID of the channel where the interaction originates.
+    attr_reader :channel_id
+
+    # @return [Member] The member that created the interaction.
+    # @note Members from an interaction may not support all methods if
+    #   the application has not been granted the `bot` scope for the server.
+    attr_reader :author
+
+    # @return [String] A continuation token for responding to the interaction.
+    attr_reader :token
+
+    # @return [Integer] Always `1`.
+    attr_reader :version
+
+    # @return [Hash]
+    # @note Only useful for ApplicationCommand types currently, exposed for use
+    #   with future interaction types.
+    attr_reader :data
+
+    # @return [Discordrb::Webhooks::Client]
+    attr_reader :webhook
+
+    def initialize(data, bot)
+      @bot = bot
+
+      @id = data['id'].to_i
+      @type = data['type']
+      @server_id = data['guild_id'].to_i
+      @channel_id = data['channel_id'].to_i
+      @author = Discordrb::Member.new(data['member'], @bot.server(@server_id), @bot)
+      @token = data['token']
+      @version = data['version']
+      @data = data['data']
+      @application_id = @bot.client_id
+    
+      @webhook = Discordrb::Webhooks::Client.new(id: @application_id, token: @token)
+    end
+
+    def server
+      @bot.server(@server_id)
+    end
+
+    def channel
+      @bot.channel(@channel_id)
+    end
+
+    def ephemeral_reply(content, show_source: false)
+      reply(content: content, show_source: show_source, flags: 1 << 6)
+    end
+
+    def reply(content: nil, tts: nil, embeds: nil, allowed_mentions: nil, show_source: false, flags: nil)
+      Discordrb::API::Webhook.create_interaction_response(@token, @id, show_source ? 4 : 3, content: content, embeds: embeds, allowed_mentions: allowed_mentions, flags: flags)
+    end
+
+    def acknowledge(show_source: false)
+      Discordrb::API::Webhook.create_interaction_response(@token, @id, show_source ? 5 : 2)
+    end
+
+    def edit_original_response(content: nil, embeds: nil, allowed_mentions: nil)
+      Discordrb::API::Webhook.edit_original_interaction_response(@token, @application_id, content: content, embeds: embeds, allowed_mentions: allowed_mentions)
+    end
+
+    def edit_message(message_id, content: nil, embeds: nil, allowed_mentions: nil)
+      Discordrb::API::Webhook.edit_webhook_message(@token, @application_id, message_id, content: content, embeds: embed, allowed_mentions: allowed_mentions)
+    end
+
+    def delete_message(message_id)
+      Discordrb::API::Webhook.delete_webhook_message(@token, @application_id, message_id)
+    end
+
+    def delete_original_response
+      Discordrb::API::Webhook.delete_original_interaction_response(@token, @application_id)
+    end
+  end
+
+  class InteractionEventHandler < EventHandler
+    def matches?(event)
+      return false unless event.is_a? InteractionEvent
+
+      [
+        matches_all(@attributes[:server], event.server_id) do |a, e|
+          a.id == e
+        end,
+        matches_all(@attributes[:channel], event.channel_id) do |a, e|
+          a.id == e
+        end,
+        matches_all(@attributes[:type], event.type, &:==)
+      ].reduce(true, &:&)
+    end
+  end
+
+  class ApplicationCommandEvent < InteractionEvent
+    # @return [String, nil]
+    attr_reader :subcommand
+
+    # @return [String, nil]
+    attr_reader :subcommand_group
+    
+    # @return [Hash<String, Object>]
+    attr_reader :options
+
+    attr_reader :command_name
+
+    def initialize(data, bot)
+      super
+
+      @command_name = data['data']['name']
+      options = data['data']['options']
+
+      if !options[0].key?('value')
+        @subcommand = options[0]['name']
+        options = options[0]['options'] || []
+
+        if options[0].is_a?(Hash) && !options[0].key?('value')
+          @subcommand_group = @subcommand
+          @subcommand = options[0]['name']
+
+          options = options[0]['options'] || []
+        end
+      end
+
+      @options = options.map { |opt| [opt['name'], opt['value']] }.to_h
+    end
+  end
+
+  class ApplicationCommandEventHandler < InteractionEventHandler
+    def matches?(event)
+      return false unless event.is_a? ApplicationCommandEvent
+
+      [
+        super,
+        matches_all(@attributes[:command_name], event.command_name) do |a, e|
+          a.to_s == e
+        end,
+        matches_all(@attributes[:group], event.subcommand_group) do |a, e|
+          a.to_s == e
+        end,
+        matches_all(@attributes[:subcommand], event.subcommand) do |a, e|
+          a.to_s == e
+        end
+      ].reduce(true, &:&)
+    end
+  end
+end


### PR DESCRIPTION
# Summary

Adds support for Interaction and ApplicationCommand events, as well as a builder for registering an ApplicationCommand on the API.

This is a WIP, and a few things are missing. Namely, docs are incomplete, no tests are written, and some logic can be cleaned up.

However, I believe this is fairly close to how I want to public facing API to resemble.

Closes #8 

---

## Added
- TODO
## Changed
- TODO
