### PR TITLE
Fix lack of errors to flatten

### DIFF
--- a/lib/discordrb/errors.rb
+++ b/lib/discordrb/errors.rb
@@ -33,7 +33,7 @@ module Discordrb
       def initialize(message, errors = nil)
         @message = message
 
-        @errors = flatten_errors(errors) if errors
+        @errors = errors ? flatten_errors(errors) : []
       end
 
       # @return [Integer] The error code represented by this error.


### PR DESCRIPTION
Many discord errors don't have an `"errors": {}` object and only have a message such as `"message": "404: Not Found"`.

This change sets stops calling `flatten_errors` and sets `@errors` to be `[]` in the case of no errors object as 404's and other auth errors are currently throwing a further exception when doing `errors.collect`.