### PR TITLE
Bugfix: handle components when editing message

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -116,13 +116,13 @@ module Discordrb::API::Channel
 
   # Edit a message
   # https://discord.com/developers/docs/resources/channel#edit-message
-  def edit_message(token, channel_id, message_id, message, mentions = [], embed = nil)
+  def edit_message(token, channel_id, message_id, message, mentions = [], embed = nil, components = nil)
     Discordrb::API.request(
       :channels_cid_messages_mid,
       channel_id,
       :patch,
       "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}",
-      { content: message, mentions: mentions, embed: embed }.to_json,
+      { content: message, mentions: mentions, embed: embed, components: components }.to_json,
       Authorization: token,
       content_type: :json
     )


### PR DESCRIPTION
# Summary

`API::Channel.edit_message` was not set up to receive components from e.g. `Message#edit`. This PR adds that missing parameter so message edits function.

Fixes #72.

---

## Fixed

- missing components parameter in `edit_message`