### PR TITLE
Modification of the maximum value of rate_limit_per_user

### DIFF
--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -345,9 +345,9 @@ module Discordrb
 
     # Sets the amount of time (in seconds) users have to wait in between sending messages.
     # @param rate [Integer]
-    # @raise [ArgumentError] if value isn't between 0 and 120
+    # @raise [ArgumentError] if value isn't between 0 and 21600
     def rate_limit_per_user=(rate)
-      raise ArgumentError, 'rate_limit_per_user must be between 0 and 120' unless rate.between?(0, 120)
+      raise ArgumentError, 'rate_limit_per_user must be between 0 and 21600' unless rate.between?(0, 21600)
 
       update_channel_data(rate_limit_per_user: rate)
     end

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -347,7 +347,7 @@ module Discordrb
     # @param rate [Integer]
     # @raise [ArgumentError] if value isn't between 0 and 21600
     def rate_limit_per_user=(rate)
-      raise ArgumentError, 'rate_limit_per_user must be between 0 and 21600' unless rate.between?(0, 21600)
+      raise ArgumentError, 'rate_limit_per_user must be between 0 and 21600' unless rate.between?(0, 21_600)
 
       update_channel_data(rate_limit_per_user: rate)
     end

--- a/spec/api/channel_spec.rb
+++ b/spec/api/channel_spec.rb
@@ -55,7 +55,7 @@ describe Discordrb::API::Channel do
 
   describe '.delete_all_emoji_reactions' do
     let(:message_id) { double('message_id', to_s: 'message_id') }
-    let(:emoji) { '\u{1F525}' }
+    let(:emoji) { "\u{1F525}" }
 
     before do
       allow(Discordrb::API).to receive(:request)


### PR DESCRIPTION
In order to match the official API, the maximum value is increased from 120 to 21600

Issue #175