### PR TITLE
Fix Interaction#button

### DIFF
--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -47,7 +47,7 @@ module Discordrb
     # @see TYPES
     attr_reader :type
 
-    # @return Hash The interaction data.
+    # @return [Hash] The interaction data.
     attr_reader :data
 
     # @!visibility private

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -240,9 +240,13 @@ module Discordrb
 
     # @return [Hash, nil] Returns the button that triggered this interaction if applicable, otherwise nil
     def button
-      return unless @type == TYPES[:button]
+      return unless @type == TYPES[:component]
 
-      Components::Button.new(@data, @bot)
+      @message['components'].each do |row|
+        Components::ActionRow.new(row, @bot).buttons.each do |button|
+          return button if button.custom_id == @data['custom_id']
+        end
+      end
     end
   end
 

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -47,7 +47,7 @@ module Discordrb
     # @see TYPES
     attr_reader :type
 
-    # @return [String] The interaction data.
+    # @return Hash The interaction data.
     attr_reader :data
 
     # @!visibility private


### PR DESCRIPTION
# Summary

Fixes #77

## Fixed

- Fixed the type check to look for the component interaction type
- Returning a button constructed within an `ActionRow` instead of constructing it from the top-level data. This is necessary because the top-level data does not contain button-specific fields like label and style.
- Corrected the documented type of `Interaction#data`