### PR TITLE
Allow CommandBot to take nil intents

### DIFF
--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -87,7 +87,7 @@ module Discordrb::Commands
         redact_token: attributes.key?(:redact_token) ? attributes[:redact_token] : true,
         ignore_bots: attributes[:ignore_bots],
         compress_mode: attributes[:compress_mode],
-        intents: attributes[:intents] || :all
+        intents: attributes[:intents]
       )
 
       @prefix = attributes[:prefix]


### PR DESCRIPTION
# Summary

`Bot#initialize` is allowed to take `nil` for its `intents` keyword argument. However, `CommandBot` breaks this by replacing `nil` with `:all`.

---

## Fixed
`CommandBot#initialize` can now take `intents: nil` like its superclass