### PR TITLE
Add to_message to Interactions::Message

### DIFF
--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -725,7 +725,7 @@ module Discordrb
         Discordrb::Message.new(@data, @bot)
       end
 
-      alias_method :to_message, :message
+      alias_method :message, :to_message
 
       # @!visibility private
       def inspect

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -642,6 +642,7 @@ module Discordrb
 
       # @!visibility private
       def initialize(data, bot, interaction)
+        @data = data
         @bot = bot
         @interaction = interaction
         @content = data['content']
@@ -718,6 +719,13 @@ module Discordrb
       def edit(content: nil, embeds: nil, allowed_mentions: nil, components: nil, &block)
         @interaction.edit_message(@id, content: content, embeds: embeds, allowed_mentions: allowed_mentions, components: components, &block)
       end
+
+      # @return [Discordrb::Message]
+      def to_message
+        Discordrb::Message.new(@data, @bot)
+      end
+
+      alias_method :to_m, :to_message
 
       # @!visibility private
       def inspect

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -725,6 +725,8 @@ module Discordrb
         Discordrb::Message.new(@data, @bot)
       end
 
+      alias_method :to_message, :message
+
       # @!visibility private
       def inspect
         "<Interaction::Message content=#{@content.inspect} embeds=#{@embeds.inspect} channel_id=#{@channel_id} server_id=#{@server_id} author=#{@author.inspect}>"

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -725,8 +725,6 @@ module Discordrb
         Discordrb::Message.new(@data, @bot)
       end
 
-      alias_method :to_m, :to_message
-
       # @!visibility private
       def inspect
         "<Interaction::Message content=#{@content.inspect} embeds=#{@embeds.inspect} channel_id=#{@channel_id} server_id=#{@server_id} author=#{@author.inspect}>"

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -396,5 +396,7 @@ module Discordrb
     def to_message
       self
     end
+
+    alias_method :to_message, :message
   end
 end

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -396,7 +396,5 @@ module Discordrb
     def to_message
       self
     end
-
-    alias_method :to_m, :to_message
   end
 end

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -390,5 +390,13 @@ module Discordrb
 
       results.flatten.compact
     end
+
+    # to_message -> self or message
+    # @return [Discordrb::Message]
+    def to_message
+      self
+    end
+
+    alias_method :to_m, :to_message
   end
 end

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -397,6 +397,6 @@ module Discordrb
       self
     end
 
-    alias_method :to_message, :message
+    alias_method :message, :to_message
   end
 end


### PR DESCRIPTION
# Summary

This would create a shortcut to using all of the methods that are available for Discordrb::Message

## Added

  - Added Interactions::Message#to_message (2c87b416a89efd2c705fbe20bd81128fe22dfa6d)
  - Added to_message to Discordrb::Message (0970ff27c2a70b26e0092af3fafff107651aae86)
  
 Adding to_message to Discordrb::Message was in inspiration of Ruby's String#to_s method.