### PR TITLE
fix: Use to_a to avoid rails problems

### DIFF
--- a/lib/discordrb/data/component.rb
+++ b/lib/discordrb/data/component.rb
@@ -125,8 +125,8 @@ module Discordrb
       end
 
       # @!visibility private
-      def to_json(_)
-        @rows.to_json
+      def to_a
+        @rows.to_a
       end
     end
 
@@ -167,8 +167,8 @@ module Discordrb
       end
 
       # @!visibility private
-      def to_json(_)
-        @components.to_json
+      def to_a
+        @components
       end
     end
 

--- a/lib/discordrb/data/component.rb
+++ b/lib/discordrb/data/component.rb
@@ -58,8 +58,8 @@ module Discordrb
       end
 
       # @!visibility private
-      def to_json(_)
-        { type: Components::TYPES[:action_row], components: @components }.to_json
+      def to_h
+        { type: Components::TYPES[:action_row], components: @components }
       end
     end
 
@@ -126,7 +126,7 @@ module Discordrb
 
       # @!visibility private
       def to_a
-        @rows.to_a
+        @rows.map(&:to_h)
       end
     end
 

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -95,7 +95,7 @@ module Discordrb
       components ||= view
       data = builder.to_json_hash.merge({ content: content, embeds: embeds, allowed_mentions: allowed_mentions }.compact)
 
-      Discordrb::API::Interaction.create_interaction_response(@token, @id, CALLBACK_TYPES[:channel_message], data[:content], tts, data[:embeds], data[:allowed_mentions], flags, components)
+      Discordrb::API::Interaction.create_interaction_response(@token, @id, CALLBACK_TYPES[:channel_message], data[:content], tts, data[:embeds], data[:allowed_mentions], flags, components.to_a)
 
       return unless wait
 
@@ -144,7 +144,7 @@ module Discordrb
       components ||= view
       data = builder.to_json_hash.merge({ content: content, embeds: embeds, allowed_mentions: allowed_mentions }.compact)
 
-      Discordrb::API::Interaction.create_interaction_response(@token, @id, CALLBACK_TYPES[:update_message], data[:content], tts, data[:embeds], data[:allowed_mentions], flags, components)
+      Discordrb::API::Interaction.create_interaction_response(@token, @id, CALLBACK_TYPES[:update_message], data[:content], tts, data[:embeds], data[:allowed_mentions], flags, components.to_a)
 
       return unless wait
 
@@ -166,7 +166,7 @@ module Discordrb
 
       components ||= view
       data = builder.to_json_hash.merge({ content: content, embeds: embeds, allowed_mentions: allowed_mentions }.compact)
-      resp = Discordrb::API::Interaction.edit_original_interaction_response(@token, @application_id, data[:content], data[:embeds], data[:allowed_mentions], components)
+      resp = Discordrb::API::Interaction.edit_original_interaction_response(@token, @application_id, data[:content], data[:embeds], data[:allowed_mentions], components.to_a)
 
       Interactions::Message.new(JSON.parse(resp), @bot, @interaction)
     end
@@ -192,7 +192,7 @@ module Discordrb
       yield builder, view if block_given?
 
       components ||= view
-      data = builder.to_json_hash.merge({ content: content, embeds: embeds, allowed_mentions: allowed_mentions, tts: tts, componenets: components }.compact)
+      data = builder.to_json_hash.merge({ content: content, embeds: embeds, allowed_mentions: allowed_mentions, tts: tts, componenets: components.to_a }.compact)
 
       resp = Discordrb::API::Webhook.token_execute_webhook(
         @token, @application_id, true, data[:content], nil, nil, data[:tts], nil, data[:embeds], data[:allowed_mentions], flags, data[:components]
@@ -212,7 +212,7 @@ module Discordrb
       yield builder, view if block_given?
 
       components ||= view
-      data = builder.to_json_hash.merge({ content: content, embeds: embeds, allowed_mentions: allowed_mentions, componenets: components }.compact)
+      data = builder.to_json_hash.merge({ content: content, embeds: embeds, allowed_mentions: allowed_mentions, componenets: components.to_a }.compact)
 
       resp = Discordrb::API::Webhook.token_edit_message(
         @token, @application_id, message.resolve_id, data[:content], data[:embeds], data[:allowed_mentions], data[:components]


### PR DESCRIPTION
# Summary

I assume that rails isn't playing nicely with the use of `to_json` in `Discordrb::Components::View`. This refactors away to `to_a` directly to avoid it all together.

---

No public API changes.
