### PR TITLE
Stage channels

### DIFF
--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -210,6 +210,25 @@ module Discordrb::API::Server
     )
   end
 
+  # Updates a users voice state inside of a Stage channel
+  # The passed channel_id must point to a Stage channel.
+  # The passed user_id must be inside of the Stage channel.
+  # TODO: docs_link
+  def update_voice_state(token, server_id, channel_id, user_id, suppress)
+    Discordrb::API.request(
+      :guilds_sid_voicestate,
+      server_id,
+      :patch,
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/voice-states/#{user_id}",
+      {
+        channel_id: channel_id,
+        suppress: suppress
+      }.to_json,
+      Authorization: token,
+      content_type: :json
+    )
+  end
+
   # Get server roles
   # https://discord.com/developers/docs/resources/guild#get-guild-roles
   def roles(token, server_id)

--- a/lib/discordrb/api/user.rb
+++ b/lib/discordrb/api/user.rb
@@ -43,6 +43,25 @@ module Discordrb::API::User
     )
   end
 
+  # Modifies the current bot's voice state on a server in a Stage channel.
+  # The passed channel_id must be a Stage channel, and the bot must be inside of it.
+  # TODO: docs_link
+  def modify_own_voice_state(token, server_id, channel_id, suppress = nil, request_to_speak_timestamp = nil)
+    Discordrb::API.request(
+      :guilds_sid_voicestate,
+      server_id,
+      :patch,
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/voice-states/@me",
+      {
+        channel_id: channel_id,
+        suppress: suppress,
+        request_to_speak_timestamp: request_to_speak_timestamp
+      }.compact.to_json,
+      Authorization: token,
+      content_type: :json
+    )
+  end
+
   # Update user data
   # https://discord.com/developers/docs/resources/user#modify-current-user
   def update_profile(token, email, password, new_username, avatar, new_password = nil)

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -13,7 +13,8 @@ module Discordrb
       group: 3,
       category: 4,
       news: 5,
-      store: 6
+      store: 6,
+      stage: 13
     }.freeze
 
     # @return [String] this channel's name.
@@ -141,6 +142,11 @@ module Discordrb
     # @return [true, false] whether or not this channel is a store channel.
     def store?
       @type == 6
+    end
+
+    # @return [true, false] whether or not this channel is a stage channel.
+    def stage?
+      @type == 13
     end
 
     # @return [Channel, nil] the category channel, if this channel is in a category

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -665,6 +665,24 @@ module Discordrb
       API::Channel.start_typing(@bot.token, @id)
     end
 
+    # Suppresses a user in a Stage channel
+    # @param user_id [Integer] The user to suppress
+    def suppress_user(user_id)
+      raise 'Attempted to suppress a user in a non-server channel!' unless server
+      raise 'Attempted to suppress a user in a non-stage channel!' unless stage?
+
+      API::Server.update_voice_state(@bot.token, @server.id, @id, user_id, true)
+    end
+
+    # Unsuppresses a user in a Stage channel
+    # @param user_id [Integer] The user to unsuppress
+    def unsuppress_user(user_id)
+      raise 'Attempted to unsuppress a user in a non-server channel!' unless server
+      raise 'Attempted to unsuppress a user in a non-stage channel!' unless stage?
+
+      API::Server.update_voice_state(@bot.token, @server.id, @id, user_id, false)
+    end
+
     # Creates a Group channel
     # @param user_ids [Array<Integer>] Array of user IDs to add to the new group channel (Excluding
     #   the recipient of the PM channel).

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -43,6 +43,16 @@ module Discordrb
       voice_state_attribute(:self_deaf)
     end
 
+    # @return [true, false] whether this member is suppressed.
+    def suppress
+      voice_state_attribute(:suppress)
+    end
+
+    # @return [true, false] whether this member has requested to speak.
+    def requested_to_speak?
+      !voice_state_attribute(:request_to_speak_timestamp).nil?
+    end
+
     # @return [Channel] the voice channel this member is in.
     def voice_channel
       voice_state_attribute(:voice_channel)
@@ -52,6 +62,7 @@ module Discordrb
     alias_method :deafened?, :deaf
     alias_method :self_muted?, :self_mute
     alias_method :self_deafened?, :self_deaf
+    alias_method :suppressed?, :suppress
 
     include MemberAttributes
 

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -475,7 +475,9 @@ module Discordrb
           data['mute'],
           data['deaf'],
           data['self_mute'],
-          data['self_deaf']
+          data['self_deaf'],
+          data['suppress'],
+          data['request_to_speak_timestamp']
         )
       else
         # The user is not in a voice channel anymore, so delete its voice state

--- a/lib/discordrb/data/voice_state.rb
+++ b/lib/discordrb/data/voice_state.rb
@@ -19,6 +19,12 @@ module Discordrb
     # @return [true, false] whether this voice state's member has deafened themselves.
     attr_reader :self_deaf
 
+    # @return [true, false] whether this voice state's member is suppressed.
+    attr_reader :suppress
+
+    # @return [Timestamp] the time at which a user requested to speak in a stage channel.
+    attr_reader :request_to_speak_timestamp
+
     # @return [Channel] the voice channel this voice state's member is in.
     attr_reader :voice_channel
 
@@ -30,12 +36,14 @@ module Discordrb
     # Update this voice state with new data from Discord
     # @note For internal use only.
     # @!visibility private
-    def update(channel, mute, deaf, self_mute, self_deaf)
+    def update(channel, mute, deaf, self_mute, self_deaf, suppress, request_to_speak_timestamp)
       @voice_channel = channel
       @mute = mute
       @deaf = deaf
       @self_mute = self_mute
       @self_deaf = self_deaf
+      @suppress = suppress
+      @request_to_speak_timestamp = request_to_speak_timestamp
     end
   end
 end

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -36,7 +36,8 @@ module Discordrb
       27 => :manage_nicknames,     # 134217728
       28 => :manage_roles,         # 268435456, also Manage Permissions
       29 => :manage_webhooks,      # 536870912
-      30 => :manage_emojis         # 1073741824
+      30 => :manage_emojis,        # 1073741824
+      32 => :request_to_speak      # 4294967296
     }.freeze
 
     FLAGS.each do |position, flag|

--- a/lib/discordrb/voice/voice_bot.rb
+++ b/lib/discordrb/voice/voice_bot.rb
@@ -140,6 +140,34 @@ module Discordrb::Voice
       @paused = false
     end
 
+    # Requests to speak inside of the current Stage channel
+    def request_to_speak
+      raise 'Cannot request to speak in a non stage channel' unless @channel.stage?
+
+
+      Discordrb::API::User.modify_own_voice_state(
+        @bot.token,
+        @channel.server.id,
+        @channel.id,
+        nil,
+        Time.now.iso8601
+      )
+    end
+
+    # Sets whether or not the bot is suppressed in the current Stage channel.
+    # @param value [true, false] whether or not the bot is suppressed
+    def suppressed=(value)
+      raise 'Cannot change suppressed state in a non stage channel' unless @channel.stage?
+
+      Discordrb::API::User.modify_own_voice_state(
+        @bot.token,
+        @channel.server.id,
+        @channel.id,
+        value,
+        nil
+      )
+    end
+
     # Skips to a later time in the song. It's impossible to go back without replaying the song.
     # @param secs [Float] How many seconds to skip forwards. Skipping will always be done in discrete intervals of
     #   0.05 seconds, so if the given amount is smaller than that, it will be rounded up.


### PR DESCRIPTION
# Summary
Add new stage channel properties and endpoints.

## Added
`API::User#modify_own_voice_state`
`API::Server#update_voice_state`
`VoiceBot#suppressed=`
`VoiceBot#request_to_speak`
`Channel#suppress_user`
`Channel#unsuppress_user`
`Member#suppressed?`
`Member#requested_to_speak?`
`:request_to_speak` Permission
`stage (13)` channel type and `Channel#stage?`

2 new properties to `VoiceState`
`:suppress`
`:request_to_speak_timestamp`

## Changed
`Server#update_voice_state` to include new properties.

## Deprecated

## Removed

## Fixed
