### PR TITLE
Issue #37 resolution: New Reaction Workflows

### DIFF
--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -309,10 +309,10 @@ module Discordrb
     # @param limit [Integer] the limit of how many users to retrieve per distinct reaction emoji. `nil` will return all users
     # @example Get all the users that reacted to a message for a giveaway.
     #   giveaway_participants = message.all_reaction_users
-    # @return Hash{String => [Array<User>]} a hash with key=reaction.to_s, value=[Array<User>]
+    # @return {String => [Array<User>]} a hash with key=reaction.to_s, value=[Array<User>]
     def all_reaction_users(limit: 100)
-      all_reactions = @reactions.map { |r| r = Hash["#{r.to_s}" => self.reacted_with(r, limit:limit)]}
-      return all_reactions.reduce(Hash.new, :merge)
+      all_reactions = @reactions.map { |r| { r.to_s => reacted_with(r, limit: limit) } }
+      all_reactions.reduce({}, :merge)
     end
 
     # Deletes a reaction made by a user on this message.

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -309,7 +309,8 @@ module Discordrb
     # @param limit [Integer] the limit of how many users to retrieve per distinct reaction emoji. `nil` will return all users
     # @example Get all the users that reacted to a message for a giveaway.
     #   giveaway_participants = message.all_reaction_users
-    # @return {String => [Array<User>]} a hash with key=reaction.to_s, value=[Array<User>]
+    # @return [Hash<String => Array<User>>] A hash mapping the string representation of a
+    #   reaction to an array of users.
     def all_reaction_users(limit: 100)
       all_reactions = @reactions.map { |r| { r.to_s => reacted_with(r, limit: limit) } }
       all_reactions.reduce({}, :merge)

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -112,6 +112,7 @@ describe Discordrb::Message do
   describe '#reacted_with' do
     let(:message) { described_class.new(message_data, bot) }
     let(:emoji) { double('emoji') }
+    let(:reaction) { double('reaction') }
 
     fixture :user_data, %i[user]
 
@@ -154,8 +155,26 @@ describe Discordrb::Message do
 
       message.reacted_with(emoji)
     end
+
+    it 'converts Reaction to strings' do
+      allow(reaction).to receive(:to_s).and_return('123')
+
+      expect(Discordrb::API::Channel).to receive(:get_reactions)
+        .with(any_args, '123', nil, nil, anything)
+
+      message.reacted_with(reaction)
+    end
   end
 
+  describe '#all_reaction_users' do
+
+    fixture :user_data, %i[user]
+    # TODO write proper tests
+    it 'returns a filled hash' do
+    end
+
+  end
+  
   describe '#reply!' do
     let(:message) { described_class.new(message_data, bot) }
     let(:content) { instance_double('String', 'content') }

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -167,7 +167,6 @@ describe Discordrb::Message do
   end
 
   describe '#all_reaction_users' do
-
     let(:message) { described_class.new(message_data, bot) }
     let(:reaction1) { double('reaction') }
     let(:reaction2) { double('reaction') }
@@ -179,23 +178,22 @@ describe Discordrb::Message do
       message.instance_variable_set(:@reactions, [reaction1, reaction2])
       allow(reaction1).to receive(:to_s).and_return('123')
       allow(reaction2).to receive(:to_s).and_return('456')
-      
+
       allow(message).to receive(:reacted_with)
-        .with(reaction1, limit:100)
-        .and_return([user1,user2])
-      
+        .with(reaction1, limit: 100)
+        .and_return([user1, user2])
+
       allow(message).to receive(:reacted_with)
-        .with(reaction2, limit:100)
-        .and_return([user1,user3])
+        .with(reaction2, limit: 100)
+        .and_return([user1, user3])
     end
 
     it 'returns a filled hash' do
-      reactions_hash = message.all_reaction_users()
-      expect(reactions_hash).to eq({'123' => [user1,user2], '456' => [user1,user3]})
+      reactions_hash = message.all_reaction_users
+      expect(reactions_hash).to eq({ '123' => [user1, user2], '456' => [user1, user3] })
     end
-
   end
-  
+
   describe '#reply!' do
     let(:message) { described_class.new(message_data, bot) }
     let(:content) { instance_double('String', 'content') }

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -168,9 +168,30 @@ describe Discordrb::Message do
 
   describe '#all_reaction_users' do
 
-    fixture :user_data, %i[user]
-    # TODO write proper tests
+    let(:message) { described_class.new(message_data, bot) }
+    let(:reaction1) { double('reaction') }
+    let(:reaction2) { double('reaction') }
+    let(:user1) { double('user') }
+    let(:user2) { double('user') }
+    let(:user3) { double('user') }
+
+    before do
+      message.instance_variable_set(:@reactions, [reaction1, reaction2])
+      allow(reaction1).to receive(:to_s).and_return('123')
+      allow(reaction2).to receive(:to_s).and_return('456')
+      
+      allow(message).to receive(:reacted_with)
+        .with(reaction1, limit:100)
+        .and_return([user1,user2])
+      
+      allow(message).to receive(:reacted_with)
+        .with(reaction2, limit:100)
+        .and_return([user1,user3])
+    end
+
     it 'returns a filled hash' do
+      reactions_hash = message.all_reaction_users()
+      expect(reactions_hash).to eq({'123' => [user1,user2], '456' => [user1,user3]})
     end
 
   end


### PR DESCRIPTION
# Summary

Making my discord bot obtain a list of users who reacted to a message was a bit unintuitive at first. Then I noticed the open issue #37 related to adding new functionality to reactions and decided to tackle this issue so that my bots and others like it can take advantage of the new workflows. 

#  Example Workflows:

Lets say you're hosting a giveaway and want people to enter for different prize pools 🟥 and 🟢 based on their reaction:
`giveaway_message.all_reaction_users`
`=> { '🟥' => [<User bob>, <User jack>], '🟢' => [<User bob>, <User jane>] }`

Additionally, it is no longer required to resolve a reaction to a string to use it with `Message#reacted_with`:
`giveaway_message.reacted_with(<Reaction 🟥>, limit:100)`
`=> [<User bob>, <User jack>]`

Resolves #37 

---

## Added

- Implemented `Message#all_reaction_users` which returns a hash of reactions and users who used it
- Added rspec tests for additions and changed features

## Changed

- added to_s coercion for reaction argument in `Message#reacted_with`
