### PR TITLE
Fixup: Paginate reactions

### DIFF
--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -291,7 +291,7 @@ module Discordrb
       reaction = reaction.to_reaction if reaction.respond_to?(:to_reaction)
       paginator = Paginator.new(limit, :down) do |last_page|
         after_id = last_page.last.id if last_page
-        last_page = JSON.parse(API::Channel.get_reactions(@bot.token, @channel.id, @id, reaction, nil, after_id, limit))
+        last_page = JSON.parse(API::Channel.get_reactions(@bot.token, @channel.id, @id, reaction, nil, after_id))
         last_page.map { |d| User.new(d, @bot) }
       end
       paginator.to_a

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -128,16 +128,9 @@ describe Discordrb::Message do
 
     it 'calls the API method' do
       expect(Discordrb::API::Channel).to receive(:get_reactions)
-        .with(any_args, '\u{1F44D}', nil, nil, 27)
+        .with(any_args, '\u{1F44D}', nil, nil)
 
       message.reacted_with('\u{1F44D}', limit: 27)
-    end
-
-    it 'defaults to a limit of 100' do
-      expect(Discordrb::API::Channel).to receive(:get_reactions)
-        .with(any_args, '\u{1F44D}', nil, nil, 100)
-
-      message.reacted_with('\u{1F44D}')
     end
 
     it 'fetches all users when limit is nil' do
@@ -150,7 +143,7 @@ describe Discordrb::Message do
       allow(emoji).to receive(:to_reaction).and_return('123')
 
       expect(Discordrb::API::Channel).to receive(:get_reactions)
-        .with(any_args, '123', nil, nil, anything)
+        .with(any_args, '123', nil, nil)
 
       message.reacted_with(emoji)
     end


### PR DESCRIPTION
Fixes sending a limit over 100 as this is an error for the API requests
The Paginator object handles limits.
The API method handles limit defaults.

# Summary

When you send Message#reacted_with with a limit over 100, it will pass this to the API method and fail.

---

## Fixed
Message#reacted_with now accepts limits over 100
