### PR TITLE
feat: Add application command permission builder

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -834,9 +834,9 @@ module Discordrb
     # @param permissions [Array<Hash>] An array of objects formatted as `{ id: ENTITY_ID, type: 1 or 2, permission: true or false }`
     def edit_application_command_permissions(command_id, server_id, permissions = [])
       builder = Interactions::PermissionBuilder.new
-      yield builder
+      yield builder if block_given?
 
-      permissions = permissions.merge(builder.to_a)
+      permissions = permissions + builder.to_a
       API::Application.edit_guild_command_permissions(@token, profile.id, server_id, command_id, permissions)
     end
 

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -836,7 +836,7 @@ module Discordrb
       builder = Interactions::PermissionBuilder.new
       yield builder if block_given?
 
-      permissions = permissions + builder.to_a
+      permissions += builder.to_a
       API::Application.edit_guild_command_permissions(@token, profile.id, server_id, command_id, permissions)
     end
 

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -448,6 +448,91 @@ module Discordrb
       end
     end
 
+    # Builder for creating server application command permissions.
+    # @deprecated This system is being replaced in the near future.
+    class PermissionBuilder
+      # Role permission type
+      ROLE = 1
+      # User permission type
+      USER = 2
+
+      # @!visibility hidden
+      def initialize
+        @permissions = []
+      end
+
+      # Allow a role to use this command.
+      # @param role_id [Integer]
+      # @return [PermissionBuilder]
+      def allow_role(role_id)
+        create_entry(role_id, ROLE, true)
+      end
+
+      # Deny a role usage of this command.
+      # @param role_id [Integer]
+      # @return [PermissionBuilder]
+      def deny_role(role_id)
+        create_entry(role_id, ROLE, false)
+      end
+
+      # Allow a user to use this command.
+      # @param user_id [Integer]
+      # @return [PermissionBuilder]
+      def allow_user(user_id)
+        create_entry(user_id, USER, true)
+      end
+
+      # Deny a user usage of this command.
+      # @param user_id [Integer]
+      # @return [PermissionBuilder]
+      def deny_user(user_id)
+        create_entry(user_id, USER, false)
+      end
+
+      # Allow an entity to use this command.
+      # @param object [Role, User, Member]
+      # @return [PermissionBuilder]
+      # @raise [ArgumentError]
+      def allow(object)
+        case object
+        when Discordrb::User, Discordrb::Member
+          create_entry(object.id, USER, true)
+        when Discordrb::Role
+          create_entry(object.id, ROLE, true)
+        else
+          raise ArgumentError, "Unable to create permission for unknown type: #{object.class}"
+        end
+      end
+
+      # Deny an entity usage of this command.
+      # @param object [Role, User, Member]
+      # @return [PermissionBuilder]
+      # @raise [ArgumentError]
+      def deny(object)
+        case object
+        when Discordrb::User, Discordrb::Member
+          create_entry(object.id, USER, false)
+        when Discordrb::Role
+          create_entry(object.id, ROLE, false)
+        else
+          raise ArgumentError, "Unable to create permission for unknown type: #{object.class}"
+        end
+      end
+
+      # @!visibility private
+      # @return [Array<Hash>]
+      def to_a
+        @permissions
+      end
+
+      private
+
+      def create_entry(id, type, permission)
+        @permissions << { id: id, type: type, permission: permission }
+        self
+      end
+    end
+
     # A message partial for interactions.
     class Message
       include IDObject

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -278,6 +278,9 @@ module Discordrb
     # @return [Hash]
     attr_reader :options
 
+    # @return [Integer]
+    attr_reader :id
+
     # @!visibility private
     def initialize(data, bot, server_id = nil)
       @bot = bot


### PR DESCRIPTION
# Summary

Adds a builder for declaring permissions when creating or editing a slash command.

---

## Added
Interactions::PermissionBuilder

## Changed
Bot#register_application_command and Bot#edit_application_command now yield PermissionBuilders
