### PR TITLE
Webhook update

### DIFF
--- a/lib/discordrb/api/webhook.rb
+++ b/lib/discordrb/api/webhook.rb
@@ -27,6 +27,28 @@ module Discordrb::API::Webhook
     )
   end
 
+  # Execute a webhook via token.
+  # https://discord.com/developers/docs/resources/webhook#execute-webhook
+  def token_execute_webhook(webhook_token, webhook_id, wait = false, content = nil, username = nil, avatar_url = nil, tts = nil, file = nil, embeds = nil, allowed_mentions = nil)
+    body = { content: content, username: username, avatar_url: avatar_url, tts: tts, embeds: embeds,  allowed_mentions: allowed_mentions }
+    body = if file
+             { file: file, payload_json: body.to_json }
+           else
+             body.to_json
+           end
+
+    headers = { content_type: :json } unless file
+
+    Discordrb::API.request(
+      :webhooks_wid,
+      webhook_id,
+      :post,
+      "#{Discordrb::API.api_base}/webhooks/#{webhook_id}/#{webhook_token}?wait=#{wait}",
+      body,
+      headers
+    )
+  end
+
   # Update a webhook
   # https://discord.com/developers/docs/resources/webhook#modify-webhook
   def update_webhook(token, webhook_id, data, reason = nil)
@@ -78,6 +100,30 @@ module Discordrb::API::Webhook
       :delete,
       "#{Discordrb::API.api_base}/webhooks/#{webhook_id}/#{webhook_token}",
       'X-Audit-Log-Reason': reason
+    )
+  end
+
+  # Edit a webhook message via webhook token
+  # https://discord.com/developers/docs/resources/webhook#edit-webhook-message
+  def token_edit_message(webhook_token, webhook_id, message_id, content = nil, embeds = nil, allowed_mentions = nil)
+    Discordrb::API.request(
+      :webhooks_wid_messages,
+      webhook_id,
+      :patch,
+      "#{Discordrb::API.api_base}/webhooks/#{webhook_id}/#{webhook_token}/messages/#{message_id}",
+      { content: content, embeds: embeds, allowed_mentions: allowed_mentions }.to_json,
+      content_type: :json
+    )
+  end
+
+  # Delete a webhook message via webhook token.
+  # https://discord.com/developers/docs/resources/webhook#delete-webhook-message
+  def token_delete_message(webhook_token, webhook_id, message_id)
+    Discordrb::API.request(
+      :webhooks_wid_messages,
+      webhook_id,
+      :delete,
+      "#{Discordrb::API.api_base}/webhooks/#{webhook_id}/#{webhook_token}/messages/#{message_id}"
     )
   end
 end

--- a/lib/discordrb/data/webhook.rb
+++ b/lib/discordrb/data/webhook.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'discordrb/webhooks/builder'
+
 module Discordrb
   # A webhook on a server channel
   class Webhook
@@ -87,13 +89,100 @@ module Discordrb
     end
 
     # Deletes the webhook.
-    # @param reason [String] The reason the invite is being deleted.
+    # @param reason [String] The reason the webhook is being deleted.
     def delete(reason = nil)
       if token?
         API::Webhook.token_delete_webhook(@token, @id, reason)
       else
         API::Webhook.delete_webhook(@bot.token, @id, reason)
       end
+    end
+
+    # Execute a webhook.
+    # @param content [String] The content of the message. May be 2000 characters long at most.
+    # @param username [String] The username the webhook will display as. If this is not set, the default username set in the webhook's settings.
+    # @param avatar_url [String] The URL of an image file to be used as an avatar. If this is not set, the default avatar from the webhook's
+    # @param tts [true, false] Whether this message should use TTS or not. By default, it doesn't.
+    # @param file [File] File to be sent together with the message. Mutually exclusive with embeds; a webhook message can contain
+    #   either a file to be sent or embeds.
+    # @param embeds [Array<Webhooks::Embed, Hash>] Embeds to attach to this message.
+    # @param allowed_mentions [AllowedMentions, Hash] Mentions that are allowed to ping in the `content`.
+    # @param wait [true, false] Whether Discord should wait for the message to be successfully received by clients, or
+    #   whether it should return immediately after sending the message. If `true` a {Message} object will be returned.
+    # @yield [builder] Gives the builder to the block to add additional steps, or to do the entire building process.
+    # @yieldparam builder [Builder] The builder given as a parameter which is used as the initial step to start from.
+    # @example Execute the webhook with kwargs
+    #   client.execute(
+    #     content: 'Testing',
+    #     username: 'discordrb',
+    #     embeds: [
+    #       { timestamp: Time.now.iso8601, title: 'testing', image: { url: 'https://i.imgur.com/PcMltU7.jpg' } }
+    #     ])
+    # @example Execute the webhook with an already existing builder
+    #   builder = Discordrb::Webhooks::Builder.new # ...
+    #   client.execute(builder)
+    # @example Execute the webhook by building a new message
+    #   client.execute do |builder|
+    #     builder.content = 'Testing'
+    #     builder.username = 'discordrb'
+    #     builder.add_embed do |embed|
+    #       embed.timestamp = Time.now
+    #       embed.title = 'Testing'
+    #       embed.image = Discordrb::Webhooks::EmbedImage.new(url: 'https://i.imgur.com/PcMltU7.jpg')
+    #     end
+    #   end
+    # @return [Message, nil] If `wait` is `true`, a {Message} will be returned. Otherwise this method will return `nil`.
+    # @note This is only available to webhooks with publically exposed tokens. This excludes channel follow webhooks and webhooks retrieved
+    #   via the audit log.
+    def execute(content: nil, username: nil, avatar_url: nil, tts: nil, file: nil, embeds: nil, allowed_mentions: nil, wait: true, builder: nil)
+      raise Discordrb::Errors::UnauthorizedWebhook unless @token
+
+      params = { content: content, username: username, avatar_url: avatar_url, tts: tts, file: file, embeds: embeds, allowed_mentions: allowed_mentions }
+
+      builder ||= Webhooks::Builder.new
+      yield(builder) if block_given?
+
+      data = builder.to_json_hash.merge(params.compact)
+
+      resp = API::Webhook.token_execute_webhook(@token, @id, wait, data[:content], data[:username], data[:avatar_url], data[:tts], data[:file], data[:embeds], data[:allowed_mentions])
+
+      Message.new(JSON.parse(resp), @bot) if wait
+    end
+
+    # Delete a message created by this webhook.
+    # @param message_id [String, Integer] The ID of the message to delete.
+    def delete_message(message_id)
+      raise Discordrb::Errors::UnauthorizedWebhook unless @token
+
+      API::Webhook.token_delete_message(@token, @id, message_id)
+    end
+
+    # Edit a message created by this webhook.
+    # @param message_id [String, Integer] The ID of the message to edit.
+    # @param content [String] The content of the message. May be 2000 characters long at most.
+    # @param embeds [Array<Webhooks::Embed, Hash>] Embeds to be attached to the message.
+    # @param allowed_mentions [AllowedMentions, Hash] Mentions that are allowed to ping in the `content`.
+    # @param builder [Builder, nil] The builder to start out with, or nil if one should be created anew.
+    # @yield [builder] Gives the builder to the block to add additional steps, or to do the entire building process.
+    # @yieldparam builder [Webhooks::Builder] The builder given as a parameter which is used as the initial step to start from.
+    # @return [Message] The updated message.
+    # @note When editing `allowed_mentions`, it will update visually in the client but not alert the user with a notification.
+    def edit_message(message_id, content: nil, embeds: nil, allowed_mentions: nil, builder: nil)
+      raise Discordrb::Errors::UnauthorizedWebhook unless @token
+
+      params = { content: content, embeds: embeds, allowed_mentions: allowed_mentions }.compact
+
+      data = if block_given?
+               builder ||= Discordrb::Webhooks::Builder.new
+               yield(builder)
+
+               builder.to_json_hash.merge(params)
+             else
+               params
+             end
+
+      resp = API::Webhook.token_edit_message(@token, @id, message_id, data[:content], data[:embeds], data[:allowed_mentions])
+      Message.new(JSON.parse(resp), @bot)
     end
 
     # Utility function to get a webhook's avatar URL.

--- a/lib/discordrb/data/webhook.rb
+++ b/lib/discordrb/data/webhook.rb
@@ -150,7 +150,7 @@ module Discordrb
     end
 
     # Delete a message created by this webhook.
-    # @param message_id [Message, String, Integer] The ID of the message to delete.
+    # @param message [Message, String, Integer] The ID of the message to delete.
     def delete_message(message)
       raise Discordrb::Errors::UnauthorizedWebhook unless @token
 

--- a/lib/discordrb/errors.rb
+++ b/lib/discordrb/errors.rb
@@ -20,6 +20,9 @@ module Discordrb
     # Raised when the bot gets a HTTP 502 error, which is usually caused by Cloudflare.
     class CloudflareError < RuntimeError; end
 
+    # Raised when using a webhook method without an associated token.
+    class UnauthorizedWebhook < RuntimeError; end
+
     # Generic class for errors denoted by API error codes
     class CodeError < RuntimeError
       class << self

--- a/lib/discordrb/webhooks/builder.rb
+++ b/lib/discordrb/webhooks/builder.rb
@@ -5,13 +5,14 @@ require 'discordrb/webhooks/embeds'
 module Discordrb::Webhooks
   # A class that acts as a builder for a webhook message object.
   class Builder
-    def initialize(content: '', username: nil, avatar_url: nil, tts: false, file: nil, embeds: [])
+    def initialize(content: '', username: nil, avatar_url: nil, tts: false, file: nil, embeds: [], allowed_mentions: nil)
       @content = content
       @username = username
       @avatar_url = avatar_url
       @tts = tts
       @file = file
       @embeds = embeds
+      @allowed_mentions = allowed_mentions
     end
 
     # The content of the message. May be 2000 characters long at most.
@@ -70,6 +71,10 @@ module Discordrb::Webhooks
     # @return [Array<Embed>] the embeds attached to this message.
     attr_reader :embeds
 
+    # @return [Discordrb::AllowedMentions, Hash] Mentions that are allowed to ping in this message.
+    # @see https://discord.com/developers/docs/resources/channel#allowed-mentions-object
+    attr_accessor :allowed_mentions
+
     # @return [Hash] a hash representation of the created message, for JSON format.
     def to_json_hash
       {
@@ -77,7 +82,8 @@ module Discordrb::Webhooks
         username: @username,
         avatar_url: @avatar_url,
         tts: @tts,
-        embeds: @embeds.map(&:to_hash)
+        embeds: @embeds.map(&:to_hash),
+        allowed_mentions: @allowed_mentions
       }
     end
 
@@ -88,7 +94,8 @@ module Discordrb::Webhooks
         username: @username,
         avatar_url: @avatar_url,
         tts: @tts,
-        file: @file
+        file: @file,
+        allowed_mentions: @allowed_mentions
       }
     end
   end

--- a/spec/webhooks_spec.rb
+++ b/spec/webhooks_spec.rb
@@ -80,4 +80,194 @@ describe Discordrb::Webhooks do
       end
     end
   end
+
+  describe Discordrb::Webhooks::Client do
+    let(:id) { Random.bytes(8) }
+    let(:token) { Random.bytes(24) }
+    let(:provided_url) { instance_double(String) }
+
+    subject { described_class.new(url: provided_url) }
+
+    describe '#initialize' do
+      it 'generates a url from id and token' do
+        client = described_class.new(id: id, token: token)
+        url = client.instance_variable_get(:@url)
+
+        expect(url).to eq "https://discord.com/api/v8/webhooks/#{id}/#{token}"
+      end
+
+      it 'takes a provided url' do
+        client = described_class.new(url: provided_url)
+        url = client.instance_variable_get(:@url)
+
+        expect(url).to be provided_url
+      end
+    end
+
+    describe '#execute' do
+      let(:json_hash) { instance_double(Hash) }
+      let(:default_builder) { instance_double(Discordrb::Webhooks::Builder, to_json_hash: json_hash) }
+
+      before do
+        allow(subject).to receive(:post_json).with(any_args)
+        allow(subject).to receive(:post_multipart).with(any_args)
+        allow(default_builder).to receive(:file).and_return(nil)
+      end
+
+      it 'takes a default builder' do
+        expect { |b| subject.execute(default_builder, &b) }.to yield_with_args(default_builder)
+      end
+
+      context 'when a builder is not provided' do
+        it 'creates a new builder if none is provided' do
+          expect { |b| subject.execute(&b) }.to yield_with_args(instance_of(Discordrb::Webhooks::Builder))
+        end
+      end
+
+      context 'when a file is provided' do
+        it 'POSTs multipart data' do
+          allow(default_builder).to receive(:file).and_return(true)
+
+          subject.execute(default_builder)
+
+          expect(subject).to have_received(:post_multipart).with(default_builder, anything)
+        end
+      end
+
+      context 'when a file is not provided' do
+        it 'POSTs json data' do
+          subject.execute(default_builder)
+
+          expect(subject).to have_received(:post_json).with(default_builder, anything)
+        end
+      end
+    end
+
+    describe '#modify' do
+      let(:name) { instance_double(String) }
+
+      before do
+        allow(RestClient).to receive(:patch).with(any_args)
+      end
+
+      it 'sends a PATCH request to the URL' do
+        subject.modify
+
+        expect(RestClient).to have_received(:patch).with(provided_url, anything, content_type: :json)
+      end
+    end
+
+    describe '#delete' do
+      before do
+        allow(RestClient).to receive(:delete).with(any_args)
+      end
+
+      it 'sends a DELETE request to the URL' do
+        reason = instance_double(String)
+
+        subject.delete(reason: reason)
+
+        expect(RestClient).to have_received(:delete).with(provided_url, 'X-Audit-Log-Reason': reason)
+      end
+    end
+
+    describe '#edit_message' do
+      let(:message_id) { Random.bytes(8) }
+      let(:json_hash) { {} }
+      let(:default_builder) { instance_double(Discordrb::Webhooks::Builder, to_json_hash: json_hash) }
+
+      before do
+        allow(RestClient).to receive(:patch).with(any_args)
+      end
+
+      it 'creates a new builder if one is not provided' do
+        expect { |b| subject.edit_message(message_id, &b) }.to yield_with_args(instance_of(Discordrb::Webhooks::Builder))
+      end
+
+      it 'uses the provided builder' do
+        expect { |b| subject.edit_message(message_id, builder: default_builder, &b) }.to yield_with_args(default_builder)
+      end
+
+      it 'sends a PATCH request to the message URL' do
+        url = subject.instance_variable_get(:@url)
+
+        subject.edit_message(message_id)
+
+        expect(RestClient).to have_received(:patch).with("#{url}/messages/#{message_id}", instance_of(String), content_type: :json)
+      end
+    end
+
+    describe '#delete_message' do
+      let(:base_url) { 'url' }
+      let(:message_id) { Random.bytes(8) }
+
+      subject { described_class.new(url: base_url) }
+
+      before do
+        allow(RestClient).to receive(:delete).with(any_args)
+      end
+
+      it 'sends a DELETE request to the message URL' do
+        subject.delete_message(message_id)
+
+        expect(RestClient).to have_received(:delete).with("#{base_url}/messages/#{message_id}")
+      end
+    end
+
+    describe '#post_json' do
+      let(:builder) { Discordrb::Webhooks::Builder.new(content: 'value') }
+
+      before do
+        allow(RestClient).to receive(:post).with(any_args)
+        allow(provided_url).to receive(:+).with(anything).and_return(provided_url)
+      end
+
+      it 'makes a POST request with JSON data' do
+        subject.__send__(:post_json, builder, false)
+
+        expect(RestClient).to have_received(:post).with(provided_url, builder.to_json_hash.to_json, content_type: :json)
+      end
+
+      it 'waits when wait=true' do
+        subject.__send__(:post_json, builder, true)
+
+        expect(provided_url).to have_received(:+).with('?wait=true')
+      end
+    end
+
+    describe '#post_multipart' do
+      let(:multipart_hash) { instance_double(Hash) }
+      let(:builder) { instance_double(Discordrb::Webhooks::Builder, to_multipart_hash: multipart_hash) }
+
+      before do
+        allow(RestClient).to receive(:post).with(any_args)
+        allow(provided_url).to receive(:+).with(anything).and_return(provided_url)
+      end
+
+      it 'makes a POST request with multipart data' do
+        subject.__send__(:post_multipart, builder, false)
+
+        expect(RestClient).to have_received(:post).with(provided_url, multipart_hash)
+      end
+
+      it 'waits for a response when wait=true' do
+        subject.__send__(:post_multipart, builder, true)
+
+        expect(provided_url).to have_received(:+).with('?wait=true')
+      end
+    end
+
+    describe '#avatarise' do
+      let(:data) { Random.bytes(24) }
+
+      it 'makes no changes if the argument does not respond to read' do
+        expect(subject.__send__(:avatarise, data)).to be data
+      end
+
+      it 'returns multipart data if the argument responds to read' do
+        encoded = subject.__send__(:avatarise, StringIO.new(data))
+        expect(encoded).to eq "data:image/jpg;base64,#{Base64.strict_encode64(data)}"
+      end
+    end
+  end
 end

--- a/spec/webhooks_spec.rb
+++ b/spec/webhooks_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'securerandom'
 require 'discordrb/webhooks'
 
 describe Discordrb::Webhooks do
@@ -82,8 +83,8 @@ describe Discordrb::Webhooks do
   end
 
   describe Discordrb::Webhooks::Client do
-    let(:id) { Random.bytes(8) }
-    let(:token) { Random.bytes(24) }
+    let(:id) { SecureRandom.bytes(8) }
+    let(:token) { SecureRandom.bytes(24) }
     let(:provided_url) { instance_double(String) }
 
     subject { described_class.new(url: provided_url) }
@@ -172,7 +173,7 @@ describe Discordrb::Webhooks do
     end
 
     describe '#edit_message' do
-      let(:message_id) { Random.bytes(8) }
+      let(:message_id) { SecureRandom.bytes(8) }
       let(:json_hash) { {} }
       let(:default_builder) { instance_double(Discordrb::Webhooks::Builder, to_json_hash: json_hash) }
 
@@ -199,7 +200,7 @@ describe Discordrb::Webhooks do
 
     describe '#delete_message' do
       let(:base_url) { 'url' }
-      let(:message_id) { Random.bytes(8) }
+      let(:message_id) { SecureRandom.bytes(8) }
 
       subject { described_class.new(url: base_url) }
 
@@ -258,7 +259,7 @@ describe Discordrb::Webhooks do
     end
 
     describe '#avatarise' do
-      let(:data) { Random.bytes(24) }
+      let(:data) { SecureRandom.bytes(24) }
 
       it 'makes no changes if the argument does not respond to read' do
         expect(subject.__send__(:avatarise, data)).to be data


### PR DESCRIPTION
# Summary

Adds support for editing and deleting webhook messages. Also adds execute support to API and Webhook objects that have tokens associated with them.

---

## Added
`Webhook#execute` - Now allows execution of webhooks retrieved via the API (with some stipulations).
`Webhook#delete_message`
`Webhook#edit_message`
`API::Webhook.token_execute_webhook`
`API::Webhook.token_edit_message`
`API::Webhook.token_delete_message`
`Webhooks::Builder#allowed_mentions`
`Webhooks::Builder#allowed_mentions=`
`Webhooks::Client#edit_message`
`Webhooks::Client#delete_message`
`Webhooks::Client#delete` - Delete a webhook via a client
`Webhooks::Client#modify` - Modify webhook properties via a client
`Errors::UnauthorizedWebhook` - Error raised when attempting to use `execute`, `delete_message`, or `edit_message` on an API webhook without an associated webhook token.

## Changed
`Webhooks::Builder` - Accepts `allowed_mentions`
