### PR TITLE
fixup: Add server arg when creating member in Message#initialize

### DIFF
--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -104,7 +104,7 @@ module Discordrb
                       Discordrb::LOGGER.debug("Member with ID #{data['author']['id']} not cached (possibly left the server).")
                       member = if data['member']
                                  member_data = data['author'].merge(data['member'])
-                                 Member.new(member_data, bot)
+                                 Member.new(member_data, @server, bot)
                                else
                                  @bot.ensure_user(data['author'])
                                end


### PR DESCRIPTION
# Summary

Use the correct arguments when creating a member from message data.
Fixes #56.

## Fixed
`Discordrb::Message#initialize` - Add server argument to initializer call.