### PR TITLE
Update permissions and add Permissions#defined_permissions

### DIFF
--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -36,7 +36,13 @@ module Discordrb
       27 => :manage_nicknames,     # 134217728
       28 => :manage_roles,         # 268435456, also Manage Permissions
       29 => :manage_webhooks,      # 536870912
-      30 => :manage_emojis         # 1073741824
+      30 => :manage_emojis,        # 1073741824, also Manage Stickers
+      31 => :use_slash_commands,   # 2147483648
+      32 => :request_to_speak,     # 4294967296
+      33 => :manage_threads,       # 8589934592
+      34 => :use_public_threads,   # 17179869184
+      35 => :use_private_threads,  # 34359738368
+      36 => :use_external_stickers # 68719476736
     }.freeze
 
     FLAGS.each do |position, flag|
@@ -113,6 +119,15 @@ module Discordrb
               end
 
       init_vars
+    end
+
+    # Return an array of permission flag symbols for this class's permissions
+    # @example Get the permissions for the bits "9"
+    #   permissions = Permissions.new(9)
+    #   permissions.defined_permissions #=> [:create_instant_invite, :administrator]
+    # @return [Array<Symbol>] the permissions
+    def defined_permissions
+      FLAGS.collect { |value, name| (@bits & (1 << value)).positive? ? name : nil }.compact
     end
 
     # Comparison based on permission bits

--- a/spec/permissions_spec.rb
+++ b/spec/permissions_spec.rb
@@ -72,6 +72,13 @@ describe Discordrb::Permissions do
         subject
       end
     end
+
+    describe '#defined_permissions' do
+      it 'returns the defined permissions' do
+        instance = Discordrb::Permissions.new 3
+        expect(instance.defined_permissions).to eq %i[foo bar]
+      end
+    end
   end
 end
 


### PR DESCRIPTION
# Summary

This PR gets us up to date with the [new permissions](https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags).

It also adds a helper method to get all the permissions a Permission object has.

```ruby
Discordrb::Permissions.new(9).defined_permissions
 => [:create_instant_invite, :administrator] 
Discordrb::Permissions.new(2425372770).defined_permissions
 => [:kick_members, :manage_server, :add_reactions, :embed_links, :connect, :deafen_members, :manage_roles, :use_slash_commands]
```

---

## Added
`Permissions#defined_permissions` to get an array of symbols of the permissions.

## Changed
- Added 31-36 permission fields, these being:
```ruby
      31 => :use_slash_commands,   # 2147483648
      32 => :request_to_speak,     # 4294967296
      33 => :manage_threads,       # 8589934592
      34 => :use_public_threads,   # 17179869184
      35 => :use_private_threads,  # 34359738368
      36 => :use_external_stickers # 68719476736
```