### PR TITLE
Allow Bot#initialize to request only unprivileged intents

### DIFF
--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -42,6 +42,9 @@ module Discordrb
   # @see https://discord.com/developers/docs/topics/gateway#privileged-intents
   UNPRIVILEGED_INTENTS = ALL_INTENTS & ~(INTENTS[:server_members] | INTENTS[:server_presences])
 
+  # No intents
+  NO_INTENTS = 0
+
   # Compares two objects based on IDs - either the objects' IDs are equal, or one object is equal to the other's ID.
   def self.id_compare(one_id, other)
     other.respond_to?(:resolve_id) ? (one_id.resolve_id == other.resolve_id) : (one_id == other)

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -35,8 +35,12 @@ module Discordrb
     direct_message_typing: 1 << 14
   }.freeze
 
-  # @return [Integer] All available intents
+  # All available intents
   ALL_INTENTS = INTENTS.values.reduce(&:|)
+
+  # All unprivileged intents
+  # @see https://discord.com/developers/docs/topics/gateway#privileged-intents
+  UNPRIVILEGED_INTENTS = ALL_INTENTS & ~(INTENTS[:server_members] | INTENTS[:server_presences])
 
   # Compares two objects based on IDs - either the objects' IDs are equal, or one object is equal to the other's ID.
   def self.id_compare(one_id, other)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -105,8 +105,8 @@ module Discordrb
     #   to Discord's gateway. `:none` will request that no payloads are received compressed (not recommended for
     #   production bots). `:large` will request that large payloads are received compressed. `:stream` will request
     #   that all data be received in a continuous compressed stream.
-    # @param intents [:all, :unprivileged, Array<Symbol>, nil] Gateway intents that this bot requires. `:all` will
-    #   request all intents. `:unprivileged` will request only intents that are not defined as "Privileged". `nil`
+    # @param intents [:all, :unprivileged, Array<Symbol>, :none] Gateway intents that this bot requires. `:all` will
+    #   request all intents. `:unprivileged` will request only intents that are not defined as "Privileged". `:none`
     #   will request no intents. An array of symbols will request only those intents specified.
     # @see Discordrb::INTENTS
     def initialize(
@@ -140,7 +140,7 @@ module Discordrb
                    ALL_INTENTS
                  when :unprivileged
                    UNPRIVILEGED_INTENTS
-                 when nil
+                 when :none
                    NO_INTENTS
                  else
                    calculate_intents(intents)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -105,7 +105,10 @@ module Discordrb
     #   to Discord's gateway. `:none` will request that no payloads are received compressed (not recommended for
     #   production bots). `:large` will request that large payloads are received compressed. `:stream` will request
     #   that all data be received in a continuous compressed stream.
-    # @param intents [:all, Array<Symbol>, nil] Intents that this bot requires.
+    # @param intents [:all, :unprivileged, Array<Symbol>, nil] Gateway intents that this bot requires. `:all` will
+    #   request all intents. `:unprivileged` will request only intents that are not defined as "Privileged". `nil`
+    #   will request no intents. An array of symbols will request only those intents specified.
+    # @see Discordrb::INTENTS
     def initialize(
       log_mode: :normal,
       token: nil, client_id: nil,
@@ -132,7 +135,14 @@ module Discordrb
 
       raise 'Token string is empty or nil' if token.nil? || token.empty?
 
-      @intents = intents == :all ? INTENTS.values.reduce(&:|) : calculate_intents(intents)
+      @intents = case intents
+                 when :all
+                   ALL_INTENTS
+                 when :unprivileged
+                   UNPRIVILEGED_INTENTS
+                 else
+                   calculate_intents(intents)
+                 end
 
       @token = process_token(@type, token)
       @gateway = Gateway.new(self, @token, @shard_key, @compress_mode, @intents)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -140,6 +140,8 @@ module Discordrb
                    ALL_INTENTS
                  when :unprivileged
                    UNPRIVILEGED_INTENTS
+                 when nil
+                   NO_INTENTS
                  else
                    calculate_intents(intents)
                  end

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -87,7 +87,7 @@ module Discordrb::Commands
         redact_token: attributes.key?(:redact_token) ? attributes[:redact_token] : true,
         ignore_bots: attributes[:ignore_bots],
         compress_mode: attributes[:compress_mode],
-        intents: attributes[:intents]
+        intents: attributes[:intents] || :all
       )
 
       @prefix = attributes[:prefix]

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -87,7 +87,7 @@ module Discordrb::Commands
         redact_token: attributes.key?(:redact_token) ? attributes[:redact_token] : true,
         ignore_bots: attributes[:ignore_bots],
         compress_mode: attributes[:compress_mode],
-        intents: attributes[:intents] || :all
+        intents: attributes[:intents]
       )
 
       @prefix = attributes[:prefix]


### PR DESCRIPTION
# Summary

With v8, intents are enforced when identifying. By default the library will request all intents, including privileged ones, even if the bot does not use them. This PR makes it easier for the authors of such bots to only request unprivileged intents as opposed to all intents.

It also allows you to specify _no_ intents. Previously the documentation suggested that you could use `nil` for this, but this would have caused an error.

---

<!---
  List each individual change you made to the library here in the appropriate
  section in short, bulleted sentences.

  This will aid in reviewing your pull request, and for adding it to the
  changelog later.

  You may remove sections that have no items if you want.
--->

## Added
`Discordrb::UNPRIVILEGED_INTENTS`
`Discordrb::NO_INTENTS`

## Changed
`Bot#initialize`: `intents` can now be equal to `:unprivileged`
`Bot#initialize`: `intents` can now be equal to `:none`
