### PR TITLE
Added support of deleting all reactions for emoji in Channel

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -224,6 +224,20 @@ module Discordrb::API::Channel
     )
   end
 
+  # Deletes all the reactions for a given emoji on a message
+  # https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji
+  def delete_all_emoji_reactions(token, channel_id, message_id, emoji)
+    emoji = URI.encode_www_form_component(emoji) unless emoji.ascii_only?
+
+    Discordrb::API.request(
+      :channels_cid_messages_mid_reactions_emoji,
+      channel_id,
+      :delete,
+      "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}",
+      Authorization: token
+    )
+  end
+
   # Update a channels permission for a role or member
   # https://discord.com/developers/docs/resources/channel#edit-channel-permissions
   def update_permission(token, channel_id, overwrite_id, allow, deny, type, reason = nil)

--- a/spec/api/channel_spec.rb
+++ b/spec/api/channel_spec.rb
@@ -52,4 +52,27 @@ describe Discordrb::API::Channel do
       Discordrb::API::Channel.get_reactions(token, channel_id, message_id, 'test', before_id, after_id, nil)
     end
   end
+
+  describe '.delete_all_emoji_reactions' do
+    let(:message_id) { double('message_id', to_s: 'message_id') }
+    let(:emoji) { '\u{1F525}' }
+
+    before do
+      allow(Discordrb::API).to receive(:request)
+        .with(anything, channel_id, :delete, kind_of(String), any_args)
+    end
+
+    it 'sends requests' do
+      expect(Discordrb::API).to receive(:request)
+        .with(
+          anything,
+          channel_id,
+          :delete,
+          "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/%F0%9F%94%A5",
+          any_args
+        )
+
+      Discordrb::API::Channel.delete_all_emoji_reactions(token, channel_id, message_id, emoji)
+    end
+  end
 end


### PR DESCRIPTION
# Summary

Added support of method https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji in `Discordrb::API::Channel`. Fixed #158 

## Added

Added `Discordrb::API::Channel.delete_all_emoji_reactions` method. Added basic test case.

## Changed

## Deprecated

## Removed

## Fixed
