### PR TITLE
fix: force guild recache from GUILD_CREATE

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1015,7 +1015,7 @@ module Discordrb
 
     # Internal handler for GUILD_CREATE
     def create_guild(data)
-      ensure_server(data)
+      ensure_server(data, true)
     end
 
     # Internal handler for GUILD_UPDATE
@@ -1143,14 +1143,14 @@ module Discordrb
         data['guilds'].each do |element|
           # Check for true specifically because unavailable=false indicates that a previously unavailable server has
           # come online
-          if element['unavailable'].is_a? TrueClass
+          if element['unavailable']
             @unavailable_servers += 1
 
             # Ignore any unavailable servers
             next
           end
 
-          ensure_server(element)
+          ensure_server(element, true)
         end
 
         # Add PM and group channels

--- a/lib/discordrb/cache.rb
+++ b/lib/discordrb/cache.rb
@@ -147,10 +147,14 @@ module Discordrb
 
     # Ensures a given server object is cached and if not, cache it from the given data hash.
     # @param data [Hash] A data hash representing a server.
+    # @param force_cache [true, false] Whether the object in cache should be updated with the given
+    #   data if it already exists.
     # @return [Server] the server represented by the data hash.
-    def ensure_server(data)
+    def ensure_server(data, force_cache = false)
       if @servers.include?(data['id'].to_i)
-        @servers[data['id'].to_i]
+        server = @servers[data['id'].to_i]
+        server.update_data(data) if force_cache
+        server
       else
         @servers[data['id'].to_i] = Server.new(data, self)
       end

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -66,24 +66,12 @@ module Discordrb
       @bot = bot
       @owner_id = data['owner_id'].to_i
       @id = data['id'].to_i
-
-      process_channels(data['channels'])
-      update_data(data)
-
-      @large = data['large']
-      @member_count = data['member_count'] || 0
-      @splash_id = nil
-      @banner_id = nil
-      @features = data['features'].map { |element| element.downcase.to_sym }
       @members = {}
       @voice_states = {}
       @emoji = {}
 
-      process_roles(data['roles'])
-      process_emoji(data['emojis'])
-      process_members(data['members'])
-      process_presences(data['presences'])
-      process_voice_states(data['voice_states'])
+      process_channels(data['channels'])
+      update_data(data)
 
       # Whether this server's members have been chunked (resolved using op 8 and GUILD_MEMBERS_CHUNK) yet
       @chunked = false
@@ -853,6 +841,19 @@ module Discordrb
       @verification_level = new_data[:verification_level] || new_data['verification_level'] || @verification_level
       @explicit_content_filter = new_data[:explicit_content_filter] || new_data['explicit_content_filter'] || @explicit_content_filter
       @default_message_notifications = new_data[:default_message_notifications] || new_data['default_message_notifications'] || @default_message_notifications
+
+      @large = new_data.key?('large') ? new_data['large'] : @large
+      @member_count = new_data['member_count'] || @member_count || 0
+      @splash_id = new_data['splash'] || @splash_id
+      @banner_id = new_data['banner'] || @banner_id
+      @features = new_data['features'] ? new_data['features'].map { |element| element.downcase.to_sym } : @features || []
+
+      process_channels(new_data['channels']) if new_data['channels']
+      process_roles(new_data['roles']) if new_data['roles']
+      process_emoji(new_data['emojis']) if new_data['emojis']
+      process_members(new_data['members']) if new_data['members']
+      process_presences(new_data['presences']) if new_data['presences']
+      process_voice_states(new_data['voice_states']) if new_data['voice_states']
     end
 
     # Adds a channel to this server's cache


### PR DESCRIPTION
# Summary

Adds an option to `ensure_server` to force the recache of a guild. This is necessary because there is a window in this cache lifecycle where we can have a server object with bad state that permanently occupies the cache.

![image](https://user-images.githubusercontent.com/822067/141665155-d46efe1f-dc8d-49e6-9d3e-d770a8bda694.png)


## Added
- `Cache#ensure_server` - Add `force_recache` parameter to ensure guilds from `GUILD_CREATE` are used as the source of truth.

## Changed
- `Server#update_data` - Move data initialization logic from `initialize` to `update_data` for reusability.
