### PR TITLE
feat: add role icons

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -228,7 +228,7 @@ module Discordrb::API
   # @format ['webp', 'png', 'jpeg']
   # @return [String]
   def role_icon_url(role_id, icon_hash, format = 'webp')
-    "#{cdn_url}/role-icons/#{icon_hash}.#{format}"
+    "#{cdn_url}/role-icons/#{role_id}/#{icon_hash}.#{format}"
   end
 
   # Login to the server

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -225,7 +225,7 @@ module Discordrb::API
 
   # @param role_id [String, Integer]
   # @param icon_hash [String]
-  # @format ['webp', 'png', 'jpeg']
+  # @param format ['webp', 'png', 'jpeg']
   # @return [String]
   def role_icon_url(role_id, icon_hash, format = 'webp')
     "#{cdn_url}/role-icons/#{role_id}/#{icon_hash}.#{format}"

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -223,6 +223,14 @@ module Discordrb::API
     "#{cdn_url}/app-assets/#{application_id}/achievements/#{achievement_id}/icons/#{icon_hash}.#{format}"
   end
 
+  # @param role_id [String, Integer]
+  # @param icon_hash [String]
+  # @format ['webp', 'png', 'jpeg']
+  # @return [String]
+  def role_icon_url(role_id, icon_hash, format = 'webp')
+    "#{cdn_url}/role-icons/#{icon_hash}.#{format}"
+  end
+
   # Login to the server
   def login(email, password)
     request(

--- a/lib/discordrb/data/role.rb
+++ b/lib/discordrb/data/role.rb
@@ -32,6 +32,9 @@ module Discordrb
     # @return [Integer] the position of this role in the hierarchy
     attr_reader :position
 
+    # @return [String, nil] The icon hash for this role.
+    attr_reader :icon
+
     # This class is used internally as a wrapper to a Role object that allows easy writing of permission data.
     class RoleWriter
       # @!visibility private
@@ -67,6 +70,8 @@ module Discordrb
       @managed = data['managed']
 
       @colour = ColourRGB.new(data['color'])
+
+      @icon = data['icon']
     end
 
     # @return [String] a string that will mention this role, if it is mentionable.
@@ -92,6 +97,7 @@ module Discordrb
       @colour = other.colour
       @position = other.position
       @managed = other.managed
+      @icon = other.icon
     end
 
     # Updates the data cache from a hash containing data
@@ -126,6 +132,20 @@ module Discordrb
     # @param colour [ColourRGB] The new colour
     def colour=(colour)
       update_role_data(colour: colour)
+    end
+
+    # Upload a role icon for servers with the ROLE_ICONS feature.
+    # @param file [File]
+    def icon=(file)
+      update_role_data(icon: file)
+    end
+
+    # @param format ['webp', 'png', 'jpeg']
+    # @return [String] URL to the icon on Discord's CDN.
+    def icon_url(format = 'webp')
+      return nil unless @icon
+
+      Discordrb::API.role_icon_url(@id, @icon, format)
     end
 
     alias_method :color=, :colour=
@@ -184,7 +204,9 @@ module Discordrb
                               (new_data[:colour] || @colour).combined,
                               new_data[:hoist].nil? ? @hoist : new_data[:hoist],
                               new_data[:mentionable].nil? ? @mentionable : new_data[:mentionable],
-                              new_data[:permissions] || @permissions.bits)
+                              new_data[:permissions] || @permissions.bits,
+                              nil,
+                              new_data.key?(:icon) ? new_data[:icon] : :undef)
       update_data(new_data)
     end
   end


### PR DESCRIPTION
# Summary

Add role icons

---


## Added
- Discordrb::API::role_icon_url
- Discordrb::Role#icon
- Discordrb::Role#icon_url
- Discordrb::Role#icon=

## Changed
- Added icon parameter to role update

## Deprecated

## Removed

## Fixed
