### PR TITLE
fix an error with webhooks view initialize

### DIFF
--- a/lib/discordrb/webhooks/view.rb
+++ b/lib/discordrb/webhooks/view.rb
@@ -122,7 +122,7 @@ class Discordrb::Webhooks::View
   # A builder to assist in adding options to select menus.
   class SelectMenuBuilder
     # @!visibility hidden
-    def initialize(custom_id, options = [], placeholder = nil, min_values = nil, max_values = nil, disabled = nil, select_type: :string_select)
+    def initialize(custom_id, options = [], placeholder = nil, min_values = nil, max_values = nil, disabled = nil, select_type = :string_select)
       @custom_id = custom_id
       @options = options
       @placeholder = placeholder


### PR DESCRIPTION
[ERROR : it-1092744109200003092 @ 2023-04-04 12:34:58.465] Exception: #<ArgumentError: wrong number of arguments (given 7, expected 1..6)>
[ERROR : it-1092744109200003092 @ 2023-04-04 12:34:58.465] .../discordrb/lib/discordrb/webhooks/view.rb:125:in `initialize'
[ERROR : it-1092744109200003092 @ 2023-04-04 12:34:58.465] .../discordrb/lib/discordrb/webhooks/view.rb:67:in `new'
[ERROR : it-1092744109200003092 @ 2023-04-04 12:34:58.465] .../discordrb/lib/discordrb/webhooks/view.rb:67:in `string_select'