### PR TITLE
feat: add modals

### DIFF
--- a/examples/modals.rb
+++ b/examples/modals.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'discordrb'
+require 'securerandom'
+
+bot = Discordrb::Bot.new(token: ENV['DISCORDRB_TOKEN'])
+bot.register_application_command(:modal_test, 'Test out a spiffy modal', server_id: ENV['DISCORDRB_SERVER_ID'])
+bot.register_application_command(:modal_await_test, 'Test out the await style', server_id: ENV['DISCORDRB_SERVER_ID'])
+
+bot.application_command :modal_test do |event|
+  event.show_modal(title: 'Test modal', custom_id: 'test1234') do |modal|
+    modal.row do |row|
+      row.text_input(
+        style: :paragraph,
+        custom_id: 'input',
+        label: 'Test input',
+        required: true,
+        placeholder: 'Type something to submit.'
+      )
+    end
+  end
+end
+
+bot.application_command :modal_await_test do |event|
+  id = SecureRandom.uuid
+  event.show_modal(title: "I'm waiting for you", custom_id: id) do |modal|
+    modal.row do |row|
+      row.text_input(
+        style: :paragraph,
+        custom_id: 'input',
+        label: 'Test input',
+        required: true,
+        placeholder: 'Type something to submit.'
+      )
+    end
+  end
+
+  start_time = Time.now
+  modal_event = bot.add_await!(Discordrb::Events::ModalSubmitEvent, custom_id: id, timeout: (60 * 10))
+
+  if event.nil?
+    modal_event.respond(content: "Time's up!", ephemeral: true)
+  else
+    modal_event.respond(content: "Thanks for submitting your modal. I waited #{Time.now - start_time} seconds")
+  end
+end
+
+bot.modal_submit custom_id: 'test1234' do |event|
+  event.respond(content: "Thanks for submitting your modal. You sent #{event.value('input').chars.count} characters.")
+end
+
+bot.run

--- a/lib/discordrb/api/interaction.rb
+++ b/lib/discordrb/api/interaction.rb
@@ -19,6 +19,21 @@ module Discordrb::API::Interaction
     )
   end
 
+  # Create a response that results in a modal.
+  # https://discord.com/developers/docs/interactions/slash-commands#create-interaction-response
+  def create_interaction_modal_response(interaction_token, interaction_id, custom_id, title, components)
+    data = { custom_id: custom_id, title: title, components: components.to_a }.compact
+
+    Discordrb::API.request(
+      :interactions_iid_token_callback,
+      interaction_id,
+      :post,
+      "#{Discordrb::API.api_base}/interactions/#{interaction_id}/#{interaction_token}/callback",
+      { type: 9, data: data }.to_json,
+      content_type: :json
+    )
+  end
+
   # Get the original response to an interaction.
   # https://discord.com/developers/docs/interactions/slash-commands#get-original-interaction-response
   def get_original_interaction_response(interaction_token, application_id)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1565,6 +1565,10 @@ module Discordrb
 
             raise_event(event)
           end
+        when Interaction::TYPES[:modal_submit]
+
+          event = ModalSubmitEvent.new(data, self)
+          raise_event(event)
         end
       when :WEBHOOKS_UPDATE
         event = WebhookUpdateEvent.new(data, self)

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -528,8 +528,8 @@ module Discordrb
     # @option attributes [Integer, Symbol, String] :type The interaction type, can be the integer value or the name
     #   of the key in {Discordrb::Interaction::TYPES}.
     # @option attributes [String, Integer, Server, nil] :server The server where this event was created. `nil` for DM channels.
-    # @option attribtues [String, Integer, Channel] :channel The channel where this event was created.
-    # @option attribtues [String, Integer, User] :user The user that triggered this event.
+    # @option attributes [String, Integer, Channel] :channel The channel where this event was created.
+    # @option attributes [String, Integer, User] :user The user that triggered this event.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [InteractionCreateEvent] The event that was raised.
     # @return [InteractionCreateEventHandler] The event handler that was registered.
@@ -574,6 +574,19 @@ module Discordrb
     # @return [SelectMenuEventHandler] The event handler that was registered.
     def select_menu(attributes = {}, &block)
       register_event(SelectMenuEvent, attributes, block)
+    end
+
+    # This **event** is raised whenever a modal is submitted.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Regexp] :custom_id A custom_id to match against.
+    # @option attributes [String, Integer, Message] :message The message to filter for.
+    # @option attributes [String, Integer, Server, nil] :server The server where this event was created. `nil` for DM channels.
+    # @option attributes [String, Integer, Channel] :channel The channel where this event was created.
+    # @option attributes [String, Integer, User] :user The user that triggered this event.    # @yield The block is executed when the event is raised.
+    # @yieldparam event [ModalSubmitEvent] The event that was raised.
+    # @return [ModalSubmitEventHandler] The event handler that was registered.
+    def modal_submit(attributes = {}, &block)
+      register_event(ModalSubmitEvent, attributes, block)
     end
 
     # This **event** is raised for every dispatch received over the gateway, whether supported by discordrb or not.
@@ -681,6 +694,7 @@ module Discordrb
 
     include Discordrb::Events
 
+    # @return [EventHandler]
     def register_event(clazz, attributes, block)
       handler = EventContainer.handler_class(clazz).new(attributes, block)
 

--- a/lib/discordrb/data/component.rb
+++ b/lib/discordrb/data/component.rb
@@ -16,6 +16,8 @@ module Discordrb
         Button.new(data, bot)
       when Webhooks::View::COMPONENT_TYPES[:select_menu]
         SelectMenu.new(data, bot)
+      when Webhooks::Modal::COMPONENT_TYPES[:text_input]
+        TextInput.new(data, bot)
       end
     end
 
@@ -41,6 +43,12 @@ module Discordrb
       # @return [Array<Button>]
       def buttons
         select { |component| component.is_a? Button }
+      end
+
+      # Get all buttons in this row
+      # @return [Array<Button>]
+      def text_inputs
+        select { |component| component.is_a? TextInput }
       end
 
       # @!visibility private
@@ -158,6 +166,63 @@ module Discordrb
         @custom_id = data['custom_id']
         @emoji = Emoji.new(data['emoji'], @bot) if data['emoji']
         @options = data['options'].map { |opt| Option.new(opt) }
+      end
+    end
+
+    # Text input component for use in modals. Can be either a line (`short`), or a multi line (`paragraph`) block.
+    class TextInput
+      # Single line text input
+      SHORT = 1
+      # Multi-line text input
+      PARAGRAPH = 2
+
+      # @return [String]
+      attr_reader :custom_id
+
+      # @return [Symbol]
+      attr_reader :style
+
+      # @return [String]
+      attr_reader :label
+
+      # @return [Integer, nil]
+      attr_reader :min_length
+
+      # @return [Integer, nil]
+      attr_reader :max_length
+
+      # @return [true, false]
+      attr_reader :required
+
+      # @return [String, nil]
+      attr_reader :value
+
+      # @return [String, nil]
+      attr_reader :placeholder
+
+      # @!visibility private
+      def initialize(data, bot)
+        @bot = bot
+        @style = data['style'] == SHORT ? :short : :paragraph
+        @label = data['label']
+        @min_length = data['min_length']
+        @max_length = data['max_length']
+        @required = data['required']
+        @value = data['value']
+        @placeholder = data['placeholder']
+        @custom_id = data['custom_id']
+      end
+
+      def short?
+        @style == :short
+      end
+
+      def paragraph?
+        @style == :paragraph
+      end
+
+      def required?
+        @required
       end
     end
   end

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'discordrb/webhooks'
+
 module Discordrb
   # Base class for interaction objects.
   class Interaction
@@ -8,7 +10,8 @@ module Discordrb
     TYPES = {
       ping: 1,
       command: 2,
-      component: 3
+      component: 3,
+      modal_submit: 5
     }.freeze
 
     # Interaction response types.
@@ -18,7 +21,8 @@ module Discordrb
       channel_message: 4,
       deferred_message: 5,
       deferred_update: 6,
-      update_message: 7
+      update_message: 7,
+      modal: 9
     }.freeze
 
     # @return [User, Member] The user that initiated the interaction.
@@ -50,6 +54,9 @@ module Discordrb
     # @return [Hash] The interaction data.
     attr_reader :data
 
+    # @return [Array<ActionRow>]
+    attr_reader :components
+
     # @!visibility private
     def initialize(data, bot)
       @bot = bot
@@ -69,6 +76,7 @@ module Discordrb
               end
       @token = data['token']
       @version = data['version']
+      @components = @data['components']&.map { |component| Components.from_data(component, @bot) }&.compact || []
     end
 
     # Respond to the creation of this interaction. An interaction must be responded to or deferred,
@@ -120,6 +128,23 @@ module Discordrb
     # Defer an update to an interaction. This is can only currently used by Button interactions.
     def defer_update
       Discordrb::API::Interaction.create_interaction_response(@token, @id, CALLBACK_TYPES[:deferred_update])
+    end
+
+    # Create a modal as a response.
+    # @param title [String] The title of the modal being shown.
+    # @param custom_id [String] The custom_id used to identify the modal and store data.
+    # @param components [Array<Component, Hash>, nil] An array of components. These can be defined through the block as well.
+    # @yieldparam [Discordrb::Webhooks::Modal] A builder for the modal's components.
+    def show_modal(title:, custom_id:, components: nil)
+      if block_given?
+        modal_builder = Discordrb::Webhooks::Modal.new
+        yield modal_builder
+
+        components = modal_builder.to_a
+      end
+
+      Discordrb::API::Interaction.create_interaction_modal_response(@token, @id, custom_id, title, components.to_a)
+      nil
     end
 
     # Respond to the creation of this interaction. An interaction must be responded to or deferred,
@@ -253,6 +278,19 @@ module Discordrb
           return button if button.custom_id == @data['custom_id']
         end
       end
+    end
+
+    # @return [Array<TextInput>]
+    def text_inputs
+      @components&.select { |component| component.is_a? TextInput } | []
+    end
+
+    # @return [TextInput, Button, SelectMenu]
+    def get_component(custom_id)
+      top_level = @components.flat_map(&:components) || []
+      message_level = @message&.components&.flat_map { |r| r.components } || []
+      components = top_level.concat(message_level)
+      components.find { |component| component.custom_id == custom_id }
     end
 
     private

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -55,6 +55,11 @@ module Discordrb::Events
       )
     end
 
+    # (see Interaction#show_modal)
+    def show_modal(title:, custom_id:, components: nil, &block)
+      @interaction.show_modal(title: title, custom_id: custom_id, components: components, &block)
+    end
+
     # (see Interaction#edit_response)
     def edit_response(content: nil, embeds: nil, allowed_mentions: nil, components: nil, &block)
       @interaction.edit_response(content: content, embeds: embeds, allowed_mentions: allowed_mentions, components: components, &block)
@@ -83,6 +88,11 @@ module Discordrb::Events
     # (see Interaction#defer_update)
     def defer_update
       @interaction.defer_update
+    end
+
+    # (see Interaction#get_component)
+    def get_component(custom_id)
+      @interaction.get_component(custom_id)
     end
   end
 
@@ -314,14 +324,14 @@ module Discordrb::Events
     # @return [String] User provided data for this button.
     attr_reader :custom_id
 
-    # @return [Interactions::Message] The message the button originates from.
+    # @return [Interactions::Message, nil] The message the button originates from.
     attr_reader :message
 
     # @!visibility private
     def initialize(data, bot)
       super
 
-      @message = Discordrb::Interactions::Message.new(data['message'], bot, @interaction)
+      @message = Discordrb::Interactions::Message.new(data['message'], bot, @interaction) if data['message']
       @custom_id = data['data']['custom_id']
     end
   end
@@ -355,8 +365,20 @@ module Discordrb::Events
   end
 
   # An event for when a user interacts with a button component.
-
   class ButtonEvent < ComponentEvent
+  end
+
+  # An event for when a user submits a modal.
+  class ModalSubmitEvent < ComponentEvent
+    # @return [Array<TextInputComponent>]
+    attr_reader :components
+
+    # Get the value of an input passed to the modal.
+    # @param custom_id [String] The custom ID of the component to look for.
+    # @return [String, nil]
+    def value(custom_id)
+      get_component(custom_id)&.value
+    end
   end
 
   # Event handler for a Button interaction event.
@@ -378,5 +400,9 @@ module Discordrb::Events
 
   # Event handler for a select menu component.
   class SelectMenuEventHandler < ComponentEventHandler
+  end
+
+  # Event handler for a modal submission.
+  class ModalSubmitEventHandler < ComponentEventHandler
   end
 end

--- a/lib/discordrb/webhooks.rb
+++ b/lib/discordrb/webhooks.rb
@@ -5,6 +5,7 @@ require 'discordrb/webhooks/embeds'
 require 'discordrb/webhooks/client'
 require 'discordrb/webhooks/builder'
 require 'discordrb/webhooks/view'
+require 'discordrb/webhooks/modal'
 
 module Discordrb
   # Webhook client

--- a/lib/discordrb/webhooks/modal.rb
+++ b/lib/discordrb/webhooks/modal.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Modal component builder.
+class Discordrb::Webhooks::Modal
+  # A mapping of names to types of components usable in a modal.
+  COMPONENT_TYPES = {
+    action_row: 1,
+    text_input: 4
+  }.freeze
+
+  # This builder is used when constructing an ActionRow. All current components must be within an action row, but this can
+  # change in the future. A message can have 5 action rows, each action row can hold a weight of 5. Buttons have a weight of 1,
+  # and dropdowns have a weight of 5.
+  class RowBuilder
+    # A mapping of short names to types of input styles. `short` is a single line where `paragraph` is a block.
+    TEXT_INPUT_STYLES = {
+      short: 1,
+      paragraph: 2
+    }.freeze
+
+    # @!visibility private
+    def initialize
+      @components = []
+    end
+
+    # Add a text input to this action row.
+    # @param style [Symbol, Integer] The text input's style type. See {TEXT_INPUT_STYLES}
+    # @param custom_id [String] Custom IDs are used to pass state to the events that are raised from interactions.
+    #  There is a limit of 100 characters to each custom_id.
+    # @param label [String, nil] The text label for the field.
+    # @param min_length [Integer, nil] The minimum input length for a text input, min 0, max 4000.
+    # @param max_length [Integer, nil] The maximum input length for a text input, min 1, max 4000.
+    # @param required [true, false, nil] Whether this component is required to be filled, default true.
+    # @param value [String, nil] A pre-filled value for this component, max 4000 characters.
+    # @param placeholder [String, nil] Custom placeholder text if the input is empty, max 100 characters
+    def text_input(style:, custom_id:, label: nil, min_length: nil, max_length: nil, required: nil, value: nil, placeholder: nil)
+      style = TEXT_INPUT_STYLES[style] || style
+
+      @components << {
+        style: style,
+        custom_id: custom_id,
+        type: COMPONENT_TYPES[:text_input],
+        label: label,
+        min_length: min_length,
+        max_length: max_length,
+        required: required,
+        value: value,
+        placeholder: placeholder
+      }
+    end
+
+    # @!visibility private
+    def to_h
+      { type: COMPONENT_TYPES[:action_row], components: @components }
+    end
+  end
+
+  attr_reader :rows
+
+  def initialize
+    @rows = []
+
+    yield self if block_given?
+  end
+
+  # Add a new ActionRow to the view
+  # @yieldparam [RowBuilder]
+  def row
+    new_row = RowBuilder.new
+
+    yield new_row
+
+    @rows << new_row
+  end
+
+  # @!visibility private
+  def to_a
+    @rows.map(&:to_h)
+  end
+end


### PR DESCRIPTION
# Summary

Add modal functionality.

---

## Added
- Discordrb::Webhooks::Modal - Modal builder for interactions
- Discordrb::EventContainer#modal_submit - Register a handler for modal submit
- Discordrb::Events::ModalSubmitEvent
- Discordrb::Events::ModalSubmitEventHandler
- Discordrb::API::Interactions.create_modal_interaction_response
- Discordrb::Interaction#get_component - Retrieve a component from an interaction via custom_id
