### PR TITLE
Allow bulk overwriting application commands

### DIFF
--- a/lib/discordrb/api/application.rb
+++ b/lib/discordrb/api/application.rb
@@ -44,13 +44,13 @@ module Discordrb::API::Application
 
   # Edit a global application command.
   # https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command
-  def edit_global_command(token, application_id, command_id, name = nil, description = nil, options = nil, default_permission = nil, type = 1)
+  def edit_global_command(token, application_id, command_id, command_data)
     Discordrb::API.request(
       :applications_aid_commands_cid,
       nil,
       :patch,
       "#{Discordrb::API.api_base}/applications/#{application_id}/commands/#{command_id}",
-      { name: name, description: description, options: options, default_permission: default_permission, type: type }.compact.to_json,
+      command_data.to_json,
       Authorization: token,
       content_type: :json
     )
@@ -122,13 +122,13 @@ module Discordrb::API::Application
 
   # Edit an application command for a guild.
   # https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
-  def edit_guild_command(token, application_id, guild_id, command_id, name = nil, description = nil, options = nil, default_permission = nil, type = 1)
+  def edit_guild_command(token, application_id, guild_id, command_id, command_data)
     Discordrb::API.request(
       :applications_aid_guilds_gid_commands_cid,
       guild_id,
       :patch,
       "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}",
-      { name: name, description: description, options: options, default_permission: default_permission, type: type }.compact.to_json,
+      command_data.to_json,
       Authorization: token,
       content_type: :json
     )

--- a/lib/discordrb/api/application.rb
+++ b/lib/discordrb/api/application.rb
@@ -30,13 +30,13 @@ module Discordrb::API::Application
 
   # Create a global application command.
   # https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
-  def create_global_command(token, application_id, name, description, options = [], default_permission = nil, type = 1)
+  def create_global_command(token, application_id, command_data)
     Discordrb::API.request(
       :applications_aid_commands,
       nil,
       :post,
       "#{Discordrb::API.api_base}/applications/#{application_id}/commands",
-      { name: name, description: description, options: options, default_permission: default_permission, type: type }.to_json,
+      command_data.to_json,
       Authorization: token,
       content_type: :json
     )
@@ -108,13 +108,13 @@ module Discordrb::API::Application
 
   # Create an application command for a guild.
   # https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command
-  def create_guild_command(token, application_id, guild_id, name, description, options = nil, default_permission = nil, type = 1)
+  def create_guild_command(token, application_id, guild_id, command_data)
     Discordrb::API.request(
       :applications_aid_guilds_gid_commands,
       guild_id,
       :post,
       "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands",
-      { name: name, description: description, options: options, default_permission: default_permission, type: type }.to_json,
+      command_data.to_json,
       Authorization: token,
       content_type: :json
     )

--- a/lib/discordrb/api/application.rb
+++ b/lib/discordrb/api/application.rb
@@ -30,13 +30,13 @@ module Discordrb::API::Application
 
   # Create a global application command.
   # https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
-  def create_global_command(token, application_id, command_data)
+  def create_global_command(token, application_id, name, description, options = [], default_permission = nil, type = 1)
     Discordrb::API.request(
       :applications_aid_commands,
       nil,
       :post,
       "#{Discordrb::API.api_base}/applications/#{application_id}/commands",
-      command_data.to_json,
+      { name: name, description: description, options: options, default_permission: default_permission, type: type }.to_json,
       Authorization: token,
       content_type: :json
     )
@@ -44,13 +44,13 @@ module Discordrb::API::Application
 
   # Edit a global application command.
   # https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command
-  def edit_global_command(token, application_id, command_id, command_data)
+  def edit_global_command(token, application_id, command_id, name = nil, description = nil, options = nil, default_permission = nil, type = 1)
     Discordrb::API.request(
       :applications_aid_commands_cid,
       nil,
       :patch,
       "#{Discordrb::API.api_base}/applications/#{application_id}/commands/#{command_id}",
-      command_data.to_json,
+      { name: name, description: description, options: options, default_permission: default_permission, type: type }.compact.to_json,
       Authorization: token,
       content_type: :json
     )
@@ -108,13 +108,13 @@ module Discordrb::API::Application
 
   # Create an application command for a guild.
   # https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command
-  def create_guild_command(token, application_id, guild_id, command_data)
+  def create_guild_command(token, application_id, guild_id, name, description, options = nil, default_permission = nil, type = 1)
     Discordrb::API.request(
       :applications_aid_guilds_gid_commands,
       guild_id,
       :post,
       "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands",
-      command_data.to_json,
+      { name: name, description: description, options: options, default_permission: default_permission, type: type }.to_json,
       Authorization: token,
       content_type: :json
     )
@@ -122,13 +122,13 @@ module Discordrb::API::Application
 
   # Edit an application command for a guild.
   # https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
-  def edit_guild_command(token, application_id, guild_id, command_id, command_data)
+  def edit_guild_command(token, application_id, guild_id, command_id, name = nil, description = nil, options = nil, default_permission = nil, type = 1)
     Discordrb::API.request(
       :applications_aid_guilds_gid_commands_cid,
       guild_id,
       :patch,
       "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}",
-      command_data.to_json,
+      { name: name, description: description, options: options, default_permission: default_permission, type: type }.compact.to_json,
       Authorization: token,
       content_type: :json
     )

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -803,9 +803,9 @@ module Discordrb
       )
 
       resp = if server_id
-               API::Application.create_guild_command(@token, profile.id, server_id, builder.to_hash)
+               API::Application.create_guild_command(@token, profile.id, server_id, builder.name, builder.description, builder.options.to_a, builder.default_permission, builder.type)
              else
-               API::Application.create_global_command(@token, profile.id, builder.to_hash)
+               API::Application.create_global_command(@token, profile.id, builder.name, builder.description, builder.options.to_a, builder.default_permission, builder.type)
              end
       cmd = ApplicationCommand.new(JSON.parse(resp), self, server_id)
 
@@ -841,9 +841,9 @@ module Discordrb
       builder.name
 
       resp = if server_id
-               API::Application.edit_guild_command(@token, profile.id, server_id, command_id, builder.to_hash)
+               API::Application.edit_guild_command(@token, profile.id, server_id, command_id, builder.name, builder.description, builder.options.to_a, builder.default_permission, builder.type)
              else
-               API::Application.edit_guild_command(@token, profile.id, command_id, builder.to_hash)
+               API::Application.edit_guild_command(@token, profile.id, command_id, builder.name, builder.description, builder.options.to_a, builder.default_permission, builder.type)
              end
       cmd = ApplicationCommand.new(JSON.parse(resp), self, server_id)
 

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -770,14 +770,11 @@ module Discordrb
       ApplicationCommand.new(JSON.parse(resp), self, server_id)
     end
 
-    # @param name [Symbol, String]
-    # @param description [String]
     # @param server_id [String, Integer, nil] The ID of the server to register the command in. Global if `nil`.
-    # @param default_permission [Boolean, nil] Whether the command is enabled by default when the app is added to a server.
-    # @param type [Symbol, Integer]
+    # @param (see Interactions::ApplicationCommandSetBuilder#command)
     #
-    # @yieldparam [OptionBuilder]
-    # @yieldparam [PermissionBuilder]
+    # @yieldparam [Interactions::OptionBuilder]
+    # @yieldparam [Interactions::PermissionBuilder]
     #
     # @return [ApplicationCommand]
     #
@@ -820,13 +817,10 @@ module Discordrb
 
     # @param command_id [String, Integer]
     # @param server_id [String, Integer, nil] The ID of the server to edit the command from. Global if `nil`.
-    # @param name [Symbol, String, nil]
-    # @param description [String, nil]
-    # @param default_permission [Boolean, nil] Whether the command is enabled by default when the app is added to a server.
-    # @param type [Symbol, Integer]
+    # @param (see Interactions::ApplicationCommandBuilder#initialize)
     #
-    # @yieldparam [OptionBuilder]
-    # @yieldparam [PermissionBuilder]
+    # @yieldparam [Interactions::OptionBuilder]
+    # @yieldparam [Interactions::PermissionBuilder]
     #
     # @return [ApplicationCommand]
     def edit_application_command(command_id, server_id: nil, name: nil, description: nil, default_permission: nil, type: :chat_input, &block)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -770,8 +770,11 @@ module Discordrb
       ApplicationCommand.new(JSON.parse(resp), self, server_id)
     end
 
+    # @param name [Symbol, String]
+    # @param description [String]
     # @param server_id [String, Integer, nil] The ID of the server to register the command in. Global if `nil`.
-    # @param (see Interactions::ApplicationCommandSetBuilder#command)
+    # @param default_permission [Boolean, nil] Whether the command is enabled by default when the app is added to a server.
+    # @param type [Symbol, Integer]
     #
     # @yieldparam options [Interactions::OptionBuilder]
     # @yieldparam permissions [Interactions::PermissionBuilder]
@@ -817,7 +820,10 @@ module Discordrb
 
     # @param command_id [String, Integer]
     # @param server_id [String, Integer, nil] The ID of the server to edit the command from. Global if `nil`.
-    # @param (see Interactions::ApplicationCommandBuilder#initialize)
+    # @param name [Symbol, String, nil]
+    # @param description [String, nil]
+    # @param default_permission [Boolean, nil] Default permission
+    # @param type [Symbol, Integer]
     #
     # @yieldparam options [Interactions::OptionBuilder]
     # @yieldparam permissions [Interactions::PermissionBuilder]

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -773,8 +773,8 @@ module Discordrb
     # @param server_id [String, Integer, nil] The ID of the server to register the command in. Global if `nil`.
     # @param (see Interactions::ApplicationCommandSetBuilder#command)
     #
-    # @yieldparam [Interactions::OptionBuilder]
-    # @yieldparam [Interactions::PermissionBuilder]
+    # @yieldparam options [Interactions::OptionBuilder]
+    # @yieldparam permissions [Interactions::PermissionBuilder]
     #
     # @return [ApplicationCommand]
     #
@@ -819,8 +819,8 @@ module Discordrb
     # @param server_id [String, Integer, nil] The ID of the server to edit the command from. Global if `nil`.
     # @param (see Interactions::ApplicationCommandBuilder#initialize)
     #
-    # @yieldparam [Interactions::OptionBuilder]
-    # @yieldparam [Interactions::PermissionBuilder]
+    # @yieldparam options [Interactions::OptionBuilder]
+    # @yieldparam permissions [Interactions::PermissionBuilder]
     #
     # @return [ApplicationCommand]
     def edit_application_command(command_id, server_id: nil, name: nil, description: nil, default_permission: nil, type: :chat_input, &block)

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -312,6 +312,59 @@ module Discordrb
 
   # Objects specific to Interactions.
   module Interactions
+    class ApplicationCommandBuilder
+      attr_accessor :name, :description, :default_permission
+      attr_reader :type
+
+      # @param name [Symbol, String, nil]
+      # @param description [String, nil]
+      # @param default_permission [Boolean, nil] Whether the command is enabled by default when the app is added to a server.
+      # @param type [Symbol, Integer]
+      #
+      # @yieldparam [OptionBuilder]
+      # @yieldparam [PermissionBuilder]
+      def initialize(name: nil, description: nil, default_permission: nil, type: :chat_input, &block)
+        @name = name
+        @description = description
+        @default_permission = default_permission
+        self.type = type
+        @options_builder = OptionBuilder.new
+        @permission_builder = PermissionBuilder.new
+
+        yield(@options_builder, @permission_builder) if block_given?
+      end
+
+      # @param value [Symbol, Integer]
+      def type=(value)
+        @type = ApplicationCommand::TYPES[value] || value
+      end
+
+      # @yieldparam [OptionBuilder]
+      # @return OptionBuilder
+      def options
+        yield @options_builder if block_given?
+        @options_builder
+      end
+
+      # @yieldparam [PermissionBuilder]
+      # @return PermissionBuilder
+      def permissions
+        yield @permission_builder if block_given?
+        @permission_builder
+      end
+
+      # @return [Hash]
+      def to_hash
+        {
+          name: name,
+          description: description,
+          options: options.to_a,
+          default_permission: default_permission,
+          type: type
+        }.compact
+      end
+    end
+
     # A builder for defining slash commands options.
     class OptionBuilder
       # @!visibility private

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -312,6 +312,36 @@ module Discordrb
 
   # Objects specific to Interactions.
   module Interactions
+    class ApplicationCommandSetBuilder
+      attr_reader :commands
+
+      def initialize
+        @commands = []
+      end
+
+      # @param name [Symbol, String]
+      # @param default_permission [Boolean, nil] Whether the command is enabled by default when the app is added to a server.
+      # @param type [Symbol, Integer]
+      # @param description [String]
+      #
+      # @yieldparam [OptionBuilder]
+      # @yieldparam [PermissionBuilder]
+      def command(name, description, default_permission: nil, type: nil, &block)
+        commands << ApplicationCommandBuilder.new(
+          name: name,
+          description: description,
+          default_permission: default_permission,
+          type: type,
+          &block
+        )
+      end
+
+      # @return [Array<Hash>]
+      def to_a
+        commands.map(&:to_hash)
+      end
+    end
+
     class ApplicationCommandBuilder
       attr_accessor :name, :description, :default_permission
       attr_reader :type

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -312,17 +312,20 @@ module Discordrb
 
   # Objects specific to Interactions.
   module Interactions
+    # A builder for defining a set of application commands.
     class ApplicationCommandSetBuilder
+      # @return [Array<ApplicationCommandBuilder>]
       attr_reader :commands
 
+      # @!visibility private
       def initialize
         @commands = []
       end
 
       # @param name [Symbol, String]
+      # @param description [String]
       # @param default_permission [Boolean, nil] Whether the command is enabled by default when the app is added to a server.
       # @param type [Symbol, Integer]
-      # @param description [String]
       #
       # @yieldparam [OptionBuilder]
       # @yieldparam [PermissionBuilder]
@@ -342,8 +345,18 @@ module Discordrb
       end
     end
 
+    # A builder for defining an application command.
     class ApplicationCommandBuilder
-      attr_accessor :name, :description, :default_permission
+      # @return [Symbol, String, nil]
+      attr_accessor :name
+
+      # @return [String, nil]
+      attr_accessor :description
+
+      # @return [Boolean, nil]
+      attr_accessor :default_permission
+
+      # @return [Symbol, Integer]
       attr_reader :type
 
       # @param name [Symbol, String, nil]
@@ -351,9 +364,9 @@ module Discordrb
       # @param default_permission [Boolean, nil] Whether the command is enabled by default when the app is added to a server.
       # @param type [Symbol, Integer]
       #
-      # @yieldparam [OptionBuilder]
-      # @yieldparam [PermissionBuilder]
-      def initialize(name: nil, description: nil, default_permission: nil, type: :chat_input, &block)
+      # @yieldparam options [OptionBuilder]
+      # @yieldparam permissions [PermissionBuilder]
+      def initialize(name: nil, description: nil, default_permission: nil, type: :chat_input)
         @name = name
         @description = description
         @default_permission = default_permission
@@ -369,14 +382,14 @@ module Discordrb
         @type = ApplicationCommand::TYPES[value] || value
       end
 
-      # @yieldparam [OptionBuilder]
+      # @yieldparam options [OptionBuilder]
       # @return OptionBuilder
       def options
         yield @options_builder if block_given?
         @options_builder
       end
 
-      # @yieldparam [PermissionBuilder]
+      # @yieldparam permissions [PermissionBuilder]
       # @return PermissionBuilder
       def permissions
         yield @permission_builder if block_given?


### PR DESCRIPTION
# Summary

Implemented method for bulk overwriting application commands and added a couple more builders in the context of interactions to facilitate that. The `ApplicationCommandBuilder` is a bit awkward because I didn't want to make any breaking changes to the existing interface of `Bot#register_application_command` and `Bot#edit_application_command`. 

<!---
  Describe the general goal of your pull request here:

  - Include details about any issues you encountered that inspired
  the pull request, such as bugs or missing features.

  - If adding or changing features, include a small example that showcases
  the new behavior.

  - Reference any related issues or pull requests.

  Stuck or need help? Join the Discord! https://discord.gg/cyK3Hjm
--->

---

<!---
  List each individual change you made to the library here in the appropriate
  section in short, bulleted sentences.

  This will aid in reviewing your pull request, and for adding it to the
  changelog later.

  You may remove sections that have no items if you want.
--->

## Added

- `Interactions::ApplicationCommandBuilder` - needed something to encapsulate all data contained in an application command to facilitate the creation of the `ApplicationCommandSetBuilder` (see below). 
- `Interactions::ApplicationCommandSetBuilder` - builder that exposes simple DSL to define multiple application commands within a single block
- `Bot#bulk_overwrite_application_commands` - public method that allows... well... bulk overwriting application commands. Works as shown in the YARD example.
```ruby
bot.bulk_overwrite_application_commands(server_id: ENV["TEST_SERVER_ID"]) do |app|
  app.command(:ping, "Pong!")
  app.command(:echo, "Echo some text") do |cmd|
    cmd.string(:text, "Text to echo")
  end
end
```

## Changed

- `API::Application.create_global_command`
- `API::Application.edit_global_command`
- `API::Application.create_guild_command`
- `API::Application.edit_guild_command`

All 4 of the above have been updated to take a hash of command parameters instead of separate arguments.
```ruby
{
  name: :test,
  description: "some command",
  options: [],
  default_permission: true,
  type: 1
}
```
This could pose problems with `.create_global_command` and `.create_guild_command` as the name and description for those are no longer *techincally* required. Suggestions on handling this are welcome.
    