### PR TITLE
Add Competing to activity types

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -505,7 +505,7 @@ module Discordrb
     # @param url [String, nil] The Twitch URL to display as a stream. nil for no stream.
     # @param since [Integer] When this status was set.
     # @param afk [true, false] Whether the bot is AFK.
-    # @param activity_type [Integer] The type of activity status to display. 
+    # @param activity_type [Integer] The type of activity status to display.
     #   Can be 0 (Playing), 1 (Streaming), 2 (Listening), 3 (Watching), or 5 (Competing).
     # @see Gateway#send_status_update
     def update_status(status, activity, url, since = 0, afk = false, activity_type = 0)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -505,7 +505,8 @@ module Discordrb
     # @param url [String, nil] The Twitch URL to display as a stream. nil for no stream.
     # @param since [Integer] When this status was set.
     # @param afk [true, false] Whether the bot is AFK.
-    # @param activity_type [Integer] The type of activity status to display. Can be 0 (Playing), 1 (Streaming), 2 (Listening), 3 (Watching)
+    # @param activity_type [Integer] The type of activity status to display. 
+    #   Can be 0 (Playing), 1 (Streaming), 2 (Listening), 3 (Watching), or 5 (Competing).
     # @see Gateway#send_status_update
     def update_status(status, activity, url, since = 0, afk = false, activity_type = 0)
       gateway_check
@@ -556,6 +557,14 @@ module Discordrb
       gateway_check
       update_status(@status, name, url)
       name
+    end
+
+    # Sets the currently competing status to the specified name.
+    # @param name [String] The name of the game to be competing in.
+    # @return [String] The game that is being competed in now.
+    def competing=(name)
+      gateway_check
+      update_status(@status, name, nil, nil, nil, 5)
     end
 
     # Sets status to online.

--- a/lib/discordrb/data/activity.rb
+++ b/lib/discordrb/data/activity.rb
@@ -265,7 +265,7 @@ module Discordrb
 
     # @return [Array<Activity>] all activities of type {Activity::COMPETING}
     def competing
-      @activities.select { |act| act.type == Activity::COMPETING}
+      @activities.select { |act| act.type == Activity::COMPETING }
     end
   end
 end

--- a/lib/discordrb/data/activity.rb
+++ b/lib/discordrb/data/activity.rb
@@ -17,7 +17,7 @@ module Discordrb
     # @return [String] the activity's name
     attr_reader :name
 
-    # @return [Integer, nil] activity type. Can be {GAME}, {STREAMING}, {LISTENING}, {CUSTOM}
+    # @return [Integer, nil] activity type. Can be {GAME}, {STREAMING}, {LISTENING}, {CUSTOM}, or {COMPETING}
     attr_reader :type
 
     # @return [String, nil] stream URL, when the activity type is {STREAMING}
@@ -67,6 +67,8 @@ module Discordrb
     WATCHING = 3
     # Type indicating the activity is a custom status
     CUSTOM = 4
+    # Type indicating the activity is for a competitive game
+    COMPETING = 5
 
     # @!visibility private
     def initialize(data, bot)
@@ -259,6 +261,11 @@ module Discordrb
     # @return [Array<Activity>] all activities of type {Activity::CUSTOM}
     def custom_status
       @activities.select { |act| act.type == Activity::CUSTOM }
+    end
+
+    # @return [Array<Activity>] all activities of type {Activity::COMPETING}
+    def competing
+      @activities.select { |act| act.type == Activity::COMPETING}
     end
   end
 end


### PR DESCRIPTION
# Summary

Add support for `Competing` activity type to `Activity` and `Bot`. Fixes #14.

---

## Added
* `Activity::COMPETING`, `ActivitySet#competing`
* `Bot#competing=` to set the competing status
* Updated comments to add Competing to the list of activity types
