### PR TITLE
fix(Webhooks): Convert allowed_mentions to hash before execute

### DIFF
--- a/lib/discordrb/webhooks/builder.rb
+++ b/lib/discordrb/webhooks/builder.rb
@@ -83,7 +83,7 @@ module Discordrb::Webhooks
         avatar_url: @avatar_url,
         tts: @tts,
         embeds: @embeds.map(&:to_hash),
-        allowed_mentions: @allowed_mentions
+        allowed_mentions: @allowed_mentions&.to_hash
       }
     end
 
@@ -95,7 +95,7 @@ module Discordrb::Webhooks
         avatar_url: @avatar_url,
         tts: @tts,
         file: @file,
-        allowed_mentions: @allowed_mentions
+        allowed_mentions: @allowed_mentions&.to_hash
       }
     end
   end


### PR DESCRIPTION
# Summary

Fixup bad logic that caused 400s when using an allowed mentions builder in webhooks.

## Fixed
`Webhooks::Builder#to_json_hash` - Call `to_hash` on allowed mentions
`Webhooks::Builder#to_multipart_hash` - Call `to_hash` on allowed mentions

Closes #81