### PR TITLE
Fixup message link

### DIFF
--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -83,7 +83,7 @@ module Discordrb
       @referenced_message = Message.new(data['referenced_message'], bot) if data['referenced_message']
       @message_reference = data['message_reference']
 
-      @server = bot.server(data['guild_id'].to_i) if data['guild_id']
+      @server = @channel.server
 
       @author = if data['author']
                   if data['author']['discriminator'] == ZERO_DISCRIM

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -103,6 +103,8 @@ describe Discordrb::Message do
       data['channel_id'] = channel_id
 
       message = described_class.new(data, bot)
+      message.instance_variable_set(:@server, nil)
+
       expect(message.link).to eq 'https://discord.com/channels/@me/channel_id/message_id'
     end
   end


### PR DESCRIPTION
# Summary

`@server` would be nil if `guild_id` wasn't in the payload, despite the channel belonging to a guild.

## Fixed
- `Message#initialize`
