### PR TITLE
fix: Server#max_emoji returning wrong value

### DIFF
--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -573,7 +573,7 @@ module Discordrb
     # The amount of emoji the server can have, based on its current Nitro Boost Level.
     # @return [Integer] the max amount of emoji
     def max_emoji
-      case @level
+      case @boost_level
       when 1
         100
       when 2


### PR DESCRIPTION
# Summary

`Server#max_emoji` has typo in it by referring to `@level` instead of `@boost_level` attribute, hence it returns `50` every time.

## Fixed

- Replaced `@level` with correct `@boost_level`