### PR TITLE
Fixes rubocop and specs

### DIFF
--- a/examples/modals.rb
+++ b/examples/modals.rb
@@ -3,9 +3,9 @@
 require 'discordrb'
 require 'securerandom'
 
-bot = Discordrb::Bot.new(token: ENV['DISCORDRB_TOKEN'])
-bot.register_application_command(:modal_test, 'Test out a spiffy modal', server_id: ENV['DISCORDRB_SERVER_ID'])
-bot.register_application_command(:modal_await_test, 'Test out the await style', server_id: ENV['DISCORDRB_SERVER_ID'])
+bot = Discordrb::Bot.new(token: ENV.fetch['DISCORDRB_TOKEN'])
+bot.register_application_command(:modal_test, 'Test out a spiffy modal', server_id: ENV.fetch['DISCORDRB_SERVER_ID'])
+bot.register_application_command(:modal_await_test, 'Test out the await style', server_id: ENV.fetch['DISCORDRB_SERVER_ID'])
 
 bot.application_command :modal_test do |event|
   event.show_modal(title: 'Test modal', custom_id: 'test1234') do |modal|

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -289,7 +289,7 @@ module Discordrb
     # @return [TextInput, Button, SelectMenu]
     def get_component(custom_id)
       top_level = @components.flat_map(&:components) || []
-      message_level = @message&.components&.flat_map { |r| r.components } || []
+      message_level = @message&.components&.flat_map(&:components) || []
       components = top_level.concat(message_level)
       components.find { |component| component.custom_id == custom_id }
     end

--- a/spec/api/channel_spec.rb
+++ b/spec/api/channel_spec.rb
@@ -55,7 +55,7 @@ describe Discordrb::API::Channel do
 
   describe '.delete_all_emoji_reactions' do
     let(:message_id) { double('message_id', to_s: 'message_id') }
-    let(:emoji) { "\u{1F525}" }
+    let(:emoji) { '\u{1F525}' }
 
     before do
       allow(Discordrb::API).to receive(:request)

--- a/spec/data/webhook_spec.rb
+++ b/spec/data/webhook_spec.rb
@@ -101,7 +101,7 @@ describe Discordrb::Webhook do
 
   describe '#update' do
     it 'calls update_webhook' do
-      expect(webhook).to receive(:update_webhook).with(avatar: avatar_string, channel_id: edited_webhook_channel_id.to_i, name: edited_webhook_name, reason: reason)
+      expect(webhook).to receive(:update_webhook).with(hash_including(avatar: avatar_string, channel_id: edited_webhook_channel_id.to_i, name: edited_webhook_name, reason: reason))
       webhook.update(avatar: avatar_string, channel: edited_webhook_channel_id, name: edited_webhook_name, reason: reason)
     end
   end


### PR DESCRIPTION
# Summary

This pr fixes the long broken rubocop, along with the failing specs.
So we are now green bois again.

---

## Fixed

- examples/modals.rb to use `ENV.fetch` instead of `ENV[...]`
- lib/discordrb/data/interaction.rb to prefer proc rather than a block to please lord rubocop.
- spec/data/webhook_spec.rb failing due to missing `hash_including` call..
- spec/api/channel_spec.rb failing due to double quotes around the unicode emoji