### PR TITLE
refactor: Use chunk_index and chunk_count to determine chunk status.

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1175,7 +1175,7 @@ module Discordrb
       when :GUILD_MEMBERS_CHUNK
         id = data['guild_id'].to_i
         server = server(id)
-        server.process_chunk(data['members'])
+        server.process_chunk(data['members'], data['chunk_index'], data['chunk_count'])
       when :INVITE_CREATE
         invite = Invite.new(data, self)
         raise_event(InviteCreateEvent.new(data, invite, self))

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -87,7 +87,6 @@ module Discordrb
 
       # Whether this server's members have been chunked (resolved using op 8 and GUILD_MEMBERS_CHUNK) yet
       @chunked = false
-      @processed_chunk_members = 0
 
       @booster_count = data['premium_subscription_count'] || 0
       @boost_level = data['premium_tier']
@@ -805,19 +804,16 @@ module Discordrb
     # Processes a GUILD_MEMBERS_CHUNK packet, specifically the members field
     # @note For internal use only
     # @!visibility private
-    def process_chunk(members)
+    def process_chunk(members, chunk_index, chunk_count)
       process_members(members)
-      @processed_chunk_members += members.length
-      LOGGER.debug("Processed one chunk on server #{@id} - length #{members.length}")
+      LOGGER.debug("Processed chunk #{chunk_index + 1}/#{chunk_count} server #{@id} - length #{members.length}")
 
-      # Don't bother with the rest of the method if it's not truly the last packet
-      return unless @processed_chunk_members == @member_count
+      return unless chunk_index + 1 == chunk_count
 
       LOGGER.debug("Finished chunking server #{@id}")
 
       # Reset everything to normal
       @chunked = true
-      @processed_chunk_members = 0
     end
 
     # @return [Channel, nil] the AFK voice channel of this server, or `nil` if none is set.

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -806,9 +806,9 @@ module Discordrb
     # @!visibility private
     def process_chunk(members, chunk_index, chunk_count)
       process_members(members)
-      LOGGER.debug("Processed chunk #{chunk_index + 1}/#{chunk_count} server #{@id} - length #{members.length}")
+      LOGGER.debug("Processed chunk #{chunk_index + 1}/#{chunk_count} server #{@id} - index #{chunk_index} - length #{members.length}")
 
-      return unless chunk_index + 1 == chunk_count
+      return if chunk_index + 1 < chunk_count
 
       LOGGER.debug("Finished chunking server #{@id}")
 

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -285,7 +285,7 @@ module Discordrb
                       '$device': 'discordrb',
                       '$referrer': '',
                       '$referring_domain': ''
-                    }, compress, 100, @shard_key, @intents)
+                    }, compress, LARGE_THRESHOLD, @shard_key, @intents)
     end
 
     # Sends an identify packet (op 2). This starts a new session on the current connection and tells Discord who we are.


### PR DESCRIPTION
# Summary

This changes chunking calculation to use the discord provided `chunk_index` and `chunk_count` fields instead of checking for expected length. This should help us avoid some difficult to trace deadlocks.

---

## Changed
`Server#process_chunk` - now accepts an additional two arguments; `chunk_index` and `chunk_count`.
