### PR TITLE
Fixed Discordrb::API::Channel.delete_all_emoji_reactions spec

### DIFF
--- a/spec/api/channel_spec.rb
+++ b/spec/api/channel_spec.rb
@@ -68,7 +68,7 @@ describe Discordrb::API::Channel do
           anything,
           channel_id,
           :delete,
-          "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/%F0%9F%94%A5",
+          "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}",
           any_args
         )
 


### PR DESCRIPTION
# Summary

Fixed failed test after merging #161. Retested in playground with my server, rubocop & rspec - 👌 

## Added

## Changed

## Deprecated

## Removed

## Fixed

Updated `emoji` attributes in test case.
