### PR TITLE
feat: add server avatar

### DIFF
--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -541,6 +541,7 @@ module Discordrb::API::Server
     )
   end
 
+  # Make an avatar URL from the guild, user and avatar IDs
   def avatar_url(guild_id, user_id, avatar_id, format = nil)
     format ||= if avatar_id.start_with?('a_')
                  'gif'

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -540,4 +540,13 @@ module Discordrb::API::Server
       Authorization: token
     )
   end
+
+  def avatar_url(guild_id, user_id, avatar_id, format = nil)
+    format ||= if avatar_id.start_with?('a_')
+                 'gif'
+               else
+                 'webp'
+               end
+    "#{Discordrb::API.cdn_url}/guilds/#{guild_id}/users/#{user_id}/avatars/#{avatar_id}.#{format}"
+  end
 end

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -24,8 +24,8 @@ module Discordrb
     alias_method :timeout, :communication_disabled_until
 
     # @!attribute [r] avatar_id
-    #   @return [String, nil] the ID of this user's current avatar, can be used to generate an avatar URL.
-    #   @see User#avatar_url
+    #   @return [String, nil] the ID of this member's current avatar, can be used to generate an avatar URL.
+    #   @see Member#avatar_url
     def avatar_id
       @avatar || @user.avatar_id
     end
@@ -302,7 +302,7 @@ module Discordrb
       nickname || username
     end
 
-    # (BoSee User#avatar_url)
+    # (See User#avatar_url)
     def avatar_url(format = nil)
       return @user.avatar_url(format) unless @avatar_id
 

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -22,6 +22,13 @@ module Discordrb
     # @return [Time] When the user's timeout will expire.
     attr_reader :communication_disabled_until
     alias_method :timeout, :communication_disabled_until
+
+    # @!attribute [r] avatar_id
+    #   @return [String, nil] the ID of this user's current avatar, can be used to generate an avatar URL.
+    #   @see User#avatar_url
+    def avatar_id
+      @avatar || @user.avatar_id
+    end
   end
 
   # A member is a user on a server. It differs from regular users in that it has roles, voice statuses and things like
@@ -77,6 +84,7 @@ module Discordrb
       timeout_until = data['communication_disabled_until']
       @communication_disabled_until = timeout_until ? Time.parse(timeout_until) : nil
       @permissions = Permissions.new(data['permissions']) if data['permissions']
+      @avatar_id = data['avatar']
     end
 
     # @return [Server] the server this member is on.
@@ -294,6 +302,13 @@ module Discordrb
       nickname || username
     end
 
+    # (BoSee User#avatar_url)
+    def avatar_url(format = nil)
+      return @user.avatar_url(format) unless @avatar_id
+
+      API::Server.avatar_url(@server_id, @user.id, @avatar_id, format)
+    end
+
     # Update this member's roles
     # @note For internal use only.
     # @!visibility private
@@ -335,6 +350,7 @@ module Discordrb
       update_nick(data['nick']) if data.key?('nick')
       @mute = data['mute'] if data.key?('mute')
       @deaf = data['deaf'] if data.key?('deaf')
+      @avatar_id = data['avatar'] if data.key?('avatar')
 
       @joined_at = Time.parse(data['joined_at']) if data['joined_at']
       timeout_until = data['communication_disabled_until']


### PR DESCRIPTION
# Summary

Add server avatar support.

Closes #145

---


## Added
- `MemberAttributes#avatar_id`
- `Member#avatar`

## Changed
- `MemberAttributes#avatar_id` no longer delegates to `User` directly
- `Member#avatar` no longer delegated to `User` directly

## Deprecated

## Removed

## Fixed
