### PR TITLE
Fix thread delete method call

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1602,7 +1602,7 @@ module Discordrb
         event = ThreadUpdateEvent.new(data, self)
         raise_event(event)
       when :THREAD_DELETE
-        channel_delete(data)
+        delete_channel(data)
         @thread_members.delete(data['id']&.resolve_id)
 
         # raise ThreadDeleteEvent


### PR DESCRIPTION
# Summary

This fixes a bug where thread channels aren't deleted.

`channel_delete` is a method call to register an event handler. As a block was not passed to this call, whenever a channel is then deleted it would raise a NoMethod error to call for nil.

## Fixed

- Threads are now deleted from the cache correctly
- Empty channel delete handlers are no longer created on thread deletion
