### PR TITLE
Add sticker support

### DIFF
--- a/lib/discordrb/api/sticker.rb
+++ b/lib/discordrb/api/sticker.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 module Discordrb
   module API
+    # API calls for Sticker object
     module Sticker
       module_function
 
@@ -26,7 +29,7 @@ module Discordrb
           Authorization: token
         )
       end
-      
+
       # List Server Stickers
       # https://discord.com/developers/docs/resources/sticker#list-guild-stickers
       def server_stickers(token, server_id)
@@ -60,13 +63,11 @@ module Discordrb
       # https://discord.com/developers/docs/resources/sticker#create-guild-sticker
       def create(token, server_id, **attributes)
         reason = attributes.delete(:reason)
-        if attributes[:tags].respond_to?(:join)
-          attributes[:tags] = attributes[:tags].join(',')
-        end
+        attributes[:tags] = attributes[:tags].join(',') if attributes[:tags].respond_to?(:join)
         body = attributes.slice(:name, :description, :tags, :file)
 
         raise(ArgumentError, 'Invalid file argument') unless body[:file].is_a?(File)
-        
+
         Discordrb::API.request(
           :guild_stickers,
           server_id,
@@ -87,9 +88,7 @@ module Discordrb
       # https://discord.com/developers/docs/resources/sticker#modify-guild-sticker
       def modify(token, server_id, sticker_id, **attributes)
         reason = attributes.delete(:reason)
-        if attributes[:tags].respond_to?(:join)
-          attributes[:tags] = attributes[:tags].join(',')
-        end
+        attributes[:tags] = attributes[:tags].join(',') if attributes[:tags].respond_to?(:join)
         body = attributes.slice(:name, :description, :tags)
 
         Discordrb::API.request(

--- a/lib/discordrb/api/sticker.rb
+++ b/lib/discordrb/api/sticker.rb
@@ -56,10 +56,10 @@ module Discordrb
 
       # Create Server Sticker
       # @param attributes [Hash] Attributes contains the following keys:
-      # @param name [String] name of sticker
-      # @param description [String] description of sticker
-      # @param tags [Array<String>, String] array tags for the sticker, or comma separated string
-      # @param file [File] the sticker file. PNG, APNG or LOTTIE. max 500kb
+      # @option name [String] name of sticker
+      # @option description [String] description of sticker
+      # @option tags [Array<String>, String] array tags for the sticker, or comma separated string
+      # @option file [File] the sticker file. PNG, APNG or LOTTIE. max 500kb
       # https://discord.com/developers/docs/resources/sticker#create-guild-sticker
       def create(token, server_id, **attributes)
         reason = attributes.delete(:reason)
@@ -80,11 +80,12 @@ module Discordrb
       end
 
       # Modify Server Sticker
+      # @param server_id [String] Server ID.
       # @param sticker_id [String] Sticker ID.
       # @param attributes [Hash] Attributes contains the following keys:
-      # @param name [String] name of sticker
-      # @param description [String] description of sticker
-      # @param tags [Array<String>, String] array tags for the sticker, or comma separated string
+      # @option name [String] name of sticker
+      # @option description [String] description of sticker
+      # @option tags [Array<String>, String] array tags for the sticker, or comma separated string
       # https://discord.com/developers/docs/resources/sticker#modify-guild-sticker
       def modify(token, server_id, sticker_id, **attributes)
         reason = attributes.delete(:reason)

--- a/lib/discordrb/api/sticker.rb
+++ b/lib/discordrb/api/sticker.rb
@@ -10,7 +10,7 @@ module Discordrb
       # https://discord.com/developers/docs/resources/sticker#get-sticker
       def resolve(token, sticker_id)
         Discordrb::API.request(
-          :sticker,
+          :stickers_sid,
           sticker_id,
           :get,
           "#{Discordrb::API.api_base}/stickers/#{sticker_id}",
@@ -22,7 +22,7 @@ module Discordrb
       # https://discord.com/developers/docs/resources/sticker#list-nitro-sticker-packs
       def packs(token)
         Discordrb::API.request(
-          :nitro_sticker,
+          :sticker_packs,
           nil,
           :get,
           "#{Discordrb::API.api_base}/sticker-packs",
@@ -34,10 +34,10 @@ module Discordrb
       # https://discord.com/developers/docs/resources/sticker#list-guild-stickers
       def server_stickers(token, server_id)
         Discordrb::API.request(
-          :guild_stickers,
+          :guilds_sid_stickers,
           server_id,
           :get,
-          "#{Discordrb::API.api_base}/#{server_id}/stickers",
+          "#{Discordrb::API.api_base}/guilds/#{server_id}/stickers",
           Authorization: token
         )
       end
@@ -46,10 +46,10 @@ module Discordrb
       # https://discord.com/developers/docs/resources/sticker#get-guild-sticker
       def resolve_server_stickers(token, server_id, sticker_id)
         Discordrb::API.request(
-          :guild_stickers,
+          :guilds_sid_stickers_sid,
           server_id,
           :get,
-          "#{Discordrb::API.api_base}/#{server_id}/stickers/#{sticker_id}",
+          "#{Discordrb::API.api_base}/guilds/#{server_id}/stickers/#{sticker_id}",
           Authorization: token
         )
       end
@@ -69,10 +69,10 @@ module Discordrb
         raise(ArgumentError, 'Invalid file argument') unless body[:file].is_a?(File)
 
         Discordrb::API.request(
-          :guild_stickers,
+          :guilds_sid_stickers,
           server_id,
           :post,
-          "#{Discordrb::API.api_base}/#{server_id}/stickers",
+          "#{Discordrb::API.api_base}/guilds/#{server_id}/stickers",
           body,
           Authorization: token,
           'X-Audit-Log-Reason': reason
@@ -93,10 +93,10 @@ module Discordrb
         body = attributes.slice(:name, :description, :tags)
 
         Discordrb::API.request(
-          :guild_stickers,
+          :guilds_sid_stickers_sid,
           server_id,
           :patch,
-          "#{Discordrb::API.api_base}/#{server_id}/stickers/#{sticker_id}",
+          "#{Discordrb::API.api_base}/guilds/#{server_id}/stickers/#{sticker_id}",
           body,
           Authorization: token,
           'X-Audit-Log-Reason': reason
@@ -107,10 +107,10 @@ module Discordrb
       # https://discord.com/developers/docs/resources/sticker#delete-guild-sticker
       def delete(token, server_id, sticker_id, reason = nil)
         Discordrb::API.request(
-          :guild_stickers,
+          :guilds_sid_stickers_sid,
           server_id,
           :delete,
-          "#{Discordrb::API.api_base}/#{server_id}/stickers/#{sticker_id}",
+          "#{Discordrb::API.api_base}/guilds/#{server_id}/stickers/#{sticker_id}",
           Authorization: token,
           'X-Audit-Log-Reason': reason
         )

--- a/lib/discordrb/api/sticker.rb
+++ b/lib/discordrb/api/sticker.rb
@@ -1,0 +1,120 @@
+module Discordrb
+  module API
+    module Sticker
+      module_function
+
+      # Resolve a sticker
+      # https://discord.com/developers/docs/resources/sticker#get-sticker
+      def resolve(token, sticker_id)
+        Discordrb::API.request(
+          :sticker,
+          sticker_id,
+          :get,
+          "#{Discordrb::API.api_base}/stickers/#{sticker_id}",
+          Authorization: token
+        )
+      end
+
+      # List Nitro Stickers
+      # https://discord.com/developers/docs/resources/sticker#list-nitro-sticker-packs
+      def packs(token)
+        Discordrb::API.request(
+          :nitro_sticker,
+          nil,
+          :get,
+          "#{Discordrb::API.api_base}/sticker-packs",
+          Authorization: token
+        )
+      end
+      
+      # List Server Stickers
+      # https://discord.com/developers/docs/resources/sticker#list-guild-stickers
+      def server_stickers(token, server_id)
+        Discordrb::API.request(
+          :guild_stickers,
+          server_id,
+          :get,
+          "#{Discordrb::API.api_base}/#{server_id}/stickers",
+          Authorization: token
+        )
+      end
+
+      # List Server Stickers
+      # https://discord.com/developers/docs/resources/sticker#get-guild-sticker
+      def resolve_server_stickers(token, server_id, sticker_id)
+        Discordrb::API.request(
+          :guild_stickers,
+          server_id,
+          :get,
+          "#{Discordrb::API.api_base}/#{server_id}/stickers/#{sticker_id}",
+          Authorization: token
+        )
+      end
+
+      # Create Server Sticker
+      # @param attributes [Hash] Attributes contains the following keys:
+      # @param name [String] name of sticker
+      # @param description [String] description of sticker
+      # @param tags [Array<String>, String] array tags for the sticker, or comma separated string
+      # @param file [File] the sticker file. PNG, APNG or LOTTIE. max 500kb
+      # https://discord.com/developers/docs/resources/sticker#create-guild-sticker
+      def create(token, server_id, **attributes)
+        reason = attributes.delete(:reason)
+        if attributes[:tags].respond_to?(:join)
+          attributes[:tags] = attributes[:tags].join(',')
+        end
+        body = attributes.slice(:name, :description, :tags, :file)
+
+        raise(ArgumentError, 'Invalid file argument') unless body[:file].is_a?(File)
+        
+        Discordrb::API.request(
+          :guild_stickers,
+          server_id,
+          :post,
+          "#{Discordrb::API.api_base}/#{server_id}/stickers",
+          body,
+          Authorization: token,
+          'X-Audit-Log-Reason': reason
+        )
+      end
+
+      # Modify Server Sticker
+      # @param sticker_id [String] Sticker ID.
+      # @param attributes [Hash] Attributes contains the following keys:
+      # @param name [String] name of sticker
+      # @param description [String] description of sticker
+      # @param tags [Array<String>, String] array tags for the sticker, or comma separated string
+      # https://discord.com/developers/docs/resources/sticker#modify-guild-sticker
+      def modify(token, server_id, sticker_id, **attributes)
+        reason = attributes.delete(:reason)
+        if attributes[:tags].respond_to?(:join)
+          attributes[:tags] = attributes[:tags].join(',')
+        end
+        body = attributes.slice(:name, :description, :tags)
+
+        Discordrb::API.request(
+          :guild_stickers,
+          server_id,
+          :patch,
+          "#{Discordrb::API.api_base}/#{server_id}/stickers/#{sticker_id}",
+          body,
+          Authorization: token,
+          'X-Audit-Log-Reason': reason
+        )
+      end
+
+      # Delete Server Sticker
+      # https://discord.com/developers/docs/resources/sticker#delete-guild-sticker
+      def delete(token, server_id, sticker_id, reason = nil)
+        Discordrb::API.request(
+          :guild_stickers,
+          server_id,
+          :delete,
+          "#{Discordrb::API.api_base}/#{server_id}/stickers/#{sticker_id}",
+          Authorization: token,
+          'X-Audit-Log-Reason': reason
+        )
+      end
+    end
+  end
+end

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1495,6 +1495,36 @@ module Discordrb
           event = ServerEmojiUpdateEvent.new(server, old_emoji_data[e], new_emoji_data[e], self)
           raise_event(event)
         end
+      when :GUILD_STICKERS_UPDATE
+        server_id = data['guild_id'].to_i
+        server = @servers[server_id]
+        old_stickers_data = server.stickers.clone
+        update_guild_stickers(data)
+        new_stickers_data = server.stickers
+
+        created_ids = new_stickers_data.keys - old_stickers_data.keys
+        deleted_ids = old_stickers_data.keys - new_stickers_data.keys
+        updated_ids = old_stickers_data.select do |k, v|
+          new_stickers_data[k] && (v.name != new_stickers_data[k].name || v.roles != new_stickers_data[k].roles)
+        end.keys
+
+#         event = ServerStickerChangeEvent.new(server, data, self)
+#         raise_event(event)
+# 
+#         created_ids.each do |e|
+#           event = ServerStickerCreateEvent.new(server, new_stickers_data[e], self)
+#           raise_event(event)
+#         end
+# 
+#         deleted_ids.each do |e|
+#           event = ServerStickerDeleteEvent.new(server, old_stickers_data[e], self)
+#           raise_event(event)
+#         end
+# 
+#         updated_ids.each do |e|
+#           event = ServerStickerUpdateEvent.new(server, old_stickers_data[e], new_stickers_data[e], self)
+#           raise_event(event)
+#         end
       when :INTERACTION_CREATE
         event = InteractionCreateEvent.new(data, self)
         raise_event(event)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -210,6 +210,18 @@ module Discordrb
       emoji.find { |element| element.name == name }
     end
 
+    def stickers(id = nil)
+      stickers_hash = servers.values.map(&:stickers).reduce(&:merge)
+      if id
+        id = id.resolve_id
+        stickers_hash[id]
+      else
+        stickers_hash.values
+      end
+    end
+
+    alias all_stickers stickers
+
     # The bot's user profile. This special user object can be used
     # to edit user data like the current username (see {Profile#username=}).
     # @return [Profile] The bot's profile that can be used to edit data.
@@ -1118,6 +1130,13 @@ module Discordrb
       server.update_emoji_data(data)
     end
 
+    # Internal handler for GUILD_STICKERS_UPDATE
+    def update_guild_stickers(data)
+      server_id = data['guild_id'].to_i
+      server = @servers[server_id]
+      server.update_sticker_data(data)
+    end
+
     # Internal handler for MESSAGE_CREATE
     def create_message(data); end
 
@@ -1508,23 +1527,23 @@ module Discordrb
           new_stickers_data[k] && (v.name != new_stickers_data[k].name || v.roles != new_stickers_data[k].roles)
         end.keys
 
-#         event = ServerStickerChangeEvent.new(server, data, self)
-#         raise_event(event)
-# 
-#         created_ids.each do |e|
-#           event = ServerStickerCreateEvent.new(server, new_stickers_data[e], self)
-#           raise_event(event)
-#         end
-# 
-#         deleted_ids.each do |e|
-#           event = ServerStickerDeleteEvent.new(server, old_stickers_data[e], self)
-#           raise_event(event)
-#         end
-# 
-#         updated_ids.each do |e|
-#           event = ServerStickerUpdateEvent.new(server, old_stickers_data[e], new_stickers_data[e], self)
-#           raise_event(event)
-#         end
+        event = ServerStickerChangeEvent.new(server, data, self)
+        raise_event(event)
+
+        created_ids.each do |e|
+          event = ServerStickerCreateEvent.new(server, new_stickers_data[e], self)
+          raise_event(event)
+        end
+
+        deleted_ids.each do |e|
+          event = ServerStickerDeleteEvent.new(server, old_stickers_data[e], self)
+          raise_event(event)
+        end
+
+        updated_ids.each do |e|
+          event = ServerStickerUpdateEvent.new(server, old_stickers_data[e], new_stickers_data[e], self)
+          raise_event(event)
+        end
       when :INTERACTION_CREATE
         event = InteractionCreateEvent.new(data, self)
         raise_event(event)

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -423,6 +423,52 @@ module Discordrb
       register_event(ServerEmojiUpdateEvent, attributes, block)
     end
 
+    # This **event** is raised when an sticker or collection of stickers is created/deleted/updated.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Integer, Server] :server Matches the server.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [ServerStickerChangeEvent] The event that was raised.
+    # @return [ServerStickerChangeEventHandler] the event handler that was registered.
+    def server_sticker(attributes = {}, &block)
+      register_event(ServerStickerChangeEvent, attributes, block)
+    end
+
+    # This **event** is raised when a sticker is created.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Integer, Server] :server Matches the server.
+    # @option attributes [String] :name Matches the name of the sticker.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [ServerStickerCreateEvent] The event that was raised.
+    # @return [ServerStickerCreateEventHandler] the event handler that was registered.
+    def server_sticker_create(attributes = {}, &block)
+      register_event(ServerStickerCreateEvent, attributes, block)
+    end
+
+    # This **event** is raised when an sticker is deleted.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Integer, Server] :server Matches the server.
+    # @option attributes [String, Integer] :id Matches the ID of the sticker.
+    # @option attributes [String] :name Matches the name of the sticker.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [ServerStickerDeleteEvent] The event that was raised.
+    # @return [ServerStickerDeleteEventHandler] the event handler that was registered.
+    def server_sticker_delete(attributes = {}, &block)
+      register_event(ServerStickerDeleteEvent, attributes, block)
+    end
+
+    # This **event** is raised when an sticker is updated.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Integer, Server] :server Matches the server.
+    # @option attributes [String, Integer] :id Matches the ID of the sticker.
+    # @option attributes [String] :name Matches the name of the sticker.
+    # @option attributes [String] :old_name Matches the name of the sticker before the update.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [ServerStickerUpdateEvent] The event that was raised.
+    # @return [ServerStickerUpdateEventHandler] the event handler that was registered.
+    def server_sticker_update(attributes = {}, &block)
+      register_event(ServerStickerUpdateEvent, attributes, block)
+    end
+
     # This **event** is raised when a role is created.
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String] :name Matches the role name.

--- a/lib/discordrb/data/audit_logs.rb
+++ b/lib/discordrb/data/audit_logs.rb
@@ -44,7 +44,7 @@ module Discordrb
       82 => :integration_delete,
       90 => :sticker_create,
       91 => :sticker_update,
-      92 => :sticker_delete,
+      92 => :sticker_delete
     }.freeze
 
     # @!visibility private

--- a/lib/discordrb/data/audit_logs.rb
+++ b/lib/discordrb/data/audit_logs.rb
@@ -41,13 +41,17 @@ module Discordrb
       75 => :message_unpin,
       80 => :integration_create,
       81 => :integration_update,
-      82 => :integration_delete
+      82 => :integration_delete,
+      90 => :sticker_create,
+      91 => :sticker_update,
+      92 => :sticker_delete,
     }.freeze
 
     # @!visibility private
     CREATE_ACTIONS = %i[
       channel_create channel_overwrite_create member_ban_add role_create
       invite_create webhook_create emoji_create integration_create
+      sticker_create
     ].freeze
 
     # @!visibility private
@@ -55,13 +59,14 @@ module Discordrb
       channel_delete channel_overwrite_delete member_kick member_prune
       member_ban_remove role_delete invite_delete webhook_delete
       emoji_delete message_delete message_bulk_delete integration_delete
+      sticker_delete
     ].freeze
 
     # @!visibility private
     UPDATE_ACTIONS = %i[
       server_update channel_update channel_overwrite_update member_update
       member_role_update role_update invite_update webhook_update
-      emoji_update integration_update
+      emoji_update integration_update sticker_update
     ].freeze
 
     # @return [Hash<String => User>] the users included in the audit logs.

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -70,6 +70,10 @@ module Discordrb
     # @return [Array<Component>]
     attr_reader :components
 
+    # @return [Array<Sticker>] array of message sticker item objects
+    attr_reader :sticker_items
+    alias sticker_items stickers
+
     # The discriminator that webhook user accounts have.
     ZERO_DISCRIM = '0000'
 
@@ -155,6 +159,8 @@ module Discordrb
 
       @components = []
       @components = data['components'].map { |component_data| Components.from_data(component_data, @bot) } if data['components']
+
+      @sticker_items = data['sticker_items'].map { |sticker_item| Sticker.new(sticker_item, @bot) } || []
     end
 
     # Replies to this message with the specified content.

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -160,7 +160,10 @@ module Discordrb
       @components = []
       @components = data['components'].map { |component_data| Components.from_data(component_data, @bot) } if data['components']
 
-      @sticker_items = data['sticker_items'].map { |sticker_item| Sticker.new(sticker_item, @bot) } || []
+      sticker_data = data['sticker_items'] || []
+      @sticker_items = sticker_data.map do |sticker_item|
+        @bot.stickers(sticker_item['id']) || Sticker.new(sticker_item, @bot)
+      end
     end
 
     # Replies to this message with the specified content.

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -72,7 +72,7 @@ module Discordrb
 
     # @return [Array<Sticker>] array of message sticker item objects
     attr_reader :sticker_items
-    alias sticker_items stickers
+    alias stickers sticker_items
 
     # The discriminator that webhook user accounts have.
     ZERO_DISCRIM = '0000'

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -61,6 +61,10 @@ module Discordrb
     # @return [Integer] the boost level, 0 if no level.
     attr_reader :boost_level
 
+    # The server's custom stickers.
+    # @return [Array<Sticker>] array of stickers.
+    attr_reader :stickers
+
     # @!visibility private
     def initialize(data, bot)
       @bot = bot
@@ -843,6 +847,11 @@ module Discordrb
       @splash_id = new_data['splash'] || @splash_id
       @banner_id = new_data['banner'] || @banner_id
       @features = new_data['features'] ? new_data['features'].map { |element| element.downcase.to_sym } : @features || []
+
+      @stickers = new_data['stickers'].each_with_object({}) do |data, hash|
+        s = Sticker.new(data, @bot)
+        hash[s.id] = s
+      end
 
       process_channels(new_data['channels']) if new_data['channels']
       process_roles(new_data['roles']) if new_data['roles']

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -848,16 +848,12 @@ module Discordrb
       @banner_id = new_data['banner'] || @banner_id
       @features = new_data['features'] ? new_data['features'].map { |element| element.downcase.to_sym } : @features || []
 
-      @stickers = new_data['stickers'].each_with_object({}) do |data, hash|
-        s = Sticker.new(data, @bot)
-        hash[s.id] = s
-      end
-
       process_channels(new_data['channels']) if new_data['channels']
       process_roles(new_data['roles']) if new_data['roles']
       process_emoji(new_data['emojis']) if new_data['emojis']
       process_members(new_data['members']) if new_data['members']
       process_presences(new_data['presences']) if new_data['presences']
+      process_stickers(new_data['stickers']) if new_data['stickers']
       process_voice_states(new_data['voice_states']) if new_data['voice_states']
     end
 
@@ -883,6 +879,13 @@ module Discordrb
     def update_emoji_data(new_data)
       @emoji = {}
       process_emoji(new_data['emojis'])
+    end
+
+    # Updates the cached sticker data with new data
+    # @note For internal use only
+    # @!visibility private
+    def update_sticker_data(new_data)
+      process_stickers(new_data['stickers'])
     end
 
     # The inspect method is overwritten to give more useful output
@@ -927,6 +930,13 @@ module Discordrb
       emoji.each do |element|
         new_emoji = Emoji.new(element, @bot, self)
         @emoji[new_emoji.id] = new_emoji
+      end
+    end
+
+    def process_stickers(stickers)
+      @stickers = stickers.each_with_object({}) do |data, hash|
+        s = Sticker.new(data, @bot)
+        hash[s.id] = s
       end
     end
 

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -62,7 +62,7 @@ module Discordrb
     attr_reader :boost_level
 
     # The server's custom stickers.
-    # @return [Array<Sticker>] array of stickers.
+    # @return [Array<Sticker>, nil] array of stickers.
     attr_reader :stickers
 
     # @!visibility private

--- a/lib/discordrb/data/sticker.rb
+++ b/lib/discordrb/data/sticker.rb
@@ -5,33 +5,67 @@ module Discordrb
   class Sticker
     include IDObject
 
-    FORMAT_TYPE = {
+    # Map of sticker format types
+    # https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-format-types
+    FORMAT_TYPES = {
       png: 1,
       apng: 2,
       lottie: 3
     }.freeze
 
+    # Map of sticker types
+    # https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-types
     TYPES = {
       standard: 1,
       guild: 2
     }.freeze
 
-    attr_reader :pack_id, :name, :description, :tags, :type, :format_type, :available, :guild_id, :user, :sort_value
-    alias author user
+
+    # @return [Integer, nil] id of the pack the sticker is from. only for standard sticker type
+    attr_reader :pack_id
+
+    # @return [String] the name of the sticker
+    attr_reader :name
+
+    # @return [String, nil] the description of the sticker
+    attr_reader :description
+
+    # @return [String] the suggestion tags for the sticker
+    attr_reader :tags
+
+    # @return [Integer] the type of the sticker
+    attr_reader :type
+
+    # @return [Integer] the format type of the sticker
+    attr_reader :format_type
+
+    # @return [true, false, nil] whether this guild sticker can be used, may be false due to loss of Server Boosts.
+    attr_reader :available
+    alias_method :available?, :available
+
+    # @return [Integer, nil] id of the guild that owns this sticker
+    attr_reader :guild_id
+
+    # @return [User, nil] the user that uploaded the guild sticker
+    attr_reader :user
+    alias_method :author, :user
+
+    # @return [Integer, nil] the standard sticker's sort order within its pack
+    attr_reader :sort_value
 
     def initialize(data, bot)
-      data.symbolize_keys!
-      @id = data[:id].to_i
-      @pack_id = data[:pack_id].to_i
-      @name = data[:name]
-      @description = data[:description]
-      @tags = data[:tags].split(',')
-      @type = TYPES.index(data[:type].to_i)
-      @format_type = FORMAT_TYPE.index(data[:format_type].to_i)
-      @available = data[:available]
-      @guild_id = data[:guild_id]
-      @user = bot.users.find { |user| user.id == data[:user]['id'].to_i }
-      @sort_value = data[:sort_value]
+      @id = data['id'].to_i
+      @pack_id = data['pack_id']&.to_i
+      @name = data['name']
+      @description = data['description'] || false
+      @tags = data['tags']
+      @type = data['type'].to_i
+      @format_type = data['format_type'].to_i
+      @available = data['available']
+      @guild_id = data['guild_id']
+
+      @user = bot.ensure_user(data['user']) if data.key?('user')
+      @sort_value = data['sort_value']&.to_i
     end
 
     def update(**attributes)
@@ -39,8 +73,8 @@ module Discordrb
       Discordrb::API::Sticker.modify(@bot.token, guild_id, id, data)
     end
 
-    def destroy(reason)
-      Discordrb::API::Sticker.destroy(@bot.token, @guild_id, id, reason)
+    def delete(reason)
+      Discordrb::API::Sticker.delete(@bot.token, @guild_id, id, reason)
     end
 
     # The inspect method is overwritten to give more useful output

--- a/lib/discordrb/data/sticker.rb
+++ b/lib/discordrb/data/sticker.rb
@@ -44,6 +44,16 @@ module Discordrb
       @sort_value = data[:sort_value]
     end
 
+
+    def update(**attributes)
+      data = attributes.slice(:name, :description, :tags, :reason)
+      Discordrb::API::Sticker.modify(@bot.token, guild_id, id, data)
+    end
+
+    def destroy(reason)
+      Discordrb::API::Sticker.destroy(@bot.token, @guild_id, id, reason)
+    end
+
     # The inspect method is overwritten to give more useful output
     def inspect
       "<Sticker name=\"#{name}\" id=#{id} format_type=#{format_type} user=#{@user}>"

--- a/lib/discordrb/data/sticker.rb
+++ b/lib/discordrb/data/sticker.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Discordrb
+  class Sticker
+    include IDObject
+
+    FORMAT_TYPE = {
+      png: 1,
+      apng: 2,
+      lottie: 3
+    }.freeze
+
+    TYPES = {
+      standard: 1,
+      guild: 2
+    }.freeze
+
+    attr_reader :pack_id
+    attr_reader :name
+    attr_reader :description
+    attr_reader :tags
+    attr_reader :type
+    attr_reader :format_type
+    attr_reader :available
+    attr_reader :guild_id
+
+    attr_reader :user
+    alias user author
+
+    attr_reader :sort_value
+
+    def initialize(data, bot)
+      data.symbolize_keys!
+      @id = data[:id].to_i
+      @pack_id = data[:pack_id].to_i
+      @name = data[:name]
+      @description = data[:description]
+      @tags = data[:tags].split(',')
+      @type = TYPES.index(data[:type].to_i)
+      @format_type = FORMAT_TYPE.index(data[:format_type].to_i)
+      @available = data[:available]
+      @guild_id = data[:guild_id]
+      @user = bot.users.find { |user| user.id == data[:user]['id'].to_i }
+      @sort_value = data[:sort_value]
+    end
+
+    # The inspect method is overwritten to give more useful output
+    def inspect
+      "<Sticker name=\"#{name}\" id=#{id} format_type=#{format_type} user=#{@user}>"
+    end
+
+    private
+
+    def parse_format_type(type)
+      raise ArgumentError, 'Invalid sticker format type specified' unless FORMAT_TYPE.keys.include?(type)
+
+      FORMAT_TYPE[type]
+    end
+  end
+end

--- a/lib/discordrb/data/sticker.rb
+++ b/lib/discordrb/data/sticker.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Discordrb
+  # A Discord Sticker
   class Sticker
     include IDObject
 
@@ -15,19 +16,8 @@ module Discordrb
       guild: 2
     }.freeze
 
-    attr_reader :pack_id
-    attr_reader :name
-    attr_reader :description
-    attr_reader :tags
-    attr_reader :type
-    attr_reader :format_type
-    attr_reader :available
-    attr_reader :guild_id
-
-    attr_reader :user
-    alias user author
-
-    attr_reader :sort_value
+    attr_reader :pack_id, :name, :description, :tags, :type, :format_type, :available, :guild_id, :user, :sort_value
+    alias author user
 
     def initialize(data, bot)
       data.symbolize_keys!
@@ -44,7 +34,6 @@ module Discordrb
       @sort_value = data[:sort_value]
     end
 
-
     def update(**attributes)
       data = attributes.slice(:name, :description, :tags, :reason)
       Discordrb::API::Sticker.modify(@bot.token, guild_id, id, data)
@@ -57,14 +46,6 @@ module Discordrb
     # The inspect method is overwritten to give more useful output
     def inspect
       "<Sticker name=\"#{name}\" id=#{id} format_type=#{format_type} user=#{@user}>"
-    end
-
-    private
-
-    def parse_format_type(type)
-      raise ArgumentError, 'Invalid sticker format type specified' unless FORMAT_TYPE.keys.include?(type)
-
-      FORMAT_TYPE[type]
     end
   end
 end

--- a/lib/discordrb/events/guilds.rb
+++ b/lib/discordrb/events/guilds.rb
@@ -191,6 +191,7 @@ module Discordrb::Events
     end
   end
 
+  # Sticker is changed
   class ServerStickerChangeEvent < ServerEvent
     # @return [Server] the server in question.
     attr_reader :server


### PR DESCRIPTION
# Summary
Add Sticker Support.

---

## Added
- Sticker API methods
- `#stickers` bot method, to access all stickers, and to find by ID
- handle `GUILD_STICKERS_UPDATE` intent, and trigger relevant events
- created Container methods to support handling Sticker events
- added Audit Log support
- added `sticker_items` support to `Message` (optional safe)
- added stickers to `Server`, and also allowed the data to be updated.
