### PR TITLE
Fix Member role_ids

### DIFF
--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -65,7 +65,7 @@ module Discordrb
       @server = server
       @server_id = server&.id || data['guild_id'].to_i
 
-      @role_ids = data['roles'].map(&:to_i)
+      @role_ids = data['roles']&.map(&:to_i) || []
 
       @nick = data['nick']
       @joined_at = data['joined_at'] ? Time.parse(data['joined_at']) : nil


### PR DESCRIPTION
# Summary

Resolves an issue where Presence events provide member objects without the `roles` key.

```
[IN : websocket @ 2021-06-09 21:33:21.774] {"t"=>"PRESENCE_UPDATE", "s"=>9, "op"=>0, "d"=>{"user"=>{"username"=>"REDACTED", "id"=>"123", "discriminator"=>"1234", "avatar"=>"aaa"}, "status"=>"online", "guild_id"=>"2345", "client_status"=>{"mobile"=>"online"}, "activities"=>[]}}
[ERROR : websocket @ 2021-06-09 21:33:21.774] Gateway message error!
[ERROR : websocket @ 2021-06-09 21:33:21.775] Exception: #<NoMethodError: undefined method `map' for nil:NilClass>
[ERROR : websocket @ 2021-06-09 21:33:21.776] .../lib/discordrb/data/member.rb:69:in `initialize'
```

## Fixed

Uses safe navigation to map the role IDs, defaulting to an empty array.