### PR TITLE
Fix rubocop offenses from modals

### DIFF
--- a/examples/modals.rb
+++ b/examples/modals.rb
@@ -3,9 +3,9 @@
 require 'discordrb'
 require 'securerandom'
 
-bot = Discordrb::Bot.new(token: ENV['DISCORDRB_TOKEN'])
-bot.register_application_command(:modal_test, 'Test out a spiffy modal', server_id: ENV['DISCORDRB_SERVER_ID'])
-bot.register_application_command(:modal_await_test, 'Test out the await style', server_id: ENV['DISCORDRB_SERVER_ID'])
+bot = Discordrb::Bot.new(token: ENV.fetch('DISCORDRB_TOKEN'))
+bot.register_application_command(:modal_test, 'Test out a spiffy modal', server_id: ENV.fetch('DISCORDRB_TOKEN'))
+bot.register_application_command(:modal_await_test, 'Test out the await style', server_id: ENV.fetch('DISCORDRB_TOKEN'))
 
 bot.application_command :modal_test do |event|
   event.show_modal(title: 'Test modal', custom_id: 'test1234') do |modal|

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -289,7 +289,7 @@ module Discordrb
     # @return [TextInput, Button, SelectMenu]
     def get_component(custom_id)
       top_level = @components.flat_map(&:components) || []
-      message_level = @message&.components&.flat_map { |r| r.components } || []
+      message_level = @message&.components&.flat_map(&:components) || []
       components = top_level.concat(message_level)
       components.find { |component| component.custom_id == custom_id }
     end


### PR DESCRIPTION
# Summary

<!---
  Describe the general goal of your pull request here:

  - Include details about any issues you encountered that inspired
  the pull request, such as bugs or missing features.

  - If adding or changing features, include a small example that showcases
  the new behavior.

  - Reference any related issues or pull requests.

  Stuck or need help? Join the Discord! https://discord.gg/cyK3Hjm
--->
This PR fixes all the rubocop offenses caused by the new modals feature added to discordrb
---

<!---
  List each individual change you made to the library here in the appropriate
  section in short, bulleted sentences.

  This will aid in reviewing your pull request, and for adding it to the
  changelog later.

  You may remove sections that have no items if you want.
--->

## Added

## Changed

## Deprecated

## Removed

## Fixed
~ Use ENV.fetch('DISCORDRB_TOKEN') instead of ENV['DISCORDRB_TOKEN']
~ Pass &:components as an argument to flat_map instead of a block