### PR TITLE
fix: Use retry-after response header if missing in the response body for 429 API bans

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -143,7 +143,7 @@ module Discordrb::API
 
       unless mutex.locked?
         response = JSON.parse(e.response)
-        wait_seconds = response['retry_after'].to_f
+        wait_seconds = response['retry_after'] ? response['retry_after'].to_f : e.response.headers[:retry_after].to_i
         Discordrb::LOGGER.ratelimit("Locking RL mutex (key: #{key}) for #{wait_seconds} seconds due to Discord rate limiting")
         trace("429 #{key.join(' ')}")
 


### PR DESCRIPTION
# Summary

In the case of a 429 after an API ban, the retry-after in the JSON body isn't present, but is present in the headers.

The library will incorrectly wait for 0.0s since it's `nil` in the body and spam the API. This fixes this issue.

## Fixed
Use retry-after response header if retry-after is missing in the response body