### PR TITLE
'Inline' `Bot#gateway_check` assertion

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -897,7 +897,11 @@ module Discordrb
 
     # Throws a useful exception if there's currently no gateway connection.
     def gateway_check
-      raise "A gateway connection is necessary to call this method! You'll have to do it inside any event (e.g. `ready`) or after `bot.run :async`." unless connected?
+      return if connected?
+
+      raise RuntimeError,
+            "A gateway connection is necessary to call this method! You'll have to do it inside any event (e.g. `ready`) or after `bot.run :async`.",
+            caller
     end
 
     # Logs a warning if there are servers which are still unavailable.


### PR DESCRIPTION
# Summary
`Bot#gateway_check` is a common method used to assert that a gateway connection is active, called as the first step in many bot methods. By using the three argument form of `raise`, along with `caller`, we can hide the `gateway_check` call from the traceback, making the source of the error clearer.


With this change, after calling `bot.servers`:
```red
/home/biqqles/Code/discordrb/lib/discordrb/bot.rb:180:in `servers': A gateway connection is necessary to call this method! You'll have to do it inside any event (e.g. `ready`) or after `bot.run :async`. (RuntimeError)
	from /home/biqqles/Code/discordrb/lib/test.rb:5:in `<main>
```

Before:
```red
/home/biqqles/Code/discordrb/lib/discordrb/bot.rb:902:in `gateway_check': A gateway connection is necessary to call this method! You'll have to do it inside any event (e.g. `ready`) or after `bot.run :async`. (RuntimeError)
	from /home/biqqles/Code/discordrb/lib/discordrb/bot.rb:180:in `servers'
	from /home/biqqles/Code/discordrb/lib/test.rb:5:in `<main>'
```

## Changed
- `Bot#gateway_check` is now hidden from the traceback it causes