### PR TITLE
Improve help message for disallowed intents

### DIFF
--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -807,9 +807,12 @@ module Discordrb
 
         if e.code == 4014
           LOGGER.error(<<~ERROR)
-            You attempted to identify with privileged intents that your bot is not authorized to use
-            Please enable the privileged intents on the bot page of your application on the discord developer page.
-            Read more here https://discord.com/developers/docs/topics/gateway#privileged-intents
+
+            Your bot attempted to identify with privileged intents that it is not authorized to use.
+            You must either enable these for your application on the Discord Developer Portal, or
+            set the intents: parameter of Bot#initialize to request only the intents that you need.
+            Read more here: https://discord.com/developers/docs/topics/gateway#privileged-intents
+                            https://drb.shardlab.dev/main/Discordrb/Bot.html#initialize-instance_method
           ERROR
         end
 


### PR DESCRIPTION
# Summary
Fixes #168

## Changed
Improved the message printed after attempting to identify with disallowed intents. The new message informs the user that they can either enable all privileged intents on the Portal or request only the ones they need.
