### PR TITLE
Support multipart file uploads for interaction responses via webhook builder

### DIFF
--- a/lib/discordrb/api/interaction.rb
+++ b/lib/discordrb/api/interaction.rb
@@ -32,8 +32,8 @@ module Discordrb::API::Interaction
 
   # Edit the original response to an interaction.
   # https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
-  def edit_original_interaction_response(interaction_token, application_id, content = nil, embeds = nil, allowed_mentions = nil, components = nil)
-    Discordrb::API::Webhook.token_edit_message(interaction_token, application_id, '@original', content, embeds, allowed_mentions, components)
+  def edit_original_interaction_response(interaction_token, application_id, content = nil, embeds = nil, allowed_mentions = nil, components = nil, file = nil)
+    Discordrb::API::Webhook.token_edit_message(interaction_token, application_id, '@original', content, embeds, allowed_mentions, components, file)
   end
 
   # Delete the original response to an interaction.

--- a/lib/discordrb/api/interaction.rb
+++ b/lib/discordrb/api/interaction.rb
@@ -6,16 +6,21 @@ module Discordrb::API::Interaction
 
   # Respond to an interaction.
   # https://discord.com/developers/docs/interactions/slash-commands#create-interaction-response
-  def create_interaction_response(interaction_token, interaction_id, type, content = nil, tts = nil, embeds = nil, allowed_mentions = nil, flags = nil, components = nil)
+  def create_interaction_response(interaction_token, interaction_id, type, content = nil, tts = nil, embeds = nil, allowed_mentions = nil, flags = nil, components = nil, file = nil)
     data = { tts: tts, content: content, embeds: embeds, allowed_mentions: allowed_mentions, flags: flags, components: components }.compact
+
+    payload = { type: type, data: data }.to_json
+    payload = { file: file, payload_json: payload } if file
+
+    headers = { content_type: :json } unless file
 
     Discordrb::API.request(
       :interactions_iid_token_callback,
       interaction_id,
       :post,
       "#{Discordrb::API.api_base}/interactions/#{interaction_id}/#{interaction_token}/callback",
-      { type: type, data: data }.to_json,
-      content_type: :json
+      payload,
+      headers
     )
   end
 

--- a/lib/discordrb/api/webhook.rb
+++ b/lib/discordrb/api/webhook.rb
@@ -116,14 +116,21 @@ module Discordrb::API::Webhook
 
   # Edit a webhook message via webhook token
   # https://discord.com/developers/docs/resources/webhook#edit-webhook-message
-  def token_edit_message(webhook_token, webhook_id, message_id, content = nil, embeds = nil, allowed_mentions = nil, components = nil)
+  def token_edit_message(webhook_token, webhook_id, message_id, content = nil, embeds = nil, allowed_mentions = nil, components = nil, file = nil)
+    data = { content: content, embeds: embeds, allowed_mentions: allowed_mentions, components: components }
+
+    payload = data.to_json
+    payload = { file: file, payload_json: payload } if file
+
+    headers = { content_type: :json } unless file
+
     Discordrb::API.request(
       :webhooks_wid_messages,
       webhook_id,
       :patch,
       "#{Discordrb::API.api_base}/webhooks/#{webhook_id}/#{webhook_token}/messages/#{message_id}",
-      { content: content, embeds: embeds, allowed_mentions: allowed_mentions, components: components }.to_json,
-      content_type: :json
+      payload,
+      headers
     )
   end
 

--- a/lib/discordrb/api/webhook.rb
+++ b/lib/discordrb/api/webhook.rb
@@ -31,11 +31,9 @@ module Discordrb::API::Webhook
   # https://discord.com/developers/docs/resources/webhook#execute-webhook
   def token_execute_webhook(webhook_token, webhook_id, wait = false, content = nil, username = nil, avatar_url = nil, tts = nil, file = nil, embeds = nil, allowed_mentions = nil, flags = nil, components = nil)
     body = { content: content, username: username, avatar_url: avatar_url, tts: tts, embeds: embeds&.map(&:to_hash),  allowed_mentions: allowed_mentions, flags: flags, components: components }
-    body = if file
-             { file: file, payload_json: body.to_json }
-           else
-             body.to_json
-           end
+
+    payload = body.to_json
+    payload = { file: file, payload_json: payload } if file
 
     headers = { content_type: :json } unless file
 
@@ -44,7 +42,7 @@ module Discordrb::API::Webhook
       webhook_id,
       :post,
       "#{Discordrb::API.api_base}/webhooks/#{webhook_id}/#{webhook_token}?wait=#{wait}",
-      body,
+      payload,
       headers
     )
   end

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -222,7 +222,7 @@ module Discordrb
       data = builder.to_payload_hash
 
       resp = Discordrb::API::Webhook.token_edit_message(
-        @token, @application_id, message.resolve_id, data[:content], data[:embeds], data[:allowed_mentions], components.to_a
+        @token, @application_id, message.resolve_id, data[:content], data[:embeds], data[:allowed_mentions], components.to_a, data[:file]
       )
       Interactions::Message.new(JSON.parse(resp), @bot, @interaction)
     end

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -95,7 +95,7 @@ module Discordrb
       yield(builder, view) if block_given?
 
       components ||= view
-      data = builder.to_json_hash
+      data = builder.to_payload_hash
 
       Discordrb::API::Interaction.create_interaction_response(@token, @id, CALLBACK_TYPES[:channel_message], data[:content], tts, data[:embeds], data[:allowed_mentions], flags, components.to_a)
 
@@ -145,7 +145,7 @@ module Discordrb
       yield(builder, view) if block_given?
 
       components ||= view
-      data = builder.to_json_hash
+      data = builder.to_payload_hash
 
       Discordrb::API::Interaction.create_interaction_response(@token, @id, CALLBACK_TYPES[:update_message], data[:content], tts, data[:embeds], data[:allowed_mentions], flags, components.to_a)
 
@@ -170,7 +170,7 @@ module Discordrb
       yield(builder, view) if block_given?
 
       components ||= view
-      data = builder.to_json_hash
+      data = builder.to_payload_hash
       resp = Discordrb::API::Interaction.edit_original_interaction_response(@token, @application_id, data[:content], data[:embeds], data[:allowed_mentions], components.to_a)
 
       Interactions::Message.new(JSON.parse(resp), @bot, @interaction)
@@ -198,7 +198,7 @@ module Discordrb
       yield builder, view if block_given?
 
       components ||= view
-      data = builder.to_json_hash
+      data = builder.to_payload_hash
 
       resp = Discordrb::API::Webhook.token_execute_webhook(
         @token, @application_id, true, data[:content], nil, nil, tts, nil, data[:embeds], data[:allowed_mentions], flags, components.to_a
@@ -219,7 +219,7 @@ module Discordrb
       yield builder, view if block_given?
 
       components ||= view
-      data = builder.to_json_hash
+      data = builder.to_payload_hash
 
       resp = Discordrb::API::Webhook.token_edit_message(
         @token, @application_id, message.resolve_id, data[:content], data[:embeds], data[:allowed_mentions], components.to_a

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -201,7 +201,7 @@ module Discordrb
       data = builder.to_payload_hash
 
       resp = Discordrb::API::Webhook.token_execute_webhook(
-        @token, @application_id, true, data[:content], nil, nil, tts, nil, data[:embeds], data[:allowed_mentions], flags, components.to_a
+        @token, @application_id, true, data[:content], nil, nil, tts, data[:file], data[:embeds], data[:allowed_mentions], flags, components.to_a
       )
       Interactions::Message.new(JSON.parse(resp), @bot, @interaction)
     end

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -171,7 +171,7 @@ module Discordrb
 
       components ||= view
       data = builder.to_payload_hash
-      resp = Discordrb::API::Interaction.edit_original_interaction_response(@token, @application_id, data[:content], data[:embeds], data[:allowed_mentions], components.to_a)
+      resp = Discordrb::API::Interaction.edit_original_interaction_response(@token, @application_id, data[:content], data[:embeds], data[:allowed_mentions], components.to_a, data[:file])
 
       Interactions::Message.new(JSON.parse(resp), @bot, @interaction)
     end

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -122,7 +122,7 @@ module Discordrb
       Discordrb::API::Interaction.create_interaction_response(@token, @id, CALLBACK_TYPES[:deferred_update])
     end
 
-    # Respond to the creation of this interaction. An interaction must be responded to or deferred,
+    # For components, edit the message the component was attached to.
     # The response may be modified with {Interaction#edit_response} or deleted with {Interaction#delete_response}.
     # Further messages can be sent with {Interaction#send_message}.
     # @param content [String] The content of the message.
@@ -147,7 +147,7 @@ module Discordrb
       components ||= view
       data = builder.to_payload_hash
 
-      Discordrb::API::Interaction.create_interaction_response(@token, @id, CALLBACK_TYPES[:update_message], data[:content], tts, data[:embeds], data[:allowed_mentions], flags, components.to_a)
+      Discordrb::API::Interaction.create_interaction_response(@token, @id, CALLBACK_TYPES[:update_message], data[:content], tts, data[:embeds], data[:allowed_mentions], flags, components.to_a, data[:file])
 
       return unless wait
 

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -97,7 +97,7 @@ module Discordrb
       components ||= view
       data = builder.to_payload_hash
 
-      Discordrb::API::Interaction.create_interaction_response(@token, @id, CALLBACK_TYPES[:channel_message], data[:content], tts, data[:embeds], data[:allowed_mentions], flags, components.to_a)
+      Discordrb::API::Interaction.create_interaction_response(@token, @id, CALLBACK_TYPES[:channel_message], data[:content], tts, data[:embeds], data[:allowed_mentions], flags, components.to_a, data[:file])
 
       return unless wait
 

--- a/lib/discordrb/webhooks/builder.rb
+++ b/lib/discordrb/webhooks/builder.rb
@@ -98,5 +98,13 @@ module Discordrb::Webhooks
         allowed_mentions: @allowed_mentions&.to_hash
       }
     end
+
+    # @return [Hash] a hash representation of the created message, for either json or multipart format depending if a
+    # file is present in the builder
+    def to_payload_hash
+      return to_multipart_hash if @file
+
+      to_json_hash
+    end
   end
 end

--- a/spec/api/channel_spec.rb
+++ b/spec/api/channel_spec.rb
@@ -55,7 +55,7 @@ describe Discordrb::API::Channel do
 
   describe '.delete_all_emoji_reactions' do
     let(:message_id) { double('message_id', to_s: 'message_id') }
-    let(:emoji) { '\u{1F525}' }
+    let(:emoji) { "\u{1F525}" }
 
     before do
       allow(Discordrb::API).to receive(:request)

--- a/spec/api/interaction_spec.rb
+++ b/spec/api/interaction_spec.rb
@@ -26,7 +26,7 @@ describe Discordrb::API::Interaction do
         interaction_token,
         interaction_id,
         callback_type,
-        'hello world'
+        content
       )
     end
 
@@ -44,7 +44,7 @@ describe Discordrb::API::Interaction do
         interaction_token,
         interaction_id,
         callback_type,
-        'hello world',
+        content,
         nil, # tts
         nil, # embeds
         nil, # allowed_mentions

--- a/spec/api/interaction_spec.rb
+++ b/spec/api/interaction_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'discordrb'
+
+describe Discordrb::API::Interaction do
+  let(:interaction_token) { SecureRandom.base64(200) }
+  let(:interaction_id) { SecureRandom.random_number(1000) }
+  let(:application_id) { SecureRandom.random_number(1000) }
+  let(:content) { 'hello world' }
+  let(:callback_type) { Discordrb::Interaction::CALLBACK_TYPES[:channel_message] }
+  let(:file) { double(File) }
+
+  describe '#create_interaction_response' do
+    it 'sends a JSON payload with headers when file is not specified' do
+      expect(Discordrb::API).to receive(:request).with(
+        :interactions_iid_token_callback,
+        interaction_id,
+        :post,
+        "#{Discordrb::API.api_base}/interactions/#{interaction_id}/#{interaction_token}/callback",
+        { type: callback_type, data: { content: content } }.to_json,
+        { content_type: :json }
+      )
+
+      Discordrb::API::Interaction.create_interaction_response(
+        interaction_token,
+        interaction_id,
+        callback_type,
+        'hello world'
+      )
+    end
+
+    it 'sends a multipart payload when a file is specified' do
+      expect(Discordrb::API).to receive(:request).with(
+        :interactions_iid_token_callback,
+        interaction_id,
+        :post,
+        "#{Discordrb::API.api_base}/interactions/#{interaction_id}/#{interaction_token}/callback",
+        { file: file, payload_json: { type: callback_type, data: { content: content } }.to_json },
+        nil
+      )
+
+      Discordrb::API::Interaction.create_interaction_response(
+        interaction_token,
+        interaction_id,
+        callback_type,
+        'hello world',
+        nil, # tts
+        nil, # embeds
+        nil, # allowed_mentions
+        nil, # flags
+        nil, # components
+        file
+      )
+    end
+  end
+
+  describe '#get_original_interaction_response' do
+    it 'calls webhook api with correct parameters' do
+      expect(Discordrb::API::Webhook).to receive(:token_get_message).with(
+        interaction_id,
+        application_id,
+        '@original'
+      )
+
+      Discordrb::API::Interaction.get_original_interaction_response(
+        interaction_id,
+        application_id
+      )
+    end
+  end
+
+  describe '#edit_original_interaction_response' do
+    it 'calls webhook api with correct parameters' do
+      expect(Discordrb::API::Webhook).to receive(:token_edit_message).with(
+        interaction_id,
+        application_id,
+        '@original',
+        content,
+        nil, # embeds
+        nil, # allowed_mentions
+        nil, # components
+        file
+      )
+
+      Discordrb::API::Interaction.edit_original_interaction_response(
+        interaction_id,
+        application_id,
+        content,
+        nil, # embeds
+        nil, # allowed_mentions
+        nil, # components
+        file
+      )
+    end
+  end
+
+  describe '#delete_original_interaction_response' do
+    it 'calls webhook api with correct parameters' do
+      expect(Discordrb::API::Webhook).to receive(:token_delete_message).with(
+        interaction_token,
+        application_id,
+        '@original'
+      )
+
+      Discordrb::API::Interaction.delete_original_interaction_response(
+        interaction_token,
+        application_id
+      )
+    end
+  end
+end

--- a/spec/data/interaction_spec.rb
+++ b/spec/data/interaction_spec.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'discordrb'
+
+describe Discordrb::Interaction do
+  let(:guild_id) { SecureRandom.random_number(200) }
+  let(:channel_id) { SecureRandom.random_number(200) }
+  let(:interaction_token) { SecureRandom.base64(200) }
+  let(:interaction_id) { SecureRandom.random_number(1000) }
+  let(:application_id) { SecureRandom.random_number(1000) }
+  let(:content) { 'hello world' }
+  let(:file) { double(File) }
+  let(:user) { double(Discordrb::Member) }
+  let(:bot) do
+    bot = double('bot')
+    allow(bot).to receive(:ensure_user).with(any_args).and_return(user)
+    bot
+  end
+  let(:interaction_data) do
+    {
+      'id' => interaction_id,
+      'application_id' => application_id,
+      'type' => -1,
+      'message' => nil,
+      'data' => double,
+      'server_id' => guild_id,
+      'channel_id' => channel_id,
+      'user' => double,
+      'token' => interaction_token,
+      'version' => 1
+    }
+  end
+  let(:message_resolve_id) { SecureRandom.random_number(1000) }
+  let(:message) do
+    message = double('message')
+    allow(message).to receive(:resolve_id).with(any_args).and_return(message_resolve_id)
+    message
+  end
+
+  subject(:interaction) do
+    described_class.new(interaction_data, bot)
+  end
+
+  before(:each) do
+    allow(Discordrb::Interactions::Message).to receive(:new).with(any_args).and_return(nil)
+  end
+
+  describe '#respond' do
+    let(:callback_type) { Discordrb::Interaction::CALLBACK_TYPES[:channel_message] }
+
+    it 'calls interaction api with correct parameters' do
+      expect(Discordrb::API::Interaction).to receive(:create_interaction_response).with(
+        interaction_token,
+        interaction_id,
+        callback_type,
+        content,
+        nil, # tts
+        [], # embeds,
+        nil, # allowed_mentions
+        0, # flags
+        [], # components
+        nil # file
+      ).and_return('null')
+
+      interaction.respond(content: content)
+    end
+
+    it 'calls interaction api with correct parameters when file is added to builder' do
+      expect(Discordrb::API::Interaction).to receive(:create_interaction_response).with(
+        interaction_token,
+        interaction_id,
+        callback_type,
+        content,
+        nil, # tts
+        nil, # embeds,
+        nil, # allowed_mentions
+        0, # flags
+        [], # components
+        file
+      ).and_return('null')
+
+      interaction.respond(content: content) do |builder|
+        builder.file = file
+      end
+    end
+  end
+
+  describe '#update_message' do
+    let(:callback_type) { Discordrb::Interaction::CALLBACK_TYPES[:update_message] }
+
+    it 'calls interaction api with correct parameters' do
+      expect(Discordrb::API::Interaction).to receive(:create_interaction_response).with(
+        interaction_token,
+        interaction_id,
+        callback_type,
+        content,
+        nil, # tts
+        [], # embeds,
+        nil, # allowed_mentions
+        0, # flags
+        [], # components
+        nil # file
+      ).and_return('null')
+
+      interaction.update_message(content: content)
+    end
+
+    it 'calls interaction api with correct parameters when file is added to builder' do
+      expect(Discordrb::API::Interaction).to receive(:create_interaction_response).with(
+        interaction_token,
+        interaction_id,
+        callback_type,
+        content,
+        nil, # tts
+        nil, # embeds,
+        nil, # allowed_mentions
+        0, # flags
+        [], # components
+        file
+      ).and_return('null')
+
+      interaction.update_message(content: content) do |builder|
+        builder.file = file
+      end
+    end
+  end
+
+  describe '#edit_response' do
+    it 'calls interaction api with correct parameters' do
+      expect(Discordrb::API::Interaction).to receive(:edit_original_interaction_response).with(
+        interaction_token,
+        application_id,
+        content,
+        [], # embeds,
+        nil, # allowed_mentions
+        [], # components
+        nil # file
+      ).and_return('null')
+
+      interaction.edit_response(content: content)
+    end
+
+    it 'calls interaction api with correct parameters when file is added to builder' do
+      expect(Discordrb::API::Interaction).to receive(:edit_original_interaction_response).with(
+        interaction_token,
+        application_id,
+        content,
+        nil, # embeds,
+        nil, # allowed_mentions
+        [], # components
+        file # file
+      ).and_return('null')
+
+      interaction.edit_response(content: content) do |builder|
+        builder.file = file
+      end
+    end
+  end
+
+  describe '#send_message' do
+    it 'calls webhook api with correct parameters' do
+      expect(Discordrb::API::Webhook).to receive(:token_execute_webhook).with(
+        interaction_token,
+        application_id,
+        true, # wait
+        content,
+        nil, # username
+        nil, # avatar_url
+        false, # tts
+        nil, # file
+        [], # embeds
+        nil, # allowed_mentions
+        0, # flags
+        [] # components
+      ).and_return('null')
+
+      interaction.send_message(content: content)
+    end
+
+    it 'calls webhook api with correct parameters when file is added to builder' do
+      expect(Discordrb::API::Webhook).to receive(:token_execute_webhook).with(
+        interaction_token,
+        application_id,
+        true, # wait
+        content,
+        nil, # username
+        nil, # avatar_url
+        false, # tts
+        file, # file
+        nil, # embeds
+        nil, # allowed_mentions
+        0, # flags
+        [] # components
+      ).and_return('null')
+
+      interaction.send_message(content: content) do |builder|
+        builder.file = file
+      end
+    end
+  end
+
+  describe '#edit_message' do
+    it 'calls webhook api with correct parameters' do
+      expect(Discordrb::API::Webhook).to receive(:token_edit_message).with(
+        interaction_token,
+        application_id,
+        message_resolve_id,
+        content,
+        [], # embeds
+        nil, # allowed_mentions
+        [], # components
+        nil # file
+      ).and_return('null')
+
+      interaction.edit_message(message, content: content)
+    end
+
+    it 'calls webhook api with correct parameters when file is added to builder' do
+      expect(Discordrb::API::Webhook).to receive(:token_edit_message).with(
+        interaction_token,
+        application_id,
+        message_resolve_id,
+        content,
+        nil, # embeds
+        nil, # allowed_mentions
+        [], # components
+        file # file
+      ).and_return('null')
+
+      interaction.edit_message(message, content: content) do |builder|
+        builder.file = file
+      end
+    end
+  end
+
+  describe '#delete_message' do
+    it 'calls webhook api with correct parameters' do
+      expect(Discordrb::API::Webhook).to receive(:token_delete_message).with(
+        interaction_token,
+        application_id,
+        message_resolve_id
+      )
+
+      interaction.delete_message(message)
+    end
+  end
+end

--- a/spec/webhooks_spec.rb
+++ b/spec/webhooks_spec.rb
@@ -16,6 +16,34 @@ describe Discordrb::Webhooks do
       expect(builder.embeds.length).to eq 1
       expect(builder.embeds.first).to eq embed
     end
+
+    describe '#to_payload_hash' do
+      it 'should return json hash when a file is not present' do
+        builder = Discordrb::Webhooks::Builder.new
+
+        builder.add_embed do |e|
+          e.title = 'hello world'
+        end
+
+        payload = builder.to_payload_hash
+
+        expect(payload).to include(:embeds)
+        expect(payload).to_not include(:file)
+      end
+
+      it 'should return multipart hash when a file is present' do
+        Tempfile.create('example') do |file|
+          builder = Discordrb::Webhooks::Builder.new
+
+          builder.file = file
+
+          payload = builder.to_payload_hash
+
+          expect(payload).to include(:file)
+          expect(payload).to_not include(:embeds)
+        end
+      end
+    end
   end
 
   describe Discordrb::Webhooks::Embed do

--- a/spec/webhooks_spec.rb
+++ b/spec/webhooks_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'base64'
 require 'securerandom'
 require 'discordrb/webhooks'
 
@@ -18,6 +19,8 @@ describe Discordrb::Webhooks do
     end
 
     describe '#to_payload_hash' do
+      let(:file) { double(File) }
+
       it 'should return json hash when a file is not present' do
         builder = Discordrb::Webhooks::Builder.new
 
@@ -32,16 +35,14 @@ describe Discordrb::Webhooks do
       end
 
       it 'should return multipart hash when a file is present' do
-        Tempfile.create('example') do |file|
-          builder = Discordrb::Webhooks::Builder.new
+        builder = Discordrb::Webhooks::Builder.new
 
-          builder.file = file
+        builder.file = file
 
-          payload = builder.to_payload_hash
+        payload = builder.to_payload_hash
 
-          expect(payload).to include(:file)
-          expect(payload).to_not include(:embeds)
-        end
+        expect(payload).to include(:file)
+        expect(payload).to_not include(:embeds)
       end
     end
   end


### PR DESCRIPTION
# Summary

Currently, if you wish to [attach a file to an interaction](https://discord.com/developers/docs/reference#uploading-files) via the webhook builder it does not work, ie:

```ruby
file = File.open('/Users/robherley/Pictures/photo.png')

event.respond(content: 'photo') do
  builder.file = file
end
```

The above will only send the content, and not the file as intended.

This is because the methods defined in the webhook API don't support a `file` parameter and the interaction data is only serialized for a json payload:

https://github.com/shardlab/discordrb/blob/dc27fe18463da3ccfd0f0266030aa7ad51b2c2b9/lib/discordrb/data/interaction.rb#L97-L100

This PR adds support for file uploads via the interaction methods that support it. To avoid breaking changes and compatibility with the current method signature, I added an additional nil-by-default param. However, it would be nice to move these all to keyword arguments eventually.

I also added some specs for the modules that were missing them. They don't have complete coverage of the module, but cover the changes introduced in this PR.

---

## Added

- `Discordrb::Webhooks::Builder#to_payload_hash`: returns relevant hash depending on the presence of `@file` 
- spec for `Discordrb::API::Interaction`
- spec for `Discordrb::Interaction`

## Changed

- `Discordrb::API::Interaction`
  - added `file` as a parameter to `#create_interaction_response`
- `Discordrb::API::Webhook`
  - added `file` as a parameter to `#token_edit_message`
- `Discordrb::Interaction`
  - for `#respond`, `#update_message`, `#edit_response`, `#send_message`, `#edit_message`:
    - using `#to_payload_hash` instead of `#to_json_hash` for webhook builder
    - passing `file` param from webhook builder to relevant API method


## Deprecated

None

## Removed

None

## Fixed

- Uploading file in interaction methods via webhook builder
- The unrelated failing `Channel#delete_all_emoji_reactions` test, it was a small mistake with the emoji encoding