### PR TITLE
fix `message.edit` and others

### DIFF
--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -110,7 +110,7 @@ module Discordrb
       return unless wait
 
       response = Discordrb::API::Interaction.get_original_interaction_response(@token, @application_id)
-      Interactions::Message.new(JSON.parse(response), @bot, @interaction)
+      Interactions::Message.new(JSON.parse(response), @bot, self)
     end
 
     # Defer an interaction, setting a temporary response that can be later overriden by {Interaction#send_message}.
@@ -177,7 +177,7 @@ module Discordrb
       return unless wait
 
       response = Discordrb::API::Interaction.get_original_interaction_response(@token, @application_id)
-      Interactions::Message.new(JSON.parse(response), @bot, @interaction)
+      Interactions::Message.new(JSON.parse(response), @bot, self)
     end
 
     # Edit the original response to this interaction.
@@ -198,7 +198,7 @@ module Discordrb
       data = builder.to_json_hash
       resp = Discordrb::API::Interaction.edit_original_interaction_response(@token, @application_id, data[:content], data[:embeds], data[:allowed_mentions], components.to_a)
 
-      Interactions::Message.new(JSON.parse(resp), @bot, @interaction)
+      Interactions::Message.new(JSON.parse(resp), @bot, self)
     end
 
     # Delete the original interaction response.
@@ -228,7 +228,7 @@ module Discordrb
       resp = Discordrb::API::Webhook.token_execute_webhook(
         @token, @application_id, true, data[:content], nil, nil, tts, nil, data[:embeds], data[:allowed_mentions], flags, components.to_a
       )
-      Interactions::Message.new(JSON.parse(resp), @bot, @interaction)
+      Interactions::Message.new(JSON.parse(resp), @bot, self)
     end
 
     # @param message [String, Integer, InteractionMessage, Message] The message created by this interaction to be edited.
@@ -249,7 +249,7 @@ module Discordrb
       resp = Discordrb::API::Webhook.token_edit_message(
         @token, @application_id, message.resolve_id, data[:content], data[:embeds], data[:allowed_mentions], components.to_a
       )
-      Interactions::Message.new(JSON.parse(resp), @bot, @interaction)
+      Interactions::Message.new(JSON.parse(resp), @bot, self)
     end
 
     # @param message [Integer, String, InteractionMessage, Message] The message created by this interaction to be deleted.


### PR DESCRIPTION
```ruby
message = event.send_message(content: 'some content')
message.edit(content: 'edited')
```

```
[ERROR : et-1 @ 2023-04-04 13:50:28.898] Exception: #<NoMethodError: undefined method `edit_message' for nil:NilClass

        @interaction.edit_message(@id, content: content, embeds: embeds, allowed_mentions: allowed_mentions, components: components, &block)
                    ^^^^^^^^^^^^^>
[ERROR : et-1 @ 2023-04-04 13:50:28.898] /Users/sergey/personal/projects/forks/discordrb/lib/discordrb/data/interaction.rb:775:in `edit'
```