### PR TITLE
feat!: Remove restricted channels check

### DIFF
--- a/lib/discordrb/cache.rb
+++ b/lib/discordrb/cache.rb
@@ -21,8 +21,6 @@ module Discordrb
 
       @channels = {}
       @pm_channels = {}
-
-      @restricted_channels = []
     end
 
     # Returns or caches the available voice regions
@@ -43,27 +41,20 @@ module Discordrb
     # @param server [Server] The server for which to search the channel for. If this isn't specified, it will be
     #   inferred using the API
     # @return [Channel] The channel identified by the ID.
+    # @raise Discordrb::Errors::NoPermission
     def channel(id, server = nil)
       id = id.resolve_id
-
-      raise Discordrb::Errors::NoPermission if @restricted_channels.include? id
 
       debug("Obtaining data for channel with id #{id}")
       return @channels[id] if @channels[id]
 
       begin
-        begin
-          response = API::Channel.resolve(token, id)
-        rescue RestClient::ResourceNotFound
-          return nil
-        end
-        channel = Channel.new(JSON.parse(response), self, server)
-        @channels[id] = channel
-      rescue Discordrb::Errors::NoPermission
-        debug "Tried to get access to restricted channel #{id}, blacklisting it"
-        @restricted_channels << id
-        raise
+        response = API::Channel.resolve(token, id)
+      rescue RestClient::ResourceNotFound
+        return nil
       end
+      channel = Channel.new(JSON.parse(response), self, server)
+      @channels[id] = channel
     end
 
     alias_method :group_channel, :channel


### PR DESCRIPTION
# Summary

We currently have an internal blacklist setup to prevent accessing a channel we don't have permission to see, but we never purge this cache so it's becoming an issue.

In the future it may be desirable to dynamically track this through every event associated with channel visibility (there are many). However for the time being removing this check entirely is the best course of action.

---

## Changed
`Cache#channel` - No longer maintains a cache of channels that have returned a 403
