### PR TITLE
Fixed compatibility of full_messages for Ruby 3.0

### DIFF
--- a/lib/discordrb/errors.rb
+++ b/lib/discordrb/errors.rb
@@ -45,7 +45,7 @@ module Discordrb
       end
 
       # @return [String] A message including the message and flattened errors.
-      def full_message
+      def full_message(*)
         error_list = @errors.collect { |err| "\t- #{err}" }
 
         "#{@message}\n#{error_list.join("\n")}"


### PR DESCRIPTION
# Summary

Fixed compatibility of `Discordrb::Errors::CodeError#full_message` with IRB for Ruby > 3.0. Fixed #163 

---

## Added

## Changed

Added unused args to `#full_messages`.

## Deprecated

## Removed

## Fixed
