### PR TITLE
Fix `.make_localization` not giving ArgumentError

### DIFF
--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -609,8 +609,8 @@ module Discordrb
       # @param name [String] The localization name
       # @param description [String] The localization description
       # @return [Array<Hash>]
-      def make_localization(locale, name: '', description: '')
-        raise ArgumentError 'You must give at least one field to add a localization to.' unless name || description
+      def make_localization(locale, name: nil, description: nil)
+        raise ArgumentError, 'You must give at least one field to add a localization to.' unless name || description
 
         @description_localizations[locale] = description
         @name_localizations[locale] = name


### PR DESCRIPTION
# Summary

<!---
  Describe the general goal of your pull request here:

  - Include details about any issues you encountered that inspired
  the pull request, such as bugs or missing features.

  - If adding or changing features, include a small example that showcases
  the new behavior.

  - Reference any related issues or pull requests.

  Stuck or need help? Join the Discord! https://discord.gg/cyK3Hjm
--->
Make .make_localization return ArgumentError instead of giving an error that doesn't help the user.
---
I messed up a part of the localization PR, and the error was raised only if nil was passed to both name and description, but the method defaulted to `''` instead of `nil`. This fixes that.
<!---
  List each individual change you made to the library here in the appropriate
  section in short, bulleted sentences.

  This will aid in reviewing your pull request, and for adding it to the
  changelog later.

  You may remove sections that have no items if you want.
--->

## Fixed
ArgumentError not being raised when no fields are given for `.make_localization`