### PR TITLE
Feat/interaction permissions

### DIFF
--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -63,7 +63,7 @@ module Discordrb
       @channel_id = data['channel_id']&.to_i
       @user = if data['member']
                 data['member']['guild_id'] = @server_id
-                Discordrb::Member.new(data['member'], nil, bot)
+                Discordrb::Member.new(data['member'], bot.servers[@server_id], bot)
               else
                 bot.ensure_user(data['user'])
               end

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -76,6 +76,7 @@ module Discordrb
       @boosting_since = data['premium_since'] ? Time.parse(data['premium_since']) : nil
       timeout_until = data['communication_disabled_until']
       @communication_disabled_until = timeout_until ? Time.parse(timeout_until) : nil
+      @permissions = Permissions.new(data['permissions']) if data['permissions']
     end
 
     # @return [Server] the server this member is on.

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -169,6 +169,11 @@ module Discordrb
     #   has_manage_channels = member.defined_permission?(:manage_channels)
     # @return [true, false] whether or not this user has the permission defined.
     def defined_permission?(action, channel = nil)
+      # For slash commands we may not have access to the server or role
+      # permissions. In this case we use the permissions given to us by the
+      # interaction.
+      return @permissions.__send__(action) if @server.nil? && @permissions
+
       # Get the permission the user's roles have
       role_permission = defined_role_permission?(action, channel)
 

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -171,8 +171,9 @@ module Discordrb
     def defined_permission?(action, channel = nil)
       # For slash commands we may not have access to the server or role
       # permissions. In this case we use the permissions given to us by the
-      # interaction.
-      return @permissions.__send__(action) if @server.nil? && @permissions
+      # interaction. If attempting to check against a specific channel the check
+      # is skipped.
+      return @permissions.__send__(action) if @permissions && channel.nil?
 
       # Get the permission the user's roles have
       role_permission = defined_role_permission?(action, channel)


### PR DESCRIPTION
# Summary

Provide server to member created by interactions when possible. Store permissions given by interactions and use them to compute a user's permissions if there is no access to the server.

---

## Changed
- Interaction event member objects now reference the origin server.

## Fixed
- Permissions use interaction permissions in absence of server access.
