### PR TITLE
fix: Correct reacted_with spec and prevent extra API call.

### DIFF
--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -298,8 +298,8 @@ module Discordrb
       reaction = reaction.to_reaction if reaction.respond_to?(:to_reaction)
       reaction = reaction.to_s if reaction.respond_to?(:to_s)
 
-      get_reactions = proc do |limit, after_id = nil|
-        resp = API::Channel.get_reactions(@bot.token, @channel.id, @id, reaction, nil, after_id, limit)
+      get_reactions = proc do |fetch_limit, after_id = nil|
+        resp = API::Channel.get_reactions(@bot.token, @channel.id, @id, reaction, nil, after_id, fetch_limit)
         return JSON.parse(resp).map { |d| User.new(d, @bot) }
       end
 

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -297,11 +297,23 @@ module Discordrb
     def reacted_with(reaction, limit: 100)
       reaction = reaction.to_reaction if reaction.respond_to?(:to_reaction)
       reaction = reaction.to_s if reaction.respond_to?(:to_s)
-      paginator = Paginator.new(limit, :down) do |last_page|
-        after_id = last_page.last.id if last_page
-        last_page = JSON.parse(API::Channel.get_reactions(@bot.token, @channel.id, @id, reaction, nil, after_id))
-        last_page.map { |d| User.new(d, @bot) }
+
+      get_reactions = proc do |limit, after_id = nil|
+        resp = API::Channel.get_reactions(@bot.token, @channel.id, @id, reaction, nil, after_id, limit)
+        return JSON.parse(resp).map { |d| User.new(d, @bot) }
       end
+
+      # Can be done without pagination
+      return get_reactions.call(limit) if limit && limit <= 100
+
+      paginator = Paginator.new(limit, :down) do |last_page|
+        if last_page && last_page.count < 100
+          []
+        else
+          get_reactions.call(100, last_page&.last&.id)
+        end
+      end
+
       paginator.to_a
     end
 

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -129,7 +129,7 @@ describe Discordrb::Message do
 
     it 'calls the API method' do
       expect(Discordrb::API::Channel).to receive(:get_reactions)
-        .with(any_args, '\u{1F44D}', nil, nil)
+        .with(any_args, '\u{1F44D}', nil, nil, 27)
 
       message.reacted_with('\u{1F44D}', limit: 27)
     end
@@ -144,7 +144,7 @@ describe Discordrb::Message do
       allow(emoji).to receive(:to_reaction).and_return('123')
 
       expect(Discordrb::API::Channel).to receive(:get_reactions)
-        .with(any_args, '123', nil, nil)
+        .with(any_args, '123', nil, nil, anything)
 
       message.reacted_with(emoji)
     end


### PR DESCRIPTION
# Summary
Fix `reacted_with` specs and prevent additional API calls when paginating.

## Changed
`Message#reacted_with` - If limit can fit in a single page, do not use a paginator, otherwise return as soon as a page is not full.
