### PR TITLE
Don't send an empty limit query parameter for Channel#get_channel

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -201,7 +201,7 @@ module Discordrb::API::Channel
   # https://discord.com/developers/docs/resources/channel#get-reactions
   def get_reactions(token, channel_id, message_id, emoji, before_id, after_id, limit = 100)
     emoji = URI.encode_www_form_component(emoji) unless emoji.ascii_only?
-    query_string = "limit=#{limit}#{"&before=#{before_id}" if before_id}#{"&after=#{after_id}" if after_id}"
+    query_string = "limit=#{limit || 100}#{"&before=#{before_id}" if before_id}#{"&after=#{after_id}" if after_id}"
     Discordrb::API.request(
       :channels_cid_messages_mid_reactions_emoji,
       channel_id,

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -201,7 +201,7 @@ module Discordrb::API::Channel
   # https://discord.com/developers/docs/resources/channel#get-reactions
   def get_reactions(token, channel_id, message_id, emoji, before_id, after_id, limit = 100)
     emoji = URI.encode_www_form_component(emoji) unless emoji.ascii_only?
-    query_string = "limit=#{limit || 100}#{"&before=#{before_id}" if before_id}#{"&after=#{after_id}" if after_id}"
+    query_string = URI.encode_www_form({ limit: limit, before: before_id, after: after_id }.compact)
     Discordrb::API.request(
       :channels_cid_messages_mid_reactions_emoji,
       channel_id,

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -201,7 +201,7 @@ module Discordrb::API::Channel
   # https://discord.com/developers/docs/resources/channel#get-reactions
   def get_reactions(token, channel_id, message_id, emoji, before_id, after_id, limit = 100)
     emoji = URI.encode_www_form_component(emoji) unless emoji.ascii_only?
-    query_string = URI.encode_www_form({ limit: limit, before: before_id, after: after_id }.compact)
+    query_string = URI.encode_www_form({ limit: limit || 100, before: before_id, after: after_id }.compact)
     Discordrb::API.request(
       :channels_cid_messages_mid_reactions_emoji,
       channel_id,

--- a/spec/api/channel_spec.rb
+++ b/spec/api/channel_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "discordrb"
+
+describe Discordrb::API::Channel do
+  let(:token) { double('token') }
+  let(:channel_id) { instance_double(String, 'channel_id') }
+
+  before do
+    allow(token).to receive(:to_s).and_return('bot_token')
+    allow(channel_id).to receive(:to_s).and_return('channel_id')
+  end
+
+  describe '.get_reactions' do
+    let(:message_id) { double('message_id') }
+    let(:before_id) { double('before_id') }
+    let(:after_id) { double('after_id') }
+
+    before do
+      allow(message_id).to receive(:to_s).and_return('message_id')
+      allow(before_id).to receive(:to_s).and_return('before_id')
+      allow(after_id).to receive(:to_s).and_return('after_id')
+
+      allow(Discordrb::API).to receive(:request)
+        .with(anything, channel_id, :get, kind_of(String), any_args)
+    end    
+
+    it 'sends requests' do
+      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, 'test', before_id, after_id, 27)
+      expect(Discordrb::API).to have_received(:request)
+        .with(
+          anything,
+          channel_id,
+          :get,
+          "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/test?limit=27&before=#{before_id}&after=#{after_id}",
+          any_args
+        )
+    end
+
+    it 'percent-encodes emoji' do
+      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, "\u{1F44D}", before_id, after_id, 27)
+      expect(Discordrb::API).to have_received(:request)
+        .with(
+          anything,
+          channel_id,
+          :get,
+          "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/%F0%9F%91%8D?limit=27&before=#{before_id}&after=#{after_id}",
+          any_args
+        )
+    end
+
+    it 'uses the maximum limit of 100 if nil is provided' do
+      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, "test", before_id, after_id, nil)
+      expect(Discordrb::API).to have_received(:request)
+        .with(
+          anything,
+          channel_id,
+          :get,
+          "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/test?limit=100&before=#{before_id}&after=#{after_id}",
+          any_args
+        )
+    end
+  end
+end

--- a/spec/api/channel_spec.rb
+++ b/spec/api/channel_spec.rb
@@ -3,24 +3,15 @@
 require 'discordrb'
 
 describe Discordrb::API::Channel do
-  let(:token) { double('token') }
-  let(:channel_id) { instance_double(String, 'channel_id') }
-
-  before do
-    allow(token).to receive(:to_s).and_return('bot_token')
-    allow(channel_id).to receive(:to_s).and_return('channel_id')
-  end
+  let(:token) { double('token', to_s: 'bot_token') }
+  let(:channel_id) { instance_double(String, 'channel_id', to_s: 'channel_id') }
 
   describe '.get_reactions' do
-    let(:message_id) { double('message_id') }
-    let(:before_id) { double('before_id') }
-    let(:after_id) { double('after_id') }
+    let(:message_id) { double('message_id', to_s: 'message_id') }
+    let(:before_id) { double('before_id', to_s: 'before_id') }
+    let(:after_id) { double('after_id', to_s: 'after_id') }
 
     before do
-      allow(message_id).to receive(:to_s).and_return('message_id')
-      allow(before_id).to receive(:to_s).and_return('before_id')
-      allow(after_id).to receive(:to_s).and_return('after_id')
-
       allow(Discordrb::API).to receive(:request)
         .with(anything, channel_id, :get, kind_of(String), any_args)
     end

--- a/spec/api/channel_spec.rb
+++ b/spec/api/channel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "discordrb"
+require 'discordrb'
 
 describe Discordrb::API::Channel do
   let(:token) { double('token') }
@@ -23,7 +23,7 @@ describe Discordrb::API::Channel do
 
       allow(Discordrb::API).to receive(:request)
         .with(anything, channel_id, :get, kind_of(String), any_args)
-    end    
+    end
 
     it 'sends requests' do
       Discordrb::API::Channel.get_reactions(token, channel_id, message_id, 'test', before_id, after_id, 27)
@@ -50,7 +50,7 @@ describe Discordrb::API::Channel do
     end
 
     it 'uses the maximum limit of 100 if nil is provided' do
-      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, "test", before_id, after_id, nil)
+      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, 'test', before_id, after_id, nil)
       expect(Discordrb::API).to have_received(:request)
         .with(
           anything,

--- a/spec/api/channel_spec.rb
+++ b/spec/api/channel_spec.rb
@@ -17,8 +17,7 @@ describe Discordrb::API::Channel do
     end
 
     it 'sends requests' do
-      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, 'test', before_id, after_id, 27)
-      expect(Discordrb::API).to have_received(:request)
+      expect(Discordrb::API).to receive(:request)
         .with(
           anything,
           channel_id,
@@ -26,11 +25,11 @@ describe Discordrb::API::Channel do
           "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/test?limit=27&before=#{before_id}&after=#{after_id}",
           any_args
         )
+      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, 'test', before_id, after_id, 27)
     end
 
     it 'percent-encodes emoji' do
-      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, "\u{1F44D}", before_id, after_id, 27)
-      expect(Discordrb::API).to have_received(:request)
+      expect(Discordrb::API).to receive(:request)
         .with(
           anything,
           channel_id,
@@ -38,11 +37,11 @@ describe Discordrb::API::Channel do
           "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/%F0%9F%91%8D?limit=27&before=#{before_id}&after=#{after_id}",
           any_args
         )
+      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, "\u{1F44D}", before_id, after_id, 27)
     end
 
     it 'uses the maximum limit of 100 if nil is provided' do
-      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, 'test', before_id, after_id, nil)
-      expect(Discordrb::API).to have_received(:request)
+      expect(Discordrb::API).to receive(:request)
         .with(
           anything,
           channel_id,
@@ -50,6 +49,7 @@ describe Discordrb::API::Channel do
           "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/test?limit=100&before=#{before_id}&after=#{after_id}",
           any_args
         )
+      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, 'test', before_id, after_id, nil)
     end
   end
 end

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -117,7 +117,14 @@ describe Discordrb::Message do
       expect(Discordrb::API::Channel).to receive(:get_reactions)
         .with(token, channel_id, any_args, 27)
         .and_return('[]')
-      message.reacted_with('👍', 27)
+      message.reacted_with('👍', limit: 27)
+    end
+
+    it 'defaults to a limit of 100' do
+      expect(Discordrb::API::Channel).to receive(:get_reactions)
+        .with(token, channel_id, any_args, 100)
+        .and_return('[]')
+      message.reacted_with('👍')
     end
 
     it 'converts Emoji to strings' do

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -140,6 +140,12 @@ describe Discordrb::Message do
         .with(any_args, '\u{1F44D}', nil, nil, 100)
     end
 
+    it 'fetches all users when limit is nil' do
+      expect(Discordrb::Paginator).to receive(:new).with(nil, :down)
+
+      message.reacted_with('\u{1F44D}', limit: nil)
+    end
+
     it 'converts Emoji to strings' do
       allow(emoji).to receive(:to_reaction).and_return('123')
 

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -109,6 +109,28 @@ describe Discordrb::Message do
     end
   end
 
+  describe '#reacted_with' do
+    let(:message) { described_class.new(message_data, bot) }
+    let(:emoji) { double('emoji') }
+
+    it 'calls the API method' do
+      expect(Discordrb::API::Channel).to receive(:get_reactions)
+        .with(token, channel_id, any_args, 27)
+        .and_return('[]')
+      message.reacted_with('👍', 27)
+    end
+
+    it 'converts Emoji to strings' do
+      allow(emoji).to receive(:to_reaction).and_return('123')
+
+      expect(Discordrb::API::Channel).to receive(:get_reactions)
+        .with(token, channel_id, anything, '123', any_args)
+        .and_return('[]')
+
+      message.reacted_with(emoji)
+    end
+  end
+
   describe '#reply!' do
     let(:message) { described_class.new(message_data, bot) }
     let(:content) { instance_double('String', 'content') }

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -127,17 +127,17 @@ describe Discordrb::Message do
     end
 
     it 'calls the API method' do
-      message.reacted_with('\u{1F44D}', limit: 27)
-
-      expect(Discordrb::API::Channel).to have_received(:get_reactions)
+      expect(Discordrb::API::Channel).to receive(:get_reactions)
         .with(any_args, '\u{1F44D}', nil, nil, 27)
+
+      message.reacted_with('\u{1F44D}', limit: 27)
     end
 
     it 'defaults to a limit of 100' do
-      message.reacted_with('\u{1F44D}')
-
-      expect(Discordrb::API::Channel).to have_received(:get_reactions)
+      expect(Discordrb::API::Channel).to receive(:get_reactions)
         .with(any_args, '\u{1F44D}', nil, nil, 100)
+
+      message.reacted_with('\u{1F44D}')
     end
 
     it 'fetches all users when limit is nil' do
@@ -149,10 +149,10 @@ describe Discordrb::Message do
     it 'converts Emoji to strings' do
       allow(emoji).to receive(:to_reaction).and_return('123')
 
-      message.reacted_with(emoji)
-
-      expect(Discordrb::API::Channel).to have_received(:get_reactions)
+      expect(Discordrb::API::Channel).to receive(:get_reactions)
         .with(any_args, '123', nil, nil, anything)
+
+      message.reacted_with(emoji)
     end
   end
 

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -114,7 +114,7 @@ describe Discordrb::Message do
     let(:emoji) { double('emoji') }
 
     fixture :user_data, %i[user]
-    
+
     before do
       # Return the appropriate number of users based on after_id
       allow(Discordrb::API::Channel).to receive(:get_reactions)


### PR DESCRIPTION
# Summary
Fixes #38.  
Discord tries to parse the `limit` parameter as an integer, if nothing is sent a HTTP 400 is returned. This sets a default to the maximum instead of the usual 25, to reduce the number of requests needed to get all users when `limit: nil` is passed.

---

## Added
Specs for `Message#reacted_with` and `API::Channel.get_reactions`

## Changed
* API::Channel.get_reactions: the query param `limit` defaults to 100 instead of the empty string when limit is nil.
