### PR TITLE
Require message_id for Channel#load_message

### DIFF
--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -554,6 +554,8 @@ module Discordrb
     # @param message_id [Integer] The ID of the message to retrieve.
     # @return [Message, nil] the retrieved message, or `nil` if it couldn't be found.
     def load_message(message_id)
+      raise ArgumentError, 'message_id cannot be nil' if message_id.nil?
+
       response = API::Channel.message(@bot.token, @id, message_id)
       Message.new(JSON.parse(response), @bot)
     rescue RestClient::ResourceNotFound


### PR DESCRIPTION

# Summary

Ensures the `message_id` parameter of `Channel#load_message` is not nil since we cannot load the message without it. Calling the method with a nil value will now return a more helpful `ArgumentError` instead of a `Discordrb::Errors::UnknownError`.

## Added

Added a check to `Channel#load_message` to ensure the `message_id` parameter is not nil.

### Before
```rb
bot.channel(12345).message(nil)

[ERROR : main @ 2021-08-13 17:40:53.860] 404: Not Found
Discordrb::Errors::UnknownError: 404: Not Found
```

### After
```rb
bot.channel(12345).message(nil)

ArgumentError: message_id cannot be nil
```