### PR TITLE
fix(ApplicationCommand): prevent nil into 0 for server_id

### DIFF
--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -286,7 +286,7 @@ module Discordrb
       @bot = bot
       @id = data['id'].to_i
       @application_id = data['application_id'].to_i
-      @server_id = server_id.to_i
+      @server_id = server_id&.to_i
 
       @name = data['name']
       @description = data['description']


### PR DESCRIPTION
# Summary

ApplicationCommand server ID was being incorrectly serialized as 0 when no ID was given.

## Fixed
- `nil` server IDs are now stored correctly on ApplicationCommands
