### PR TITLE
Fix: Catching send_temporary_message exceptions

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -418,10 +418,11 @@ module Discordrb
     # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @param components [View, Array<Hash>] Interaction components to associate with this message.
     def send_temporary_message(channel, content, timeout, tts = false, embeds = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil)
+      message = send_message(channel, content, tts, embeds, attachments, allowed_mentions, message_reference, components)
+      
       Thread.new do
         Thread.current[:discordrb_name] = "#{@current_thread}-temp-msg"
 
-        message = send_message(channel, content, tts, embeds, attachments, allowed_mentions, message_reference, components)
         sleep(timeout)
         message.delete
       end


### PR DESCRIPTION
# Summary

I was trying to send an error message if my bot couldnt send a temporary message in a different channel and found a small bug in send_temporary_message.
Its currently not possible to catch exceptions because send_temporary_message creates the message in a different thread before deleting it after the timeout.

```rb
    begin
      different_channel.send_temporary_message content, 30
    rescue Discordrb::Errors::NoPermission => e
      next "No Permission!: #{e}"       # This branch never runs because we cant catch the exception currently
    end
```

## Fixed

We can now catch the exception in user code
