### PR TITLE
V8 update

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -112,6 +112,13 @@ module Discordrb::API
         response = raw_request(type, attributes)
       rescue RestClient::Exception => e
         response = e.response
+
+        if response.body
+          data = JSON.parse(response.body)
+          err_klass = Discordrb::Errors.error_class_for(data['code'] || 0)
+          e = err_klass.new(data['message'], data['errors'])
+        end
+
         raise e
       rescue Discordrb::Errors::NoPermission => e
         if e.respond_to?(:_rc_response)

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -117,6 +117,8 @@ module Discordrb::API
           data = JSON.parse(response.body)
           err_klass = Discordrb::Errors.error_class_for(data['code'] || 0)
           e = err_klass.new(data['message'], data['errors'])
+
+          Discordrb::LOGGER.error(e.full_message)
         end
 
         raise e

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -9,7 +9,7 @@ require 'discordrb/errors'
 # List of methods representing endpoints in Discord's API
 module Discordrb::API
   # The base URL of the Discord REST API.
-  APIBASE = 'https://discord.com/api/v6'
+  APIBASE = 'https://discord.com/api/v8'
 
   # The URL of Discord's CDN
   CDN_URL = 'https://cdn.discordapp.com'

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -94,9 +94,6 @@ module Discordrb::API
     # Add a custom user agent
     attributes.last[:user_agent] = user_agent if attributes.last.is_a? Hash
 
-    # Specify RateLimit precision
-    attributes.last[:x_ratelimit_precision] = 'millisecond'
-
     # The most recent Discord rate limit requirements require the support of major parameters, where a particular route
     # and major parameter combination (*not* the HTTP method) uniquely identifies a RL bucket.
     key = [key, major_parameter].freeze

--- a/lib/discordrb/api/invite.rb
+++ b/lib/discordrb/api/invite.rb
@@ -11,7 +11,7 @@ module Discordrb::API::Invite
       :invite_code,
       nil,
       :get,
-      "#{Discordrb::API.api_base}/invite/#{invite_code}#{counts ? '?with_counts=true' : ''}",
+      "#{Discordrb::API.api_base}/invites/#{invite_code}#{counts ? '?with_counts=true' : ''}",
       Authorization: token
     )
   end
@@ -36,7 +36,7 @@ module Discordrb::API::Invite
       :invite_code,
       nil,
       :post,
-      "#{Discordrb::API.api_base}/invite/#{invite_code}",
+      "#{Discordrb::API.api_base}/invites/#{invite_code}",
       nil,
       Authorization: token
     )

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -190,7 +190,7 @@ module Discordrb::API::Server
       :guilds_sid_bans_uid,
       server_id,
       :put,
-      "#{Discordrb::API.api_base}/guilds/#{server_id}/bans/#{user_id}?delete-message-days=#{message_days}&reason=#{reason}",
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/bans/#{user_id}?delete_message_days=#{message_days}&reason=#{reason}",
       nil,
       Authorization: token
     )
@@ -434,7 +434,7 @@ module Discordrb::API::Server
       :guilds_sid_embed,
       server_id,
       :get,
-      "#{Discordrb::API.api_base}/guilds/#{server_id}/embed",
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/widget",
       Authorization: token
     )
   end
@@ -446,7 +446,7 @@ module Discordrb::API::Server
       :guilds_sid_embed,
       server_id,
       :patch,
-      "#{Discordrb::API.api_base}/guilds/#{server_id}/embed",
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/widget",
       { enabled: enabled, channel_id: channel_id }.to_json,
       Authorization: token,
       'X-Audit-Log-Reason': reason,

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -427,9 +427,9 @@ module Discordrb::API::Server
     )
   end
 
-  # Retrieves a server's embed information
-  # https://discord.com/developers/docs/resources/guild#get-guild-embed
-  def embed(token, server_id)
+  # Retrieves a server's widget information
+  # https://discord.com/developers/docs/resources/guild#get-guild-widget
+  def widget(token, server_id)
     Discordrb::API.request(
       :guilds_sid_embed,
       server_id,
@@ -438,10 +438,11 @@ module Discordrb::API::Server
       Authorization: token
     )
   end
+  alias embed widget
 
-  # Modify a server's embed settings
-  # https://discord.com/developers/docs/resources/guild#modify-guild-embed
-  def modify_embed(token, server_id, enabled, channel_id, reason = nil)
+  # Modify a server's widget settings
+  # https://discord.com/developers/docs/resources/guild#modify-guild-widget
+  def modify_widget(token, server_id, enabled, channel_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_embed,
       server_id,
@@ -453,6 +454,7 @@ module Discordrb::API::Server
       content_type: :json
     )
   end
+  alias modify_embed modify_widget
 
   # Adds a custom emoji.
   # https://discord.com/developers/docs/resources/emoji#create-guild-emoji

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -102,14 +102,13 @@ module Discordrb
     #   to Discord's gateway. `:none` will request that no payloads are received compressed (not recommended for
     #   production bots). `:large` will request that large payloads are received compressed. `:stream` will request
     #   that all data be received in a continuous compressed stream.
-    # @param intents [:all, Array<Symbol>, nil] Intents that this bot requires. See {Discordrb::INTENTS}. If `nil`, no intents
-    #   field will be passed.
+    # @param intents [:all, Array<Symbol>, nil] Intents that this bot requires.
     def initialize(
       log_mode: :normal,
       token: nil, client_id: nil,
       type: nil, name: '', fancy_log: false, suppress_ready: false, parse_self: false,
       shard_id: nil, num_shards: nil, redact_token: true, ignore_bots: false,
-      compress_mode: :large, intents: nil
+      compress_mode: :large, intents: :all
     )
       LOGGER.mode = log_mode
       LOGGER.token = token if redact_token
@@ -130,7 +129,7 @@ module Discordrb
 
       raise 'Token string is empty or nil' if token.nil? || token.empty?
 
-      @intents = intents == :all ? INTENTS.values.reduce(&:|) : calculate_intents(intents) if intents
+      @intents = intents == :all ? INTENTS.values.reduce(&:|) : calculate_intents(intents)
 
       @token = process_token(@type, token)
       @gateway = Gateway.new(self, @token, @shard_key, @compress_mode, @intents)

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -69,7 +69,9 @@ module Discordrb::Commands
     # @option attributes [String] :quote_end Character that should end a quoted string (see
     #   :advanced_functionality). Default is '"' or the same as :quote_start. Set to an empty string to disable.
     # @option attributes [true, false] :ignore_bots Whether the bot should ignore bot accounts or not. Default is false.
-    def initialize(attributes = {})
+    def initialize(**attributes)
+      # TODO: This needs to be revisited. undefined attributes are treated
+      # as explicitly passed nils.
       super(
         log_mode: attributes[:log_mode],
         token: attributes[:token],
@@ -84,7 +86,7 @@ module Discordrb::Commands
         redact_token: attributes.key?(:redact_token) ? attributes[:redact_token] : true,
         ignore_bots: attributes[:ignore_bots],
         compress_mode: attributes[:compress_mode],
-        intents: attributes[:intents]
+        intents: attributes[:intents] || :all
       )
 
       @prefix = attributes[:prefix]

--- a/lib/discordrb/data/integration.rb
+++ b/lib/discordrb/data/integration.rb
@@ -15,6 +15,36 @@ module Discordrb
     end
   end
 
+  # Bot/OAuth2 application for discord integrations
+  class IntegrationApplication
+    # @return [Integer] the ID of the application.
+    attr_reader :id
+
+    # @return [String] the name of the application.
+    attr_reader :name
+
+    # @return [String, nil] the icon hash of the application.
+    attr_reader :icon
+
+    # @return [String] the description of the application.
+    attr_reader :description
+
+    # @return [String] the summary of the application.
+    attr_reader :summary
+
+    # @return [User, nil] the bot associated with this application.
+    attr_reader :bot
+
+    def initialize(data, bot)
+      @id = data['id'].to_i
+      @name = data['name']
+      @icon = data['icon']
+      @description = data['description']
+      @summary = data['summary']
+      @bot = Discordrb::User.new(data['user'], bot) if data['user']
+    end
+  end
+
   # Server integration
   class Integration
     include IDObject
@@ -28,8 +58,8 @@ module Discordrb
     # @return [User] the user the integration is linked to
     attr_reader :user
 
-    # @return [Role, nil] the role that this integration uses for "subscribers"
-    attr_reader :role
+    # @return [Integer, nil] the role that this integration uses for "subscribers"
+    attr_reader :role_id
 
     # @return [true, false] whether emoticons are enabled
     attr_reader :emoticon
@@ -57,6 +87,12 @@ module Discordrb
     # @return [Integer] the grace period before subscribers expire (in days)
     attr_reader :expire_grace_period
 
+    # @return [Integer, nil] how many subscribers this integration has.
+    attr_reader :subscriber_count
+
+    # @return [true, false] has this integration been revoked.
+    attr_reader :revoked
+
     def initialize(data, bot, server)
       @bot = bot
 
@@ -71,8 +107,11 @@ module Discordrb
       @expire_behaviour = %i[remove kick][data['expire_behavior']]
       @expire_grace_period = data['expire_grace_period']
       @user = @bot.ensure_user(data['user'])
-      @role = server.role(data['role_id']) || nil
+      @role_id = data['role_id']&.to_i
       @emoticon = data['enable_emoticons']
+      @subscriber_count = data['subscriber_count']&.to_i
+      @revoked = data['revoked']
+      @application = IntegrationApplication.new(data['application'], bot) if data['application']
     end
 
     # The inspect method is overwritten to give more useful output

--- a/lib/discordrb/data/overwrite.rb
+++ b/lib/discordrb/data/overwrite.rb
@@ -53,8 +53,8 @@ module Discordrb
                 type
               end
 
-      @allow = allow.is_a?(Permissions) ? allow : Permissions.new(allow)
-      @deny = deny.is_a?(Permissions) ? deny : Permissions.new(deny)
+      @allow = allow.is_a?(Permissions) ? allow : Permissions.new(allow.to_i)
+      @deny = deny.is_a?(Permissions) ? deny : Permissions.new(deny.to_i)
     end
 
     # Comparison by attributes [:id, :type, :allow, :deny]

--- a/lib/discordrb/data/overwrite.rb
+++ b/lib/discordrb/data/overwrite.rb
@@ -4,6 +4,12 @@ module Discordrb
   # A permissions overwrite, when applied to channels describes additional
   # permissions a member needs to perform certain actions in context.
   class Overwrite
+    # Types of overwrites mapped to their API value.
+    TYPES = {
+      role: 0,
+      member: 1
+    }.freeze
+
     # @return [Integer] ID of the thing associated with this overwrite type
     attr_accessor :id
 
@@ -32,14 +38,14 @@ module Discordrb
     # @example Create an overwrite by ID and permissions bits
     #   Overwrite.new(120571255635181568, type: 'member', allow: 1024, deny: 0)
     # @param object [Integer, #id] the ID or object this overwrite is for
-    # @param type [String] the type of object this overwrite is for (only required if object is an Integer)
-    # @param allow [Integer, Permissions] allowed permissions for this overwrite, by bits or a Permissions object
-    # @param deny [Integer, Permissions] denied permissions for this overwrite, by bits or a Permissions object
+    # @param type [String, Symbol, Integer] the type of object this overwrite is for (only required if object is an Integer)
+    # @param allow [String, Integer, Permissions] allowed permissions for this overwrite, by bits or a Permissions object
+    # @param deny [String, Integer, Permissions] denied permissions for this overwrite, by bits or a Permissions object
     # @raise [ArgumentError] if type is not :member or :role
     def initialize(object = nil, type: nil, allow: 0, deny: 0)
       if type
-        type = type.to_sym
-        raise ArgumentError, 'Overwrite type must be :member or :role' unless (type != :member) || (type != :role)
+        type = TYPES.value?(type) ? TYPES.key(type) : type.to_sym
+        raise ArgumentError, 'Overwrite type must be :member or :role' unless type
       end
 
       @id = object.respond_to?(:id) ? object.id : object
@@ -53,8 +59,8 @@ module Discordrb
                 type
               end
 
-      @allow = allow.is_a?(Permissions) ? allow : Permissions.new(allow.to_i)
-      @deny = deny.is_a?(Permissions) ? deny : Permissions.new(deny.to_i)
+      @allow = allow.is_a?(Permissions) ? allow : Permissions.new(allow)
+      @deny = deny.is_a?(Permissions) ? deny : Permissions.new(deny)
     end
 
     # Comparison by attributes [:id, :type, :allow, :deny]
@@ -71,7 +77,7 @@ module Discordrb
     def self.from_hash(data)
       new(
         data['id'].to_i,
-        type: data['type'],
+        type: TYPES.key(data['type']),
         allow: Permissions.new(data['allow']),
         deny: Permissions.new(data['deny'])
       )
@@ -93,7 +99,7 @@ module Discordrb
     def to_hash
       {
         id: id,
-        type: type,
+        type: TYPES[type],
         allow: allow.bits,
         deny: deny.bits
       }

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -189,78 +189,73 @@ module Discordrb
       AuditLogs.new(self, @bot, JSON.parse(API::Server.audit_logs(@bot.token, @id, limit, user, action, before)))
     end
 
-    # Cache @embed
+    # Cache @widget
     # @note For internal use only
     # @!visibility private
-    def cache_embed_data
-      data = JSON.parse(API::Server.embed(@bot.token, @id))
-      @embed_enabled = data['enabled']
-      @embed_channel_id = data['channel_id']
+    def cache_widget_data
+      data = JSON.parse(API::Server.widget(@bot.token, @id))
+      @widget_enabled = data['enabled']
+      @widget_channel_id = data['channel_id']
     end
 
     # @return [true, false] whether or not the server has widget enabled
-    def embed_enabled?
-      cache_embed_data if @embed_enabled.nil?
-      @embed_enabled
+    def widget_enabled?
+      cache_widget_data if @widget_enabled.nil?
+      @widget_enabled
     end
-    alias_method :widget_enabled, :embed_enabled?
-    alias_method :widget?, :embed_enabled?
-    alias_method :embed?, :embed_enabled?
+    alias_method :widget?, :widget_enabled?
+    alias_method :embed_enabled, :widget_enabled?
+    alias_method :embed?, :widget_enabled?
 
-    # @return [Channel, nil] the channel the server embed will make an invite for.
-    def embed_channel
-      cache_embed_data if @embed_enabled.nil?
-      @bot.channel(@embed_channel_id) if @embed_channel_id
+    # @return [Channel, nil] the channel the server widget will make an invite for.
+    def widget_channel
+      cache_widget_data if @widget_enabled.nil?
+      @bot.channel(@widget_channel_id) if @widget_channel_id
     end
-    alias_method :widget_channel, :embed_channel
+    alias_method :embed_channel, :widget_channel
 
-    # Sets whether this server's embed (widget) is enabled
+    # Sets whether this server's widget is enabled
     # @param value [true, false]
-    def embed_enabled=(value)
-      modify_embed(value, embed_channel)
+    def widget_enabled=(value)
+      modify_widget(value, widget_channel)
     end
+    alias_method :embed_enabled=, :widget_enabled=
 
-    alias_method :widget_enabled=, :embed_enabled=
-
-    # Sets whether this server's embed (widget) is enabled
+    # Sets whether this server's widget is enabled
     # @param value [true, false]
     # @param reason [String, nil] the reason to be shown in the audit log for this action
-    def set_embed_enabled(value, reason = nil)
-      modify_embed(value, embed_channel, reason)
+    def set_widget_enabled(value, reason = nil)
+      modify_widget(value, widget_channel, reason)
     end
+    alias_method :set_embed_enabled, :set_widget_enabled
 
-    alias_method :set_widget_enabled, :set_embed_enabled
-
-    # Changes the channel on the server's embed (widget)
-    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the embed
-    def embed_channel=(channel)
-      modify_embed(embed?, channel)
+    # Changes the channel on the server's widget
+    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the widget
+    def widget_channel=(channel)
+      modify_widget(widget?, channel)
     end
+    alias_method :embed_channel=, :widget_channel=
 
-    alias_method :widget_channel=, :embed_channel=
-
-    # Changes the channel on the server's embed (widget)
-    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the embed
+    # Changes the channel on the server's widget
+    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the widget
     # @param reason [String, nil] the reason to be shown in the audit log for this action
-    def set_embed_channel(channel, reason = nil)
-      modify_embed(embed?, channel, reason)
+    def set_widget_channel(channel, reason = nil)
+      modify_widget(widget?, channel, reason)
     end
+    alias_method :set_embed_channel, :set_widget_channel
 
-    alias_method :set_widget_channel, :set_embed_channel
-
-    # Changes the channel on the server's embed (widget), and sets whether it is enabled.
-    # @param enabled [true, false] whether the embed (widget) is enabled
-    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the embed
+    # Changes the channel on the server's widget, and sets whether it is enabled.
+    # @param enabled [true, false] whether the widget is enabled
+    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the widget
     # @param reason [String, nil] the reason to be shown in the audit log for this action
-    def modify_embed(enabled, channel, reason = nil)
-      cache_embed_data if @embed_enabled.nil?
-      channel_id = channel ? channel.resolve_id : @embed_channel_id
-      response = JSON.parse(API::Server.modify_embed(@bot.token, @id, enabled, channel_id, reason))
-      @embed_enabled = response['enabled']
-      @embed_channel_id = response['channel_id']
+    def modify_widget(enabled, channel, reason = nil)
+      cache_widget_data if @widget_enabled.nil?
+      channel_id = channel ? channel.resolve_id : @widget_channel_id
+      response = JSON.parse(API::Server.modify_widget(@bot.token, @id, enabled, channel_id, reason))
+      @widget_enabled = response['enabled']
+      @widget_channel_id = response['channel_id']
     end
-
-    alias_method :modify_widget, :modify_embed
+    alias_method :modify_embed, :modify_widget
 
     # @param include_idle [true, false] Whether to count idle members as online.
     # @param include_bots [true, false] Whether to include bot accounts in the count.
@@ -842,12 +837,12 @@ module Discordrb
 
       afk_channel_id = new_data[:afk_channel_id] || new_data['afk_channel_id'] || @afk_channel
       @afk_channel_id = afk_channel_id.nil? ? nil : afk_channel_id.resolve_id
-      embed_channel_id = new_data[:embed_channel_id] || new_data['embed_channel_id'] || @embed_channel
-      @embed_channel_id = embed_channel_id.nil? ? nil : embed_channel_id.resolve_id
+      widget_channel_id = new_data[:widget_channel_id] || new_data['widget_channel_id'] || @widget_channel
+      @widget_channel_id = widget_channel_id.nil? ? nil : widget_channel_id.resolve_id
       system_channel_id = new_data[:system_channel_id] || new_data['system_channel_id'] || @system_channel
       @system_channel_id = system_channel_id.nil? ? nil : system_channel_id.resolve_id
 
-      @embed_enabled = new_data[:embed_enabled] || new_data['embed_enabled']
+      @widget_enabled = new_data[:widget_enabled] || new_data['widget_enabled']
       @splash = new_data[:splash_id] || new_data['splash_id'] || @splash_id
 
       @verification_level = new_data[:verification_level] || new_data['verification_level'] || @verification_level

--- a/lib/discordrb/events/channels.rb
+++ b/lib/discordrb/events/channels.rb
@@ -31,7 +31,7 @@ module Discordrb::Events
 
     def initialize(data, bot)
       @bot = bot
-      @channel = bot.channel(data['id'].to_i)
+      @channel = data.is_a?(Discordrb::Channel) ? data : bot.channel(data['id'].to_i)
     end
   end
 

--- a/lib/discordrb/events/presence.rb
+++ b/lib/discordrb/events/presence.rb
@@ -65,28 +65,35 @@ module Discordrb::Events
     # @return [User] the user whose status got updated.
     attr_reader :user
 
-    # @return [String] the new game the user is playing.
-    attr_reader :game
+    # @return [Discordrb::Activity] The new activity
+    attr_reader :activity
 
-    # @return [String] the URL to the stream
-    attr_reader :url
+    # @!attribute [r] url
+    #   @return [String] the URL to the stream
 
-    # @return [String] what the player is currently doing (ex. game being streamed)
-    attr_reader :details
+    # @!attribute [r] details
+    #   @return [String] what the player is currently doing (ex. game being streamed)
 
-    # @return [Integer] the type of play. 0 = game, 1 = Twitch
-    attr_reader :type
+    # @!attribute [r] type
+    #   @return [Integer] the type of play. See {Discordrb::Activity}
+    delegate :url, :details, :type, to: :activity
 
-    def initialize(data, bot)
+    # @return [Hash<Symbol, Symbol>] the current online status (`:online`, `:idle` or `:dnd`) of the user
+    #   on various device types (`:desktop`, `:mobile`, or `:web`). The value will be `nil` if the user is offline or invisible.
+    attr_reader :client_status
+
+    def initialize(data, activity, bot)
       @bot = bot
+      @activity = activity
 
       @server = bot.server(data['guild_id'].to_i)
       @user = bot.user(data['user']['id'].to_i)
-      @game = data['game'] ? data['game']['name'] : nil
-      @type = data['game'] ? data['game']['type'].to_i : nil
-      # Handle optional 'game' fields safely
-      @url = data['game'] && data['game']['url'] ? data['game']['url'] : nil
-      @details = data['game'] && data['game']['details'] ? data['game']['details'] : nil
+      @client_status = @user.client_status
+    end
+
+    # @return [String] the name of the new game the user is playing.
+    def game
+      @activity.name
     end
   end
 

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -134,7 +134,7 @@ module Discordrb
     LARGE_THRESHOLD = 100
 
     # The version of the gateway that's supposed to be used.
-    GATEWAY_VERSION = 6
+    GATEWAY_VERSION = 8
 
     # Heartbeat ACKs are Discord's way of verifying on the client side whether the connection is still alive. If this is
     # set to true (default value) the gateway client will use that functionality to detect zombie connections and

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -143,7 +143,7 @@ module Discordrb
     # @return [true, false] whether or not this gateway should check for heartbeat ACKs.
     attr_accessor :check_heartbeat_acks
 
-    def initialize(bot, token, shard_key = nil, compress_mode = :stream, intents = nil)
+    def initialize(bot, token, shard_key = nil, compress_mode = :stream, intents = ALL_INTENTS)
       @token = token
       @bot = bot
 
@@ -282,7 +282,7 @@ module Discordrb
                       '$device': 'discordrb',
                       '$referrer': '',
                       '$referring_domain': ''
-                    }, compress, 100, @shard_key)
+                    }, compress, 100, @shard_key, @intents)
     end
 
     # Sends an identify packet (op 2). This starts a new session on the current connection and tells Discord who we are.
@@ -303,15 +303,15 @@ module Discordrb
     #   its member list chunked.
     # @param shard_key [Array(Integer, Integer), nil] The shard key to use for sharding, represented as
     #   [shard_id, num_shards], or nil if the bot should not be sharded.
-    def send_identify(token, properties, compress, large_threshold, shard_key = nil)
+    def send_identify(token, properties, compress, large_threshold, shard_key = nil, intents = ALL_INTENTS)
       data = {
         # Don't send a v anymore as it's entirely determined by the URL now
         token: token,
         properties: properties,
         compress: compress,
-        large_threshold: large_threshold
+        large_threshold: large_threshold,
+        intents: intents
       }
-      data[:intents] = @intents unless @intents.nil?
 
       # Don't include the shard key at all if it is nil as Discord checks for its mere existence
       data[:shard] = shard_key if shard_key
@@ -790,7 +790,8 @@ module Discordrb
     # - 4003: Not authenticated. How did this happen?
     # - 4004: Authentication failed. Token was wrong, nothing we can do.
     # - 4011: Sharding required. Currently requires developer intervention.
-    FATAL_CLOSE_CODES = [4003, 4004, 4011].freeze
+    # - 4014: Use of disabled privileged intents.
+    FATAL_CLOSE_CODES = [4003, 4004, 4011, 4014].freeze
 
     def handle_close(e)
       @bot.__send__(:raise_event, Events::DisconnectEvent.new(@bot))
@@ -800,6 +801,15 @@ module Discordrb
         LOGGER.error('Websocket close frame received!')
         LOGGER.error("Code: #{e.code}")
         LOGGER.error("Message: #{e.data}")
+
+        if e.code == 4014
+          LOGGER.error(<<~ERROR) 
+            You attempted to identify with privileged intents that your bot is not authorized to use
+            Please enable the privileged intents on the bot page of your application on the discord developer page.
+            Read more here https://discord.com/developers/docs/topics/gateway#privileged-intents
+          ERROR
+        end
+
         @should_reconnect = false if FATAL_CLOSE_CODES.include?(e.code)
       elsif e.is_a? Exception
         # Log the exception

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -803,7 +803,7 @@ module Discordrb
         LOGGER.error("Message: #{e.data}")
 
         if e.code == 4014
-          LOGGER.error(<<~ERROR) 
+          LOGGER.error(<<~ERROR)
             You attempted to identify with privileged intents that your bot is not authorized to use
             Please enable the privileged intents on the bot page of your application on the discord developer page.
             Read more here https://discord.com/developers/docs/topics/gateway#privileged-intents

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -101,7 +101,7 @@ module Discordrb
     #   permission.can_speak = true
     # @example Create a permissions object that could allow/deny read messages, connect, and speak by an array of symbols
     #   Permissions.new [:read_messages, :connect, :speak]
-    # @param bits [Integer, Array<Symbol>] The permission bits that should be set from the beginning, or an array of permission flag symbols
+    # @param bits [String, Integer, Array<Symbol>] The permission bits that should be set from the beginning, or an array of permission flag symbols
     # @param writer [RoleWriter] The writer that should be used to update data when a permission is set.
     def initialize(bits = 0, writer = nil)
       @writer = writer
@@ -109,7 +109,7 @@ module Discordrb
       @bits = if bits.is_a? Array
                 self.class.bits(bits)
               else
-                bits
+                bits.to_i
               end
 
       init_vars

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -104,8 +104,8 @@ describe Discordrb::Bot do
     end
 
     context 'when handling a PRESENCE_UPDATE' do
-      let(:user) { instance_double(Discordrb::User, activities: [], id: 12345, client_status: nil) }
-      let(:guild_id) { 123456 }
+      let(:user) { instance_double(Discordrb::User, activities: [], id: 12_345, client_status: nil) }
+      let(:guild_id) { 123_456 }
       let(:activity) { instance_double(Discordrb::Activity, name: 'name') }
       let(:activity_fixture) { { 'name' => 'New Activity' } }
       let(:old_activity) { instance_double(Discordrb::Activity, 'old_activity', name: 'Old Activity') }
@@ -120,20 +120,20 @@ describe Discordrb::Bot do
       end
 
       it 'raises a PlayingEvent for each new activity' do
-        bot.send(:handle_dispatch, :PRESENCE_UPDATE, { 'activities' => [activity_fixture, activity_fixture], 'user' => { 'id' => user.id}, 'guild_id' => guild_id })
+        bot.send(:handle_dispatch, :PRESENCE_UPDATE, { 'activities' => [activity_fixture, activity_fixture], 'user' => { 'id' => user.id }, 'guild_id' => guild_id })
         expect(bot).to have_received(:raise_event).with(instance_of(Discordrb::Events::PlayingEvent)).twice
       end
 
       it 'raises a PlayingEvent for each removed activity' do
         allow(user).to receive(:activities).and_return([old_activity])
-        bot.send(:handle_dispatch, :PRESENCE_UPDATE, { 'activities' => [], 'user' => { 'id' => user.id}, 'guild_id' => guild_id })
+        bot.send(:handle_dispatch, :PRESENCE_UPDATE, { 'activities' => [], 'user' => { 'id' => user.id }, 'guild_id' => guild_id })
 
         expect(bot).to have_received(:raise_event).with(instance_of(Discordrb::Events::PlayingEvent))
       end
 
       it 'raises a PlayingEvent for each new and removed activity' do
         allow(user).to receive(:activities).and_return([old_activity])
-        bot.send(:handle_dispatch, :PRESENCE_UPDATE, { 'activities' => [activity_fixture], 'user' => { 'id' => user.id}, 'guild_id' => guild_id })
+        bot.send(:handle_dispatch, :PRESENCE_UPDATE, { 'activities' => [activity_fixture], 'user' => { 'id' => user.id }, 'guild_id' => guild_id })
 
         expect(bot).to have_received(:raise_event).with(an_instance_of(Discordrb::Events::PlayingEvent)).twice
       end
@@ -142,6 +142,41 @@ describe Discordrb::Bot do
         bot.send(:handle_dispatch, :PRESENCE_UPDATE, { 'activities' => [], 'user' => { 'id' => user.id }, 'guild_id' => guild_id, 'status' => 'online' })
 
         expect(bot).to have_received(:raise_event).with(an_instance_of(Discordrb::Events::PresenceEvent))
+      end
+    end
+
+    context 'when handling a MESSAGE_CREATE event' do
+      let(:channel_id) { instance_double(Integer, 'channel_id') }
+      let(:channel) { instance_double(Discordrb::Channel, recipient: author, server: nil) }
+      let(:user_id) { instance_double(Integer, 'user_id') }
+      let(:author) { instance_double(Discordrb::User, id: user_id) }
+      let(:message_fixture) { { 'author' => { 'id' => user_id }, 'channel_id' => channel_id } }
+      let(:message) { instance_double(Discordrb::Message, channel: channel, from_bot?: false, mentions: []) }
+
+      before do
+        allow(bot).to receive(:channel).with(channel_id).and_return(channel)
+        allow(channel).to receive(:is_a?).with(Discordrb::Channel).and_return(true)
+        allow(bot).to receive(:ignored?).with(user_id).and_return(false)
+        allow(bot).to receive(:raise_event)
+        allow(Discordrb::Message).to receive(:new).and_return(message)
+      end
+
+      it 'raises a ChannelCreateEvent if the DM channel is uncached' do
+        allow(channel).to receive(:private?).and_return(true)
+        allow(bot).to receive(:create_channel)
+
+        bot.send(:handle_dispatch, :MESSAGE_CREATE, message_fixture)
+
+        expect(bot).to have_received(:raise_event).with(instance_of(Discordrb::Events::ChannelCreateEvent))
+      end
+
+      it 'does not raise a ChannelCreateEvent if the DM channel is cached' do
+        allow(channel).to receive(:private?).and_return(true)
+        bot.instance_variable_set(:@pm_channels, { user_id => channel })
+
+        bot.send(:handle_dispatch, :MESSAGE_CREATE, message_fixture)
+
+        expect(bot).to_not have_received(:raise_event).with(instance_of(Discordrb::Events::ChannelCreateEvent))
       end
     end
   end

--- a/spec/overwrite_spec.rb
+++ b/spec/overwrite_spec.rb
@@ -3,7 +3,7 @@
 require 'discordrb'
 
 describe Discordrb::Overwrite do
-  describe '#initialize', focus: true do
+  describe '#initialize' do
     context 'when object is an Integer' do
       let(:id) { instance_double(Integer) }
 

--- a/spec/overwrite_spec.rb
+++ b/spec/overwrite_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'discordrb'
+
+describe Discordrb::Overwrite do
+  describe '#initialize', focus: true do
+    context 'when object is an Integer' do
+      let(:id) { instance_double(Integer) }
+
+      it 'accepts the API value for `type`' do
+        overwrite = described_class.new(id, type: 0, allow: 0, deny: 0)
+
+        expect(overwrite.type).to eq Discordrb::Overwrite::TYPES.key(0)
+      end
+
+      it 'accepts a short name value for `type`' do
+        overwrite = described_class.new(id, type: :role, allow: 0, deny: 0)
+
+        expect(overwrite.type).to eq :role
+      end
+
+      it 'accepts a string as a value for `type`' do
+        overwrite = described_class.new(id, type: 'role', allow: 0, deny: 0)
+
+        expect(overwrite.type).to eq :role
+      end
+    end
+
+    context 'when object is a User type' do
+      let(:user_types) { [Discordrb::User, Discordrb::Member, Discordrb::Recipient, Discordrb::Profile] }
+      let(:users) do
+        user_types.collect { |k| [k, instance_double(k)] }.to_h
+      end
+
+      before do
+        users.each do |user_type, dbl|
+          allow(user_type).to receive(:===).with(anything).and_return(false)
+          allow(user_type).to receive(:===).with(dbl).and_return(true)
+        end
+      end
+
+      it 'infers type from a User object' do
+        users.each do |_user_type, user|
+          expect(described_class.new(user).type).to eq :member
+        end
+      end
+    end
+
+    context 'when object is a Role' do
+      let(:role) { instance_double(Discordrb::Role) }
+
+      it 'infers type from a Role object' do
+        allow(Discordrb::Role).to receive(:===).with(anything).and_return(false)
+        allow(Discordrb::Role).to receive(:===).with(role).and_return(true)
+
+        expect(described_class.new(role).type).to eq :role
+      end
+    end
+  end
+
+  describe '#to_hash' do
+    let(:id) { instance_double(Integer) }
+    let(:allow_perm) { instance_double(Discordrb::Permissions, bits: allow_bits) }
+    let(:allow_bits) { instance_double(Integer) }
+    let(:deny_perm) { instance_double(Discordrb::Permissions, bits: deny_bits) }
+    let(:deny_bits) { instance_double(Integer) }
+
+    before do
+      allow(allow_perm).to receive(:is_a?).with(Discordrb::Permissions).and_return(true)
+      allow(deny_perm).to receive(:is_a?).with(Discordrb::Permissions).and_return(true)
+    end
+
+    it 'creates a hash from the relevant values' do
+      overwrite = described_class.new(id, type: :member, allow: allow_perm, deny: deny_perm)
+      expect(overwrite.to_hash).to eq({
+                                        id: id,
+                                        type: Discordrb::Overwrite::TYPES[:member],
+                                        allow: allow_bits,
+                                        deny: deny_bits
+                                      })
+    end
+  end
+
+  describe '.from_hash' do
+    let(:id) { instance_double(Integer) }
+    let(:type) { Discordrb::Overwrite::TYPES[:role] }
+
+    before do
+      allow(id).to receive(:to_i).and_return(id)
+    end
+
+    it 'converts a hash to an Overwrite' do
+      overwrite = described_class.from_hash({
+                                              'id' => id, 'type' => type, 'allow' => 0, 'deny': 0
+                                            })
+
+      expect(overwrite).to eq described_class.new(id, type: :role, allow: 0, deny: 0)
+    end
+  end
+
+  describe '.from_other' do
+    let(:original) { described_class.new(12_345, type: :role, allow: 100, deny: 100) }
+
+    it 'creates a new object from another Overwrite' do
+      copy = described_class.from_other(original)
+
+      expect(copy).to eq original
+    end
+
+    it 'creates new permission objects' do
+      copy = described_class.from_other(original)
+
+      expect(copy.allow).not_to be original.allow
+      expect(copy.deny).not_to be original.deny
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,6 +69,8 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  config.filter_run_when_matching focus: true
 end
 
 # Keeps track of what events are run; if one isn't run it will fail


### PR DESCRIPTION
# Summary

This is a WIP PR, as there are many things to accomplish.

- [X] Bump API version for REST
- [X] Bump API version for Gateway
- [X] Permissions as strings
- [X] Required Intents
- [X] Default ratelimit precision
- [X] Deprecated routes
- [X] `delete-message-days` => `delete_message_days`
- [x] Widget route names
- [X] `invite` => `invites`
- [X] `bulk_delete` => `bulk-delete`
- [X] ~~Integration objects~~ We were supposed to remove fields, but somehow ended up adding to them?
- [X] ~~Retry-After seconds~~ (more accurate body already in use)
- [X] No channel create for dms
- [X] ~~Remove roles, premium_since, and nick from presence update event~~ (Fields not used)
- [X] Permission overwrite types are numbers
- [X] Enhanced Errors
- [X] Removal of `game` field

I'm hoping to get this done within a few weeks, but it's subject to how difficult it is to untangle certain features.

---

## Changed

`Permissions#initialize` - can accept a base 10 integer String
`Overwrite#initialize` - can accept base 10 integer strings for permissions, and the API value (Integer) for type.
`EventContainer#channel_create` - only fires for DMs where the channel is uncached, opposed to firing on every message create.
`Bot#initialize` - intents defaults to `:all`, to retain v6 functionality.

## Deprecated
`API::Server.embed` - Prefer `.widget`
`API::Server.modify_embed` - Prefer `.modify_widget`
`Server#embed_enabled?`/`Server#embed?` - Prefer `#widget_enabled?`/`#widget?`
`Server#embed` - Prefer `#widget`
`Server#embed_enabled=` - Prefer `#widget_enabled=`
`Server#set_embed_enabled` - Prefer `#set_widget_enabled`
`Server#embed_channel` - Prefer `#widget_channel`
`Server#set_embed_channel` - Prefer `#set_embed_channel`
`Server#modify_embed` - Prefer `Server#modify_widget`

