### PR TITLE
Add new channel types.

### DIFF
--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -20,6 +20,9 @@ module Discordrb
       news_thread: 10,
       public_thread: 11,
       private_thread: 12
+      stage_voice: 13,
+      directory: 14,
+      forum: 15
     }.freeze
 
     # @return [String] this channel's name.

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -19,7 +19,7 @@ module Discordrb
       store: 6,
       news_thread: 10,
       public_thread: 11,
-      private_thread: 12
+      private_thread: 12,
       stage_voice: 13,
       directory: 14,
       forum: 15


### PR DESCRIPTION
# Summary
There are three channel types not currently represented in the gem, although I guess it may not be worth adding these values if we don't support their corresponding functionality in the gem?

Also, not sure if forum (15) should be included since it's in active development.

See https://discord.com/developers/docs/resources/channel#channel-object-channel-types

---

## Added

- Added the newest channel types to the TYPES hash in Discordrb::Channel:
  - `GUILD_STAGE_VOICE` as `stage_voice`
  - `GUILD_DIRECTORY` as `directory`
  - `GUILD_FORUM` as `forum`
