### PR TITLE
Use Docker executor in CI for deploying docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,12 @@ jobs:
           at: /tmp/workspace
       - run:
           name: Clone docs
-          command: git clone $CIRCLE_REPOSITORY_URL -b gh-pages .
+          command: |
+            mkdir -p ~/.ssh
+
+            echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
+
+            git clone $CIRCLE_REPOSITORY_URL -b gh-pages .
       - add_ssh_keys:
           fingerprints:
             - "9a:4c:50:94:23:46:81:74:41:97:87:04:4e:59:4b:4e"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,12 @@ jobs:
             - docs
 
   pages:
-    machine: true
+    docker:
+      - image: alpine
     steps:
+      - run:
+          name: Install OS packages
+          command: apk add git openssh-client-default
       - attach_workspace:
           at: /tmp/workspace
       - run:


### PR DESCRIPTION
# Summary

As noted in #136 CircleCI is deprecating its 14.04/16.04 images. This PR resolves #136 by switching to a Docker executor in the docs deploy step, where we were previously using the default `machine` executor.

---

## Changed

- Switch to Docker executor in CI for docs deploy step