### PR TITLE
feat: Add message type methods

### DIFF
--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -5,6 +5,36 @@ module Discordrb
   class Message
     include IDObject
 
+    # Mapping of message type names to their numeric representation.
+    # @return Hash<Symbol, Integer>
+    TYPES = {
+      default: 0,
+      recipient_add: 1,
+      recipient_remove: 2,
+      call: 3,
+      channel_name_change: 4,
+      channel_icon_change: 5,
+      channel_pinned_message: 6,
+      guild_member_join: 7,
+      user_premium_guild_subscription: 8,
+      # rubocop:disable Naming/VariableNumber
+      user_premium_guild_subscription_tier_1: 9,
+      user_premium_guild_subscription_tier_2: 10,
+      user_premium_guild_subscription_tier_3: 11,
+      # rubocop:enable Naming/VariableNumber
+      channel_follow_add: 12,
+      guild_discovery_disqualified: 14,
+      guild_discovery_requalified: 15,
+      guild_discovery_grace_period_initial_warning: 16,
+      guild_discovery_grace_period_final_warning: 17,
+      thread_created: 18,
+      reply: 19,
+      chat_input_command: 20,
+      thread_starter_message: 21,
+      guild_invite_reminder: 22,
+      context_menu_command: 23
+    }.freeze
+
     # @return [String] the content of this message.
     attr_reader :content
     alias_method :text, :content
@@ -155,6 +185,8 @@ module Discordrb
 
       @components = []
       @components = data['components'].map { |component_data| Components.from_data(component_data, @bot) } if data['components']
+
+      @type = data['type']
     end
 
     # Replies to this message with the specified content.
@@ -375,6 +407,68 @@ module Discordrb
       end
 
       results.flatten.compact
+    end
+
+    # @return [Symbol] The name for the message type, `:unknown` if the type is not mapped in {TYPES}
+    # @see TYPES
+    def type
+      TYPES.key(@type) || :unknown
+    end
+
+    # @!group Types
+
+    # @!attribute [r] default?
+    #   @return [true, false]
+    # @!attribute [r] recipient_add?
+    #   @return [true, false]
+    # @!attribute [r] recipient_remove?
+    #   @return [true, false]
+    # @!attribute [r] call?
+    #   @return [true, false]
+    # @!attribute [r] channel_name_change?
+    #   @return [true, false]
+    # @!attribute [r] channel_icon_change?
+    #   @return [true, false]
+    # @!attribute [r] channel_pinned_message?
+    #   @return [true, false]
+    # @!attribute [r] guild_member_join?
+    #   @return [true, false]
+    # @!attribute [r] user_premium_guild_subscription?
+    #   @return [true, false]
+    # @!attribute [r] user_premium_guild_subscription_tier_1?
+    #   @return [true, false]
+    # @!attribute [r] user_premium_guild_subscription_tier_2?
+    #   @return [true, false]
+    # @!attribute [r] user_premium_guild_subscription_tier_3?
+    #   @return [true, false]
+    # @!attribute [r] channel_follow_add?
+    #   @return [true, false]
+    # @!attribute [r] guild_discovery_disqualified?
+    #   @return [true, false]
+    # @!attribute [r] guild_discovery_requalified?
+    #   @return [true, false]
+    # @!attribute [r] guild_discovery_grace_period_initial_warning?
+    #   @return [true, false]
+    # @!attribute [r] guild_discovery_grace_period_final_warning?
+    #   @return [true, false]
+    # @!attribute [r] thread_created?
+    #   @return [true, false]
+    # @!attribute [r] reply?
+    #   @return [true, false]
+    # @!attribute [r] chat_input_command?
+    #   @return [true, false]
+    # @!attribute [r] thread_starter_message?
+    #   @return [true, false]
+    # @!attribute [r] guild_invite_reminder?
+    #   @return [true, false]
+    # @!attribute [r] context_menu_command?
+    #   @return [true, false]
+
+    # @!endgroup
+    TYPES.each do |name, value|
+      define_method("#{name}?") do
+        @type == value
+      end
     end
   end
 end


### PR DESCRIPTION
# Summary

Adds a TYPES const and attribute readers to test Message types.

## Added
`Message::TYPES` - A mapping of names to internal type integers.
`Message#type` - Return the symbol name of the message type
Various readers to test message types in the form of `{message_type}? => bool`

Closes #83 