### PR TITLE
Ruby 2.6 EOL and Dependency Chores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,17 +27,6 @@ commands:
             - ./vendor/bundle
 
 jobs:
-  test_ruby_26:
-    docker:
-      - image: ruby:2.6-alpine
-    steps:
-      - setup-env
-      - run:
-          name: Run RSpec
-          command: bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml
-      - store_test_results:
-          path: ~/rspec
-
   test_ruby_27:
     docker:
       - image: ruby:2.7-alpine
@@ -68,11 +57,11 @@ jobs:
       - setup-env
       - run:
           name: Run RSpec
-          command: bundle exec rspec
+          command: bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml
 
   rubocop:
     docker:
-      - image: ruby:2.6-alpine
+      - image: ruby:2.7-alpine
     steps:
       - setup-env
       - run:
@@ -81,7 +70,7 @@ jobs:
 
   yard:
     docker:
-      - image: ruby:2.6-alpine
+      - image: ruby:2.7-alpine
     steps:
       - setup-env
       - attach_workspace:
@@ -136,7 +125,6 @@ jobs:
 workflows:
   test:
     jobs:
-      - test_ruby_26
       - test_ruby_27
       - test_ruby_30
       - test_ruby_31

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ inherit_mode:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 # Disable line length checks
 Layout/LineLength:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you enjoy using the library, consider getting involved with the community to 
 
 ## Dependencies
 
-* Ruby >= 2.6 supported
+* Ruby >= 2.7 supported
 * An installed build system for native extensions (on Windows, make sure you download the "Ruby+Devkit" version of [RubyInstaller](https://rubyinstaller.org/downloads/))
 
 ### Voice dependencies

--- a/discordrb-webhooks.gemspec
+++ b/discordrb-webhooks.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client', '>= 2.0.0'
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
   spec.metadata = {
     'rubygems_mfa_required' => 'true'
   }

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.11.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.5.1'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 1.28.2'
+  spec.add_development_dependency 'rubocop', '~> 1.30.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.11.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.5.1'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 1.30.0'
+  spec.add_development_dependency 'rubocop', '~> 1.36.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'discordrb-webhooks', '~> 3.4.2'
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -37,9 +37,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'redcarpet', '~> 3.5.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.11.0'
-  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'
+  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.5.1'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 1.27.0'
+  spec.add_development_dependency 'rubocop', '~> 1.28.2'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'
   spec.add_development_dependency 'simplecov', '~> 0.21.0'

--- a/examples/slash_commands.rb
+++ b/examples/slash_commands.rb
@@ -2,7 +2,7 @@
 
 require 'discordrb'
 
-bot = Discordrb::Bot.new(token: ENV['SLASH_COMMAND_BOT_TOKEN'], intents: [:server_messages])
+bot = Discordrb::Bot.new(token: ENV.fetch('SLASH_COMMAND_BOT_TOKEN', nil), intents: [:server_messages])
 
 # We need to register our application commands separately from the handlers with a special DSL.
 # This example uses server specific commands so that they appear immediately for testing,
@@ -11,7 +11,7 @@ bot = Discordrb::Bot.new(token: ENV['SLASH_COMMAND_BOT_TOKEN'], intents: [:serve
 #
 # You may want to have a separate script for registering your commands so you don't need to do this every
 # time you start your bot.
-bot.register_application_command(:example, 'Example commands', server_id: ENV['SLASH_COMMAND_BOT_SERVER_ID']) do |cmd|
+bot.register_application_command(:example, 'Example commands', server_id: ENV.fetch('SLASH_COMMAND_BOT_SERVER_ID', nil)) do |cmd|
   cmd.subcommand_group(:fun, 'Fun things!') do |group|
     group.subcommand('8ball', 'Shake the magic 8 ball') do |sub|
       sub.string('question', 'Ask a question to receive wisdom', required: true)
@@ -29,7 +29,7 @@ bot.register_application_command(:example, 'Example commands', server_id: ENV['S
   end
 end
 
-bot.register_application_command(:spongecase, 'Are you mocking me?', server_id: ENV['SLASH_COMMAND_BOT_SERVER_ID']) do |cmd|
+bot.register_application_command(:spongecase, 'Are you mocking me?', server_id: ENV.fetch('SLASH_COMMAND_BOT_SERVER_ID', nil)) do |cmd|
   cmd.string('message', 'Message to spongecase')
   cmd.boolean('with_picture', 'Show the mocking sponge?')
 end

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -10,7 +10,7 @@ module Discordrb
   Thread.current[:discordrb_name] = 'main'
 
   # The default debug logger used by discordrb.
-  LOGGER = Logger.new(ENV['DISCORDRB_FANCY_LOG'])
+  LOGGER = Logger.new(ENV.fetch('DISCORDRB_FANCY_LOG', false))
 
   # The Unix timestamp Discord IDs are based on
   DISCORD_EPOCH = 1_420_070_400_000

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -609,7 +609,7 @@ module Discordrb
       if text?
         server.online_members(include_idle: true).select { |u| u.can_read_messages? self }
       elsif voice?
-        server.voice_states.map { |id, voice_state| server.member(id) if !voice_state.voice_channel.nil? && voice_state.voice_channel.id == @id }.compact
+        server.voice_states.filter_map { |id, voice_state| server.member(id) if !voice_state.voice_channel.nil? && voice_state.voice_channel.id == @id }
       end
     end
 

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -127,7 +127,7 @@ module Discordrb
     #   permissions.defined_permissions #=> [:create_instant_invite, :administrator]
     # @return [Array<Symbol>] the permissions
     def defined_permissions
-      FLAGS.collect { |value, name| (@bits & (1 << value)).positive? ? name : nil }.compact
+      FLAGS.filter_map { |value, name| (@bits & (1 << value)).positive? ? name : nil }
     end
 
     # Comparison based on permission bits


### PR DESCRIPTION
# Summary

Ruby 2.6 is EOL. This PR bumps our minimum Ruby support to >= 2.7 and performs all the usual dependency chores (version bumps, application of new cops). Also fixed a small issue with CI test result storage introduced because #140 didn't integrate the changes from #95. 

---

## Changed

- Dropped support for Ruby 2.6.

## Fixed

- CI test results for Ruby 3.1 are stored like the other versions.
- Applied new cops.