### PR TITLE
fix(InteractionCreate): dont override user for interactions

### DIFF
--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -21,7 +21,7 @@ module Discordrb
       update_message: 7
     }.freeze
 
-    # @return [User] The user that initiated the interaction.
+    # @return [User, Member] The user that initiated the interaction.
     attr_reader :user
 
     # @return [Integer, nil] The ID of the server this interaction originates from.

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -321,7 +321,6 @@ module Discordrb::Events
     def initialize(data, bot)
       super
 
-      data['message']['author'] = data['member']
       @message = Discordrb::Interactions::Message.new(data['message'], bot, @interaction)
       @custom_id = data['data']['custom_id']
     end


### PR DESCRIPTION
# Summary

I'm not sure why, but I previously was overwriting the message author with the person who invoked the interaction.
This doesn't really make any sense to do so it's been removed.

---
## Changed
- `Interaction#user` is now documented to also return a Member object for guild based interactions.

## Fixed
- `InteractionCreateEvent` no longer overwrites the data from the interaction.
