### PR TITLE
Remove extra attempted heartbeat after stopping Bot normally

### DIFF
--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -444,13 +444,16 @@ module Discordrb
       @heartbeat_interval = interval
       @heartbeat_thread = Thread.new do
         Thread.current[:discordrb_name] = 'heartbeat'
+        # We've just gotten a Hello, don't send another heartbeat immediately.
+        sleep @heartbeat_interval
+        
         loop do
           # Send a heartbeat if heartbeats are active and either no session exists yet, or an existing session is
           # suspended (e.g. after op7)
           if (@session && !@session.suspended?) || !@session
-            sleep @heartbeat_interval
             @bot.raise_heartbeat_event
             heartbeat
+            sleep @heartbeat_interval
           else
             sleep 1
           end


### PR DESCRIPTION
# Summary

Changes the sequence of time delays in the heartbeat thread.

If the delay happens after checking the session, the session could be
suspended while the thread is sleeping, causing us to try to heartbeat on a
suspended session. Moving the sleep down sends the heartbeat right after the
check.

---

## Changed
- `Gateway`'s `@heartbeat_thread`: Moved the heartbeat_interval delay to after raising the heartbeat event, before
checking if the session is suspended.

