### PR TITLE
Allow disconnect user from a voice channel via the Server#move method

### DIFF
--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -619,8 +619,8 @@ module Discordrb
       API::Server.remove_member(@bot.token, @id, user.resolve_id, reason)
     end
 
-    # Forcibly moves a user into a different voice channel. Only works if the bot has the permission needed.
-    # Can't move user if he's not already connected to a server voice channel.
+    # Forcibly moves a user into a different voice channel.
+    # Only works if the bot has the permission needed and if the user is already connected to some voice channel on this server.
     # @param user [User, String, Integer] The user to move.
     # @param channel [Channel, String, Integer, nil] The voice channel to move into. (If nil, the user is disconnected from the voice channel)
     def move(user, channel)

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -620,10 +620,11 @@ module Discordrb
     end
 
     # Forcibly moves a user into a different voice channel. Only works if the bot has the permission needed.
+    # Can't move user if he's not already connected to a server voice channel.
     # @param user [User, String, Integer] The user to move.
-    # @param channel [Channel, String, Integer] The voice channel to move into.
+    # @param channel [Channel, String, Integer, nil] The voice channel to move into. (If nil, the user is disconnected from the voice channel)
     def move(user, channel)
-      API::Server.update_member(@bot.token, @id, user.resolve_id, channel_id: channel.resolve_id)
+      API::Server.update_member(@bot.token, @id, user.resolve_id, channel_id: channel&.resolve_id)
     end
 
     # Deletes this server. Be aware that this is permanent and impossible to undo, so be careful!


### PR DESCRIPTION
# Summary

It's all in the title
Allows to fix issue #185 

---

## Changed
- Server#move accept nil for channel param