### PR TITLE
Check if we have the SERVER_MEMBERS intent before fetching server members

### DIFF
--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -143,10 +143,15 @@ module Discordrb
     end
 
     # @return [Array<Member>] an array of all the members on this server.
+    # @raise [RuntimeError] if the bot was not started with the :server_member intent
     def members
       return @members.values if @chunked
 
       @bot.debug("Members for server #{@id} not chunked yet - initiating")
+
+      # If the SERVER_MEMBERS intent flag isn't set, the gateway won't respond when we ask for members.
+      raise 'The :server_members intent is required to get server members' if @bot.gateway.intents & INTENTS[:server_members] == 0
+
       @bot.request_chunks(@id)
       sleep 0.05 until @chunked
       @members.values

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -150,7 +150,7 @@ module Discordrb
       @bot.debug("Members for server #{@id} not chunked yet - initiating")
 
       # If the SERVER_MEMBERS intent flag isn't set, the gateway won't respond when we ask for members.
-      raise 'The :server_members intent is required to get server members' if @bot.gateway.intents & INTENTS[:server_members] == 0
+      raise 'The :server_members intent is required to get server members' if (@bot.gateway.intents & INTENTS[:server_members]).zero?
 
       @bot.request_chunks(@id)
       sleep 0.05 until @chunked

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -143,6 +143,9 @@ module Discordrb
     # @return [true, false] whether or not this gateway should check for heartbeat ACKs.
     attr_accessor :check_heartbeat_acks
 
+    # @return [Integer] the intent parameter sent to the gateway server.
+    attr_accessor :intents
+
     def initialize(bot, token, shard_key = nil, compress_mode = :stream, intents = ALL_INTENTS)
       @token = token
       @bot = bot

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -144,7 +144,7 @@ module Discordrb
     attr_accessor :check_heartbeat_acks
 
     # @return [Integer] the intent parameter sent to the gateway server.
-    attr_accessor :intents
+    attr_reader :intents
 
     def initialize(bot, token, shard_key = nil, compress_mode = :stream, intents = ALL_INTENTS)
       @token = token


### PR DESCRIPTION
# Summary
Fixes #51.

The gateway doesn't respond if we try to ask for server members without first declaring the intent. Originally, `Server#members` would just wait for a response that isn't coming, causing it to never return. This change checks the intents we sent with the gateway first before requesting members.

---

## Added
- Exposed `Gateway#intents`, the final calculated intents parameter sent to the gateway
- `Server#members` now raises a RuntimeError if the gateway was not initialized with the SERVER_MEMBERS intent