### PR TITLE
Update webhooks gemspec to match

### DIFF
--- a/discordrb-webhooks.gemspec
+++ b/discordrb-webhooks.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rest-client', '>= 2.0.0'
+  spec.add_dependency 'rest-client', '~> 2.1.0'
 
   spec.required_ruby_version = '>= 2.5'
 end

--- a/discordrb-webhooks.gemspec
+++ b/discordrb-webhooks.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rest-client', '~> 2.1.0'
+  spec.add_dependency 'rest-client', '>= 2.0.0'
 
   spec.required_ruby_version = '>= 2.5'
 end

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rest-client', '>= 2.0.0'
   spec.add_dependency 'websocket-client-simple', '>= 0.3.0'
 
-  spec.add_dependency 'discordrb-webhooks', '~> 3.3.0'
+  spec.add_dependency 'discordrb-webhooks', '~> 3.4.0'
 
   spec.required_ruby_version = '>= 2.5'
 

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -25,10 +25,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'ffi', '>= 1.9.24'
   spec.add_dependency 'opus-ruby'
-  spec.add_dependency 'rest-client', '>= 2.0.0'
+  spec.add_dependency 'rest-client', '~> 2.1.0'
   spec.add_dependency 'websocket-client-simple', '>= 0.3.0'
 
-  spec.add_dependency 'discordrb-webhooks', '~> 3.4.0'
+  spec.add_dependency 'discordrb-webhooks', '~> 3.4.1'
 
   spec.required_ruby_version = '>= 2.5'
 

--- a/lib/discordrb/version.rb
+++ b/lib/discordrb/version.rb
@@ -3,5 +3,5 @@
 # Discordrb and all its functionality, in this case only the version.
 module Discordrb
   # The current version of discordrb.
-  VERSION = '3.4.0'
+  VERSION = '3.4.1'
 end

--- a/lib/discordrb/webhooks/version.rb
+++ b/lib/discordrb/webhooks/version.rb
@@ -4,6 +4,6 @@
 module Discordrb
   module Webhooks
     # The current version of discordrb-webhooks.
-    VERSION = '3.4.0'
+    VERSION = '3.4.1'
   end
 end


### PR DESCRIPTION
When the both webhooks and the main library were updated to 3.4.0, the gemspec pointing to webhooks from main was left on 3.3.0.

3.3.0 used `rest-client >= 2.1.0.rc1` which was reverted here https://github.com/shardlab/discordrb/commit/648596335da886b01ed87ff6f43c8bc2a7e0aae4

This causes incompatibilities when using rest-client 2.0.x in other gems.