### PR TITLE
Dependency Bumps, Test Matrix Update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - setup-env
       - run:
           name: Run Rubocop
-          command: bundle exec rubocop -P
+          command: bundle exec rubocop
 
   yard:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,15 @@ jobs:
           name: Run RSpec
           command: bundle exec rspec
 
+  test_ruby_31:
+    docker:
+      - image: ruby:3.1-alpine
+    steps:
+      - setup-env
+      - run:
+          name: Run RSpec
+          command: bundle exec rspec
+
   rubocop:
     docker:
       - image: ruby:2.6-alpine
@@ -114,6 +123,7 @@ workflows:
       - test_ruby_26
       - test_ruby_27
       - test_ruby_30
+      - test_ruby_31
       - rubocop
       - yard
   deploy:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Using [Bundler](https://bundler.io/#getting-started), you can add discordrb to y
 
 And then install via `bundle install`.
 
-Run the [ping example](https://github.com/shardlab/discordrb/blob/master/examples/ping.rb) to verify that the installation works (make sure to replace the token and client ID in there with your bots'!):
+Run the [ping example](https://github.com/shardlab/discordrb/blob/main/examples/ping.rb) to verify that the installation works (make sure to replace the token and client ID in there with your bots'!):
 
 To run the bot while using bundler:
 
@@ -109,7 +109,7 @@ bot.run
 
 This bot responds to every "Ping!" with a "Pong!".
 
-See [additional examples here](https://github.com/shardlab/discordrb/tree/master/examples).
+See [additional examples here](https://github.com/shardlab/discordrb/tree/main/examples).
 
 You can find examples of projects that use discordrb by [searching for the discordrb topic on GitHub](https://github.com/topics/discordrb).
 

--- a/discordrb-webhooks.gemspec
+++ b/discordrb-webhooks.gemspec
@@ -23,4 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rest-client', '>= 2.0.0'
 
   spec.required_ruby_version = '>= 2.6'
+  spec.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }
 end

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.metadata = {
-    'changelog_uri' => 'https://github.com/shardlab/discordrb/blob/master/CHANGELOG.md',
+    'changelog_uri' => 'https://github.com/shardlab/discordrb/blob/main/CHANGELOG.md',
     'rubygems_mfa_required' => 'true'
   }
   spec.require_paths = ['lib']

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'redcarpet', '~> 3.5.0' # YARD markdown formatting
-  spec.add_development_dependency 'rspec', '~> 3.10.0'
+  spec.add_development_dependency 'rspec', '~> 3.11.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
   spec.add_development_dependency 'rubocop', '~> 1.25.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.metadata = {
-    'changelog_uri' => 'https://github.com/shardlab/discordrb/blob/master/CHANGELOG.md'
+    'changelog_uri' => 'https://github.com/shardlab/discordrb/blob/master/CHANGELOG.md',
+    'rubygems_mfa_required' => 'true'
   }
   spec.require_paths = ['lib']
 
@@ -37,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.5.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.10.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 1.22.0'
+  spec.add_development_dependency 'rubocop', '~> 1.24.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.5.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.10.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 1.24.0'
+  spec.add_development_dependency 'rubocop', '~> 1.25.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.5.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.11.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 1.25.0'
+  spec.add_development_dependency 'rubocop', '~> 1.26.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.5.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.11.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 1.26.0'
+  spec.add_development_dependency 'rubocop', '~> 1.27.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.5.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.10.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 1.21.0'
+  spec.add_development_dependency 'rubocop', '~> 1.22.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'

--- a/lib/discordrb/data/user.rb
+++ b/lib/discordrb/data/user.rb
@@ -161,7 +161,7 @@ module Discordrb
 
     # @!visibility private
     def process_client_status(client_status)
-      (client_status || {}).map { |k, v| [k.to_sym, v.to_sym] }.to_h
+      (client_status || {}).to_h { |k, v| [k.to_sym, v.to_sym] }
     end
 
     # @!method offline?

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -212,7 +212,7 @@ module Discordrb::Events
     end
 
     def transform_options_hash(hash)
-      hash.map { |opt| [opt['name'], opt['options'] || opt['value']] }.to_h
+      hash.to_h { |opt| [opt['name'], opt['options'] || opt['value']] }
     end
   end
 

--- a/spec/overwrite_spec.rb
+++ b/spec/overwrite_spec.rb
@@ -29,7 +29,7 @@ describe Discordrb::Overwrite do
     context 'when object is a User type' do
       let(:user_types) { [Discordrb::User, Discordrb::Member, Discordrb::Recipient, Discordrb::Profile] }
       let(:users) do
-        user_types.collect { |k| [k, instance_double(k)] }.to_h
+        user_types.to_h { |k| [k, instance_double(k)] }
       end
 
       before do


### PR DESCRIPTION
# Summary

Ruby 2.6 EOLs at the end of March, so this should be the last of my RuboCop/dependency/general hedge-trimming PRs to target 2.6. Future PRs of this nature will be from my Ruby 2.7-based branch.

Changes are minimal here; the main change that should be noted is the [opt-in to requiring MFA for privileged operations on RubyGems](https://guides.rubygems.org/mfa-requirement-opt-in/).

---

## Changed

- Added Ruby 3.1 to the CI test matrix.
- Updated dependencies (RuboCop, RSpec) and applied new RuboCop suggestions.
- Added MFA requirement for RubyGems.