### PR TITLE
Fix typo in slash commands

### DIFF
--- a/examples/slash_commands.rb
+++ b/examples/slash_commands.rb
@@ -5,7 +5,7 @@ require 'discordrb'
 bot = Discordrb::Bot.new(token: ENV['SLASH_COMMAND_BOT_TOKEN'], intents: [:server_messages])
 
 # We need to register our application comomands separately from the handlers with a special DSL.
-# This example uses server specifc commands so that they appear immediately for testing,
+# This example uses server specific commands so that they appear immediately for testing,
 # but you can omit the server_id as well to register a global command that can take up to an hour
 # to appear.
 #


### PR DESCRIPTION
I thought I already made a PR for this lol

# Summary
It's just a typo fix, thats all this is.
I only noticed this using this example file to get an idea of how this api works
<!---
  Describe the general goal of your pull request here:

  - Include details about any issues you encountered that inspired
  the pull request, such as bugs or missing features.

  - If adding or changing features, include a small example that showcases
  the new behavior.

  - Reference any related issues or pull requests.

  Stuck or need help? Join the Discord! https://discord.gg/cyK3Hjm
--->

---

<!---
  List each individual change you made to the library here in the appropriate
  section in short, bulleted sentences.

  This will aid in reviewing your pull request, and for adding it to the
  changelog later.

  You may remove sections that have no items if you want.
--->

## Added
+ Singular letter into a comment
## Changed
Slash_Commands.rb
## Deprecated

## Removed

## Fixed
A singular typo :P