### PR TITLE
Pass a callable into CommandBot command_doesnt_exist_message:

### DIFF
--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -120,6 +120,40 @@ describe Discordrb::Commands::CommandBot, order: :defined do
     end
   end
 
+  context 'with :command_doesnt_exist_message attribute' do
+    let(:plain_event) { command_event_double_for_channel(first_channel) }
+
+    context 'as a string' do
+      bot = Discordrb::Commands::CommandBot.new(token: 'token', command_doesnt_exist_message: 'command %command% does not exist!')
+
+      it 'replies with the message including % substitution' do
+        expect(plain_event).to receive(:respond).with('command bleep_blorp does not exist!')
+        result = bot.execute_command(:bleep_blorp, plain_event, [])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'as a lambda' do
+      bot = Discordrb::Commands::CommandBot.new(token: 'token', command_doesnt_exist_message: ->(event) { "command %command% does not exist in #{event.channel.name} and 1+2=#{1 + 2}" })
+
+      it 'executes the lambda and replies with a message including % substitution' do
+        expect(plain_event).to receive(:respond).with('command bleep_blorp does not exist in test-channel and 1+2=3')
+        result = bot.execute_command(:bleep_blorp, plain_event, [])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'with a nil' do
+      bot = Discordrb::Commands::CommandBot.new(token: 'token', command_doesnt_exist_message: ->(_event) {})
+
+      it 'does not reply' do
+        expect(plain_event).to_not receive(:respond)
+        result = bot.execute_command(:bleep_blorp, plain_event, [])
+        expect(result).to be_nil
+      end
+    end
+  end
+
   describe '#execute_command', order: :defined do
     context 'with role filter', order: :defined do
       bot = Discordrb::Commands::CommandBot.new(token: 'token', help_available: false)


### PR DESCRIPTION
Reopens https://github.com/discordrb/discordrb/pull/750 as per @swarley and fixes rubocop violations.


# Summary

Allows the `CommandBot` `command_doesnt_exist_message:` to be a callable. The behaviour stays the same for existing strings and `nil` passed in, but if instead something that responds to `:call` is passed in, that is first called with the `event`, then the result handled in the same way as above. This includes the `nil` behaviour and the replacing of the `"%command%"` substring.

Example:

```ruby
bot = Discordrb::Commands::CommandBot.new(
  token: token,
  prefix: "!",
  command_doesnt_exist_message: ->(event) {
    "Your command %command% doesn't exist. Have you tried? #{ find_similar_commands(event) }"
  }
)
```

## Added

* `CommandBot` `command_doesnt_exist_message:` can be be a callable.


# Alternative approach?

The other approach I was considering was adding:
```ruby
class CommandBot
  def command_not_found(&block)
    @command_not_found = block
  end
end
```

It would be invoked in the same way when a command is missing, but it would mean that it would be defined like:

```ruby
bot = Discordrb::Commands::CommandBot.new(token: token)
bot.command_not_found do |event|
  "Your command %command% doesn't exist. Have you tried? #{ find_similar_commands(event) }"
end
```

This is more in line with the DSL to define commands and responses, but would mean deprecating the `command_doesnt_exist_message` argument, then bumping the semver version.

I would be happy to implement this approach instead. It's mostly working on a branch.