### PR TITLE
bugfix: Do not parse 429s as a code error

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -113,7 +113,7 @@ module Discordrb::API
       rescue RestClient::Exception => e
         response = e.response
 
-        if response.body
+        if response.body && !e.is_a?(RestClient::TooManyRequests)
           data = JSON.parse(response.body)
           err_klass = Discordrb::Errors.error_class_for(data['code'] || 0)
           e = err_klass.new(data['message'], data['errors'])


### PR DESCRIPTION
# Summary

429s were being consumed as coded Discord errors and not being properly re-raised.

---

## Fixed
`Discordrb::API.request` - Do not parse 429s as code errors.