### PR TITLE
Fix test for Ruby 3.0

### DIFF
--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -74,7 +74,7 @@ describe Discordrb::Commands::CommandBot, order: :defined do
     command_event_double.tap do |event|
       append_author_to_double(event)
       append_bot_to_double(event)
-      append_channel_to_double(event, channel_id, kwargs)
+      append_channel_to_double(event, channel_id, **kwargs)
     end
   end
 


### PR DESCRIPTION
# Summary

Fix test for positional arguments and keyword arguments separation for Ruby 3.0.

See more about keyword arguments behaviour: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

## How to reproduce

```shell
# Use ruby 3.0
rbenv local 3.0.0 

gem i bundler
bundle install

# You'll see the test failing on main branch.
bundle exec rspec
```
## Fixed

`spec/commands_spec.rb`