### PR TITLE
feat: add interaction helper methods

### DIFF
--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -194,6 +194,42 @@ module Discordrb::Events
       @resolved.find { |data| data.key?(@target_id) }[@target_id]
     end
 
+    # @param name [String] The name of the option.
+    # @return [User]
+    def options_user(name)
+      @resolved[:users][@options[name].to_i]
+    end
+
+    # @param name [String] The name of the option.
+    # @return [Member]
+    def options_member(name)
+      @resolved[:members][@options[name].to_i]
+    end
+
+    # @param name [String] The name of the option.
+    # @return [Role]
+    def options_role(name)
+      @resolved[:roles][@options[name].to_i]
+    end
+
+    # @param name [String] The name of the option.
+    # @return [Channel]
+    def options_channel(name)
+      @resolved[:channels][@options[name].to_i]
+    end
+
+    # @param name [String] The name of the option.
+    # @return [Member, Role]
+    def options_mentionable(name)
+      member(name) || role(name)
+    end
+
+    # @param name [String] The name of the option.
+    # @return [Attachment]
+    def options_attachment(name)
+      @resolved[:attachments][@options[name].to_i]
+    end
+
     private
 
     def process_resolved(resolved_data)


### PR DESCRIPTION
# Summary

Currently discordrb "hydrates" provided slash command options into objects but there's no fancy way to extract, doing that looks next way:

```rb
bot.register_application_command(:user, "get info about user", server_id: SERVER_ID) do |cmd|
  cmd.user("user", "user to inspect", required: true)
end

bot.application_command(:user) do |event|
  user = event.options_user[event.options["users"].to_i] # <
  # ...
end
```

Which is alot of boilerplate code, that's why I suggest adding helper methods, similar to ones in [discord.js](https://old.discordjs.dev/#/docs/discord.js/main/class/CommandInteractionOptionResolver?scrollTo=getMember) *i.e. `getMember/getMessage/etc.`) methods retrieving would look next way:

```rb
user = event.options_user("user")
```

---

## Added

- `options_user` - returns User
- `options_member` - returns Member
- `options_role` - returns Role
- `options_channel` - returns Channel
- `options_mentionable` - returns Member or Role
- `options_attachment` - returns Attachment
