### PR TITLE
Update documentation for Message#reply!

### DIFF
--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -158,7 +158,7 @@ module Discordrb
       @channel.send_message(content)
     end
 
-    # Sends a message to this channel.
+    # Responds to this message as an inline reply.
     # @param content [String] The content to send. Should not be longer than 2000 characters or it will result in an error.
     # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
     # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.


### PR DESCRIPTION
# Summary

<!---
  Describe the general goal of your pull request here:

  - Include details about any issues you encountered that inspired
  the pull request, such as bugs or missing features.

  - If adding or changing features, include a small example that showcases
  the new behavior.

  - Reference any related issues or pull requests.

  Stuck or need help? Join the Discord! https://discord.gg/cyK3Hjm
--->

#3 added support for inline replies, which is fantastic, but it seems the documentation for `Message#reply!` was accidentally copied over from `Channel#send_message`. This patch updates that documentation.

I debated putting _inline reply_ in quotation marks since as far as I can find it's not an official term in [the API](https://discord.com/developers/docs/resources/channel#message-object) (an inline reply is simply referred to as "a reply"), but decided it only made the sentence more confusing.

---

## Fixed

Incorrect description for `Message#reply!`
