### PR TITLE
fixup: remove bad conditional in Invite initializer

### DIFF
--- a/lib/discordrb/data/invite.rb
+++ b/lib/discordrb/data/invite.rb
@@ -87,7 +87,7 @@ module Discordrb
     def initialize(data, bot)
       @bot = bot
 
-      @channel = if data['channel_id'] || bot.channel
+      @channel = if data['channel_id']
                    bot.channel(data['channel_id'])
                  else
                    InviteChannel.new(data['channel'], bot)


### PR DESCRIPTION
# Summary

Left in a bad conditional check in the Invite initializer

## Fixed
`Invite#initialize`