### PR TITLE
Use discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Gem](https://img.shields.io/gem/dt/discordrb.svg)](https://rubygems.org/gems/discordrb)
 [![CircleCI](https://circleci.com/gh/shardlab/discordrb.svg?style=svg)](https://circleci.com/gh/shardlab/discordrb)
 [![Inline docs](http://inch-ci.org/github/shardlab/discordrb.svg?branch=main)](https://drb.shardlab.dev/v3.4.0/)
-[![Join Discord](https://img.shields.io/badge/discord-join-7289DA.svg)](https://discord.gg/cyK3Hjm)
+[![Discord](https://img.shields.io/discord/81384788765712384?color=7289da&label=discord)](https://discord.gg/cyK3Hjm)
 # discordrb
 
 An implementation of the [Discord](https://discord.com/) API using Ruby.


### PR DESCRIPTION
# Summary
I made discord badge of readme.md use `(count) online` badge.
![Join Discord](https://img.shields.io/badge/discord-join-7289DA.svg) is now ![Discord](https://img.shields.io/discord/81384788765712384?color=7289da&label=discord)
<!---
  Describe the general goal of your pull request here:

  - Include details about any issues you encountered that inspired
  the pull request, such as bugs or missing features.

  - If adding or changing features, include a small example that showcases
  the new behavior.

  - Reference any related issues or pull requests.

  Stuck or need help? Join the Discord! https://discord.gg/cyK3Hjm
--->

---

<!---
  List each individual change you made to the library here in the appropriate
  section in short, bulleted sentences.

  This will aid in reviewing your pull request, and for adding it to the
  changelog later.

  You may remove sections that have no items if you want.
--->

## Added

## Changed
Make readme.md use discord badge
## Deprecated

## Removed

## Fixed
