### PR TITLE
Feature: Support attachment option type

### DIFF
--- a/lib/discordrb/data/attachment.rb
+++ b/lib/discordrb/data/attachment.rb
@@ -27,6 +27,16 @@ module Discordrb
     # @return [Integer, nil] the height of an image file, in pixels, or `nil` if the file is not an image.
     attr_reader :height
 
+    # @return [String, nil] the attachment's description.
+    attr_reader :description
+
+    # @return [String, nil] the attachment's media type.
+    attr_reader :content_type
+
+    # @return [true, false] whether this attachment is ephemeral.
+    attr_reader :ephemeral
+    alias_method :ephemeral?, :ephemeral
+
     # @!visibility private
     def initialize(data, message, bot)
       @bot = bot
@@ -41,6 +51,11 @@ module Discordrb
 
       @width = data['width']
       @height = data['height']
+
+      @description = data['description']
+      @content_type = data['content_type']
+
+      @ephemeral = data['ephemeral']
     end
 
     # @return [true, false] whether this file is an image file.

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -400,7 +400,8 @@ module Discordrb
         channel: 7,
         role: 8,
         mentionable: 9,
-        number: 10
+        number: 10,
+        attachment: 11
       }.freeze
 
       # Channel types that can be provided to #channel
@@ -529,6 +530,14 @@ module Discordrb
       def number(name, description, required: nil, min_value: nil, max_value: nil, choices: nil)
         option(TYPES[:number], name, description,
                required: required, min_value: min_value, max_value: max_value, choices: choices)
+      end
+
+      # @param name [String, Symbol] The name of the argument.
+      # @param description [String] A description of the argument.
+      # @param required [true, false] Whether this option must be provided.
+      # @return (see #option)
+      def attachment(name, description, required: nil)
+        option(TYPES[:attachment], name, description, required: required)
       end
 
       # @!visibility private

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -130,7 +130,7 @@ module Discordrb::Events
   # Event for ApplicationCommand interactions.
   class ApplicationCommandEvent < InteractionCreateEvent
     # Struct to allow accessing data via [] or methods.
-    Resolved = Struct.new('Resolved', :channels, :members, :messages, :roles, :users) # rubocop:disable Lint/StructNewOverride
+    Resolved = Struct.new('Resolved', :channels, :members, :messages, :roles, :users, :attachments) # rubocop:disable Lint/StructNewOverride
 
     # @return [String] The name of the command.
     attr_reader :command_name
@@ -162,7 +162,7 @@ module Discordrb::Events
       @command_name = command_data['name'].to_sym
 
       @target_id = command_data['target_id']&.to_i
-      @resolved = Resolved.new({}, {}, {}, {}, {})
+      @resolved = Resolved.new({}, {}, {}, {}, {}, {})
       process_resolved(command_data['resolved']) if command_data['resolved']
 
       options = command_data['options'] || []
@@ -218,6 +218,10 @@ module Discordrb::Events
 
       resolved_data['messages']&.each do |id, data|
         @resolved[:messages][id.to_i] = Discordrb::Message.new(data, @bot)
+      end
+
+      resolved_data['attachments']&.each do |id, data|
+        @resolved[:attachments][id.to_i] = Discordrb::Attachment.new(data, nil, @bot)
       end
     end
 


### PR DESCRIPTION
# Summary

This pull request adds support of `attachment` option type to Interactions.
Also adds missing [attributes](https://discord.com/developers/docs/resources/channel#attachment-object) to Attachment class.

## Added

- add `attachment` type to option types and builder;
- resolve attachments objects so they can be accessed within interaction;

## Changed

- add `description`, `content_type` and `ephemeral` (w/ `ephemeral?` alias) attributes to Attachment class.

## Example

```rb
bot.register_application_command(:test, "get info about attachment", server_id: SERVER_ID) do |cmd|
  cmd.attachment("file", "test file", required: true)
end

bot.application_command(:test) do |event|
  file = event.resolved.attachments[event.options["file"].to_i]

  event.respond do |msg|
    msg.add_embed do |embed|
      embed.description = <<~MSG
        id: #{file.id}
        filename: #{file.filename}
        size: #{file.size}
        url: #{file.url}
        proxy_url: #{file.proxy_url}
        height: #{file.height}
        width: #{file.width}
        description: #{file.description}
        content_type: #{file.content_type}
        ephemeral: #{file.ephemeral?}
      MSG
    end
  end
end
```