### PR TITLE
Update channel.rb

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -123,7 +123,7 @@ module Discordrb::API::Channel
       channel_id,
       :patch,
       "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}",
-      { content: message, mentions: mentions, embed: embed, components: components }.to_json,
+      { content: message, mentions: mentions, embed: embed, components: components&.to_a }.to_json,
       Authorization: token,
       content_type: :json
     )


### PR DESCRIPTION
When writing a message to channel with components, the `send_message` method converts `components` to an array. The`edit_message` method does not. This sends something like `"components":"#<Discordrb::Components::View:0x000055589734d998>"}` in the actual API rather than the expected array.

# Summary

<!---
  Describe the general goal of your pull request here:

  - Include details about any issues you encountered that inspired
  the pull request, such as bugs or missing features.

  - If adding or changing features, include a small example that showcases
  the new behavior.

  - Reference any related issues or pull requests.

  Stuck or need help? Join the Discord! https://discord.gg/cyK3Hjm
--->

---

<!---
  List each individual change you made to the library here in the appropriate
  section in short, bulleted sentences.

  This will aid in reviewing your pull request, and for adding it to the
  changelog later.

  You may remove sections that have no items if you want.
--->

## Added

## Changed

## Deprecated

## Removed

## Fixed
