### PR TITLE
feat: Support timeouts

### DIFF
--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -153,7 +153,7 @@ module Discordrb::API::Server
         deaf: deaf,
         channel_id: channel_id,
         communication_disabled_until: communication_disabled_until
-      }.reject {|_, v| v == :undef }.to_json,
+      }.reject { |_, v| v == :undef }.to_json,
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -140,7 +140,8 @@ module Discordrb::API::Server
 
   # Update a user properties
   # https://discord.com/developers/docs/resources/guild#modify-guild-member
-  def update_member(token, server_id, user_id, nick: nil, roles: nil, mute: nil, deaf: nil, channel_id: nil, reason: nil)
+  def update_member(token, server_id, user_id, nick: :undef, roles: :undef, mute: :undef, deaf: :undef, channel_id: :undef,
+                    communication_disabled_until: :undef, reason: nil)
     Discordrb::API.request(
       :guilds_sid_members_uid,
       server_id,
@@ -150,8 +151,9 @@ module Discordrb::API::Server
         nick: nick,
         mute: mute,
         deaf: deaf,
-        channel_id: channel_id
-      }.compact.to_json,
+        channel_id: channel_id,
+        communication_disabled_until: communication_disabled_until
+      }.reject {|_, v| v == :undef }.to_json,
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1047,6 +1047,7 @@ module Discordrb
       member.update_roles(data['roles'])
       member.update_nick(data['nick'])
       member.update_boosting_since(data['premium_since'])
+      member.update_communication_disabled_until(data['communication_disabled_until'])
     end
 
     # Internal handler for GUILD_MEMBER_DELETE

--- a/lib/discordrb/commands/container.rb
+++ b/lib/discordrb/commands/container.rb
@@ -86,7 +86,7 @@ module Discordrb::Commands
     # Adds all commands from another container into this one. Existing commands will be overwritten.
     # @param container [Module] A module that `extend`s {CommandContainer} from which the commands will be added.
     def include_commands(container)
-      handlers = container.instance_variable_get '@commands'
+      handlers = container.instance_variable_get :@commands
       return unless handlers
 
       @commands ||= {}

--- a/lib/discordrb/commands/rate_limiter.rb
+++ b/lib/discordrb/commands/rate_limiter.rb
@@ -125,7 +125,7 @@ module Discordrb::Commands
     # Adds all the buckets from another RateLimiter onto this one.
     # @param limiter [Module] Another {RateLimiter} module
     def include_buckets(limiter)
-      buckets = limiter.instance_variable_get('@buckets') || {}
+      buckets = limiter.instance_variable_get(:@buckets) || {}
       @buckets ||= {}
       @buckets.merge! buckets
     end

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -632,7 +632,7 @@ module Discordrb
     # @param container [Module] A module that `extend`s {EventContainer} from which the handlers will be added.
     def include_events(container)
       application_command_handlers = container.instance_variable_get(:@application_commands)
-      handlers = container.instance_variable_get '@event_handlers'
+      handlers = container.instance_variable_get :@event_handlers
       return unless handlers || application_command_handlers
 
       @event_handlers ||= {}

--- a/lib/discordrb/errors.rb
+++ b/lib/discordrb/errors.rb
@@ -87,7 +87,7 @@ module Discordrb
     # rubocop:disable Naming/MethodName
     def self.Code(code)
       classy = Class.new(CodeError)
-      classy.instance_variable_set('@code', code)
+      classy.instance_variable_set(:@code, code)
 
       @code_classes ||= {}
       @code_classes[code] = classy

--- a/spec/permissions_spec.rb
+++ b/spec/permissions_spec.rb
@@ -31,8 +31,8 @@ describe Discordrb::Permissions do
       it 'sets an attribute for each flag' do
         expect(
           [
-            subject.instance_variable_get('@foo'),
-            subject.instance_variable_get('@bar')
+            subject.instance_variable_get(:@foo),
+            subject.instance_variable_get(:@bar)
           ]
         ).to eq [false, false]
       end


### PR DESCRIPTION
# Summary

Support new discord timeouts feature.

---

Adds `Member#communication_disabled_until`, `Member#communication_disabled_until=`, and `Member#communication_disabled?`. Also corresponding aliases using `timeout` terminology.
