### PR TITLE
Add application command localization support.

### DIFF
--- a/examples/slash_commands.rb
+++ b/examples/slash_commands.rb
@@ -11,10 +11,10 @@ bot = Discordrb::Bot.new(token: ENV.fetch('SLASH_COMMAND_BOT_TOKEN', nil), inten
 #
 # You may want to have a separate script for registering your commands so you don't need to do this every
 # time you start your bot.
-bot.register_application_command(:example, 'Example commands', server_id: ENV.fetch('SLASH_COMMAND_BOT_SERVER_ID', nil)) do |cmd|
+bot.register_application_command(:example, 'Example commands', server_id: ENV.fetch('SLASH_COMMAND_BOT_SERVER_ID', nil), name_localizations: { 'de' => 'beispiel' }, description_localizations: { 'de' => 'Beispielbefehle' }) do |cmd|
   cmd.subcommand_group(:fun, 'Fun things!') do |group|
     group.subcommand('8ball', 'Shake the magic 8 ball') do |sub|
-      sub.string('question', 'Ask a question to receive wisdom', required: true)
+      sub.string('question', 'Ask a question to receive wisdom', required: true, name_localizations: { 'de' => 'frage' }, description_localizations: { 'de' => 'Stell eine Frage um Weisheit zu erhalten' })
     end
 
     group.subcommand('java', 'What if it was java?')

--- a/lib/discordrb/api/application.rb
+++ b/lib/discordrb/api/application.rb
@@ -6,12 +6,12 @@ module Discordrb::API::Application
 
   # Get a list of global application commands.
   # https://discord.com/developers/docs/interactions/slash-commands#get-global-application-commands
-  def get_global_commands(token, application_id)
+  def get_global_commands(token, application_id, with_localizations: nil)
     Discordrb::API.request(
       :applications_aid_commands,
       nil,
       :get,
-      "#{Discordrb::API.api_base}/applications/#{application_id}/commands",
+      "#{Discordrb::API.api_base}/applications/#{application_id}/commands#{"?with_localizations=#{!!with_localizations}" unless with_localizations.nil?}",
       Authorization: token
     )
   end
@@ -84,12 +84,12 @@ module Discordrb::API::Application
 
   # Get a guild's commands for an application.
   # https://discord.com/developers/docs/interactions/slash-commands#get-guild-application-commands
-  def get_guild_commands(token, application_id, guild_id)
+  def get_guild_commands(token, application_id, guild_id, with_localizations: nil)
     Discordrb::API.request(
       :applications_aid_guilds_gid_commands,
       guild_id,
       :get,
-      "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands",
+      "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands#{"?with_localizations=#{!!with_localizations}" unless with_localizations.nil?}",
       Authorization: token
     )
   end

--- a/lib/discordrb/api/application.rb
+++ b/lib/discordrb/api/application.rb
@@ -30,13 +30,13 @@ module Discordrb::API::Application
 
   # Create a global application command.
   # https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
-  def create_global_command(token, application_id, name, description, options = [], default_permission = nil, type = 1, default_member_permissions = nil, contexts = nil, nsfw = false)
+  def create_global_command(token, application_id, name, description, options = [], default_permission = nil, type = 1, default_member_permissions = nil, contexts = nil, nsfw = false, name_localizations = {}, description_localizations = {})
     Discordrb::API.request(
       :applications_aid_commands,
       nil,
       :post,
       "#{Discordrb::API.api_base}/applications/#{application_id}/commands",
-      { name: name, description: description, options: options, default_permission: default_permission, type: type, default_member_permissions: default_member_permissions, contexts: contexts, nsfw: nsfw }.to_json,
+      { name: name, description: description, options: options, default_permission: default_permission, type: type, default_member_permissions: default_member_permissions, contexts: contexts, nsfw: nsfw, name_localizations: name_localizations, description_localizations: description_localizations }.to_json,
       Authorization: token,
       content_type: :json
     )
@@ -44,13 +44,13 @@ module Discordrb::API::Application
 
   # Edit a global application command.
   # https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command
-  def edit_global_command(token, application_id, command_id, name = nil, description = nil, options = nil, default_permission = nil, type = 1, default_member_permissions = nil, contexts = nil, nsfw = nil)
+  def edit_global_command(token, application_id, command_id, name = nil, description = nil, options = nil, default_permission = nil, type = 1, default_member_permissions = nil, contexts = nil, nsfw = nil, name_localizations = {}, description_localizations = {})
     Discordrb::API.request(
       :applications_aid_commands_cid,
       nil,
       :patch,
       "#{Discordrb::API.api_base}/applications/#{application_id}/commands/#{command_id}",
-      { name: name, description: description, options: options, default_permission: default_permission, type: type, default_member_permissions: default_member_permissions, contexts: contexts, nsfw: nsfw }.compact.to_json,
+      { name: name, description: description, options: options, default_permission: default_permission, type: type, default_member_permissions: default_member_permissions, contexts: contexts, nsfw: nsfw, name_localizations: name_localizations, description_localizations: description_localizations }.compact.to_json,
       Authorization: token,
       content_type: :json
     )
@@ -108,13 +108,13 @@ module Discordrb::API::Application
 
   # Create an application command for a guild.
   # https://discord.com/developers/docs/interactions/slash-commands#create-guild-application-command
-  def create_guild_command(token, application_id, guild_id, name, description, options = nil, default_permission = nil, type = 1, default_member_permissions = nil, contexts = nil, nsfw = false)
+  def create_guild_command(token, application_id, guild_id, name, description, options = nil, default_permission = nil, type = 1, default_member_permissions = nil, contexts = nil, nsfw = false, name_localizations = {}, description_localizations = {})
     Discordrb::API.request(
       :applications_aid_guilds_gid_commands,
       guild_id,
       :post,
       "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands",
-      { name: name, description: description, options: options, default_permission: default_permission, type: type, default_member_permissions: default_member_permissions, contexts: contexts, nsfw: nsfw }.to_json,
+      { name: name, description: description, options: options, default_permission: default_permission, type: type, default_member_permissions: default_member_permissions, contexts: contexts, nsfw: nsfw, name_localizations: name_localizations, description_localizations: description_localizations }.to_json,
       Authorization: token,
       content_type: :json
     )
@@ -122,13 +122,13 @@ module Discordrb::API::Application
 
   # Edit an application command for a guild.
   # https://discord.com/developers/docs/interactions/slash-commands#edit-guild-application-command
-  def edit_guild_command(token, application_id, guild_id, command_id, name = nil, description = nil, options = nil, default_permission = nil, type = 1, default_member_permissions = nil, contexts = nil, nsfw = nil)
+  def edit_guild_command(token, application_id, guild_id, command_id, name = nil, description = nil, options = nil, default_permission = nil, type = 1, default_member_permissions = nil, contexts = nil, nsfw = nil, name_localizations = {}, description_localizations = {})
     Discordrb::API.request(
       :applications_aid_guilds_gid_commands_cid,
       guild_id,
       :patch,
       "#{Discordrb::API.api_base}/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}",
-      { name: name, description: description, options: options, default_permission: default_permission, type: type, default_member_permissions: default_member_permissions, contexts: contexts, nsfw: nsfw }.compact.to_json,
+      { name: name, description: description, options: options, default_permission: default_permission, type: type, default_member_permissions: default_member_permissions, contexts: contexts, nsfw: nsfw, name_localizations: name_localizations, description_localizations: description_localizations }.compact.to_json,
       Authorization: token,
       content_type: :json
     )

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -785,12 +785,13 @@ module Discordrb
 
     # Get all application commands.
     # @param server_id [String, Integer, nil] The ID of the server to get the commands from. Global if `nil`.
+    # @param with_localizations [true, false, nil] Whether the full localizations of commands should be included in the result. `nil` requests the Discord API default.
     # @return [Array<ApplicationCommand>]
-    def get_application_commands(server_id: nil)
+    def get_application_commands(server_id: nil, with_localizations: nil)
       resp = if server_id
-               API::Application.get_guild_commands(@token, profile.id, server_id)
+               API::Application.get_guild_commands(@token, profile.id, server_id, with_localizations: with_localizations)
              else
-               API::Application.get_global_commands(@token, profile.id)
+               API::Application.get_global_commands(@token, profile.id, with_localizations: with_localizations)
              end
 
       JSON.parse(resp).map do |command_data|

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -824,7 +824,7 @@ module Discordrb
     #       end
     #     end
     #   end
-    def register_application_command(name, description, server_id: nil, default_permission: nil, type: :chat_input, default_member_permissions: nil, contexts: nil, nsfw: false)
+    def register_application_command(name, description, server_id: nil, default_permission: nil, type: :chat_input, default_member_permissions: nil, contexts: nil, nsfw: false, name_localizations: nil, description_localizations: nil)
       type = ApplicationCommand::TYPES[type] || type
 
       builder = Interactions::OptionBuilder.new
@@ -832,9 +832,9 @@ module Discordrb
       yield(builder, permission_builder) if block_given?
 
       resp = if server_id
-               API::Application.create_guild_command(@token, profile.id, server_id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts, nsfw)
+               API::Application.create_guild_command(@token, profile.id, server_id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts, nsfw, name_localizations, description_localizations)
              else
-               API::Application.create_global_command(@token, profile.id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts, nsfw)
+               API::Application.create_global_command(@token, profile.id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts, nsfw, name_localizations, description_localizations)
              end
       cmd = ApplicationCommand.new(JSON.parse(resp), self, server_id)
 
@@ -849,7 +849,7 @@ module Discordrb
 
     # @yieldparam [OptionBuilder]
     # @yieldparam [PermissionBuilder]
-    def edit_application_command(command_id, server_id: nil, name: nil, description: nil, default_permission: nil, type: :chat_input, default_member_permissions: nil, contexts: nil, nsfw: nil)
+    def edit_application_command(command_id, server_id: nil, name: nil, description: nil, default_permission: nil, type: :chat_input, default_member_permissions: nil, contexts: nil, nsfw: nil, name_localizations: nil, description_localizations: nil)
       type = ApplicationCommand::TYPES[type] || type
 
       builder = Interactions::OptionBuilder.new
@@ -858,9 +858,9 @@ module Discordrb
       yield(builder, permission_builder) if block_given?
 
       resp = if server_id
-               API::Application.edit_guild_command(@token, profile.id, server_id, command_id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts, nsfw)
+               API::Application.edit_guild_command(@token, profile.id, server_id, command_id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts, nsfw, name_localizations, description_localizations)
              else
-               API::Application.edit_global_command(@token, profile.id, command_id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts, nsfw)
+               API::Application.edit_global_command(@token, profile.id, command_id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts, nsfw, name_localizations, description_localizations)
              end
       cmd = ApplicationCommand.new(JSON.parse(resp), self, server_id)
 

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -562,6 +562,8 @@ module Discordrb
 
       # @param name [String, Symbol] The name of the subcommand.
       # @param description [String] A description of the subcommand.
+      # @param name_localizations [Hash, nil] The localized names of the subcommand.
+      # @param description_localizations [Hash, nil] The localized descriptions of the subcommand.
       # @yieldparam [OptionBuilder]
       # @return (see #option)
       # @example
@@ -570,15 +572,17 @@ module Discordrb
       #       sub.string('message', 'What to echo back', required: true)
       #     end
       #   end
-      def subcommand(name, description)
+      def subcommand(name, description, name_localizations: nil, description_localizations: nil)
         builder = OptionBuilder.new
         yield builder if block_given?
 
-        option(TYPES[:subcommand], name, description, options: builder.to_a)
+        option(TYPES[:subcommand], name, description, options: builder.to_a, name_localizations: name_localizations, description_localizations: description_localizations)
       end
 
       # @param name [String, Symbol] The name of the subcommand group.
       # @param description [String] A description of the subcommand group.
+      # @param name_localizations [Hash, nil] The localized names of the subcommand group.
+      # @param description_localizations [Hash, nil] The localized descriptions of the subcommand group.
       # @yieldparam [OptionBuilder]
       # @return (see #option)
       # @example
@@ -589,11 +593,11 @@ module Discordrb
       #       end
       #     end
       #   end
-      def subcommand_group(name, description)
+      def subcommand_group(name, description, name_localizations: nil, description_localizations: nil)
         builder = OptionBuilder.new
         yield builder
 
-        option(TYPES[:subcommand_group], name, description, options: builder.to_a)
+        option(TYPES[:subcommand_group], name, description, options: builder.to_a, name_localizations: name_localizations, description_localizations: description_localizations)
       end
 
       # @param name [String, Symbol] The name of the argument.
@@ -603,10 +607,12 @@ module Discordrb
       # @param max_length [Integer] A maximum length for option value.
       # @param choices [Hash, nil] Available choices, mapped as `Name => Value`.
       # @param autocomplete [true, false] Whether this option can dynamically show choices.
+      # @param name_localizations [Hash, nil] The localized names of the argument.
+      # @param description_localizations [Hash, nil] The localized descriptions of the argument.
       # @return (see #option)
-      def string(name, description, required: nil, min_length: nil, max_length: nil, choices: nil, autocomplete: nil)
+      def string(name, description, required: nil, min_length: nil, max_length: nil, choices: nil, autocomplete: nil, name_localizations: nil, description_localizations: nil)
         option(TYPES[:string], name, description,
-               required: required, min_length: min_length, max_length: max_length, choices: choices, autocomplete: autocomplete)
+               required: required, min_length: min_length, max_length: max_length, choices: choices, autocomplete: autocomplete, name_localizations: name_localizations, description_localizations: description_localizations)
       end
 
       # @param name [String, Symbol] The name of the argument.
@@ -616,52 +622,64 @@ module Discordrb
       # @param max_value [Integer] A maximum value for option.
       # @param choices [Hash, nil] Available choices, mapped as `Name => Value`.
       # @param autocomplete [true, false] Whether this option can dynamically show choices.
+      # @param name_localizations [Hash, nil] The localized names of the argument.
+      # @param description_localizations [Hash, nil] The localized descriptions of the argument.
       # @return (see #option)
-      def integer(name, description, required: nil, min_value: nil, max_value: nil, choices: nil, autocomplete: nil)
+      def integer(name, description, required: nil, min_value: nil, max_value: nil, choices: nil, autocomplete: nil, name_localizations: nil, description_localizations: nil)
         option(TYPES[:integer], name, description,
-               required: required, min_value: min_value, max_value: max_value, choices: choices, autocomplete: autocomplete)
+               required: required, min_value: min_value, max_value: max_value, choices: choices, autocomplete: autocomplete, name_localizations: name_localizations, description_localizations: description_localizations)
       end
 
       # @param name [String, Symbol] The name of the argument.
       # @param description [String] A description of the argument.
       # @param required [true, false] Whether this option must be provided.
+      # @param name_localizations [Hash, nil] The localized names of the argument.
+      # @param description_localizations [Hash, nil] The localized descriptions of the argument.
       # @return (see #option)
-      def boolean(name, description, required: nil)
-        option(TYPES[:boolean], name, description, required: required)
+      def boolean(name, description, required: nil, name_localizations: nil, description_localizations: nil)
+        option(TYPES[:boolean], name, description, required: required, name_localizations: name_localizations, description_localizations: description_localizations)
       end
 
       # @param name [String, Symbol] The name of the argument.
       # @param description [String] A description of the argument.
       # @param required [true, false] Whether this option must be provided.
+      # @param name_localizations [Hash, nil] The localized names of the argument.
+      # @param description_localizations [Hash, nil] The localized descriptions of the argument.
       # @return (see #option)
-      def user(name, description, required: nil)
-        option(TYPES[:user], name, description, required: required)
+      def user(name, description, required: nil, name_localizations: nil, description_localizations: nil)
+        option(TYPES[:user], name, description, required: required, name_localizations: name_localizations, description_localizations: description_localizations)
       end
 
       # @param name [String, Symbol] The name of the argument.
       # @param description [String] A description of the argument.
       # @param required [true, false] Whether this option must be provided.
       # @param types [Array<Symbol, Integer>] See {CHANNEL_TYPES}
+      # @param name_localizations [Hash, nil] The localized names of the argument.
+      # @param description_localizations [Hash, nil] The localized descriptions of the argument.
       # @return (see #option)
-      def channel(name, description, required: nil, types: nil)
+      def channel(name, description, required: nil, types: nil, name_localizations: nil, description_localizations: nil)
         types = types&.collect { |type| type.is_a?(Numeric) ? type : CHANNEL_TYPES[type] }
-        option(TYPES[:channel], name, description, required: required, channel_types: types)
+        option(TYPES[:channel], name, description, required: required, channel_types: types, name_localizations: name_localizations, description_localizations: description_localizations)
       end
 
       # @param name [String, Symbol] The name of the argument.
       # @param description [String] A description of the argument.
       # @param required [true, false] Whether this option must be provided.
+      # @param name_localizations [Hash, nil] The localized names of the argument.
+      # @param description_localizations [Hash, nil] The localized descriptions of the argument.
       # @return (see #option)
-      def role(name, description, required: nil)
-        option(TYPES[:role], name, description, required: required)
+      def role(name, description, required: nil, name_localizations: nil, description_localizations: nil)
+        option(TYPES[:role], name, description, required: required, name_localizations: name_localizations, description_localizations: description_localizations)
       end
 
       # @param name [String, Symbol] The name of the argument.
       # @param description [String] A description of the argument.
       # @param required [true, false] Whether this option must be provided.
+      # @param name_localizations [Hash, nil] The localized names of the argument.
+      # @param description_localizations [Hash, nil] The localized descriptions of the argument.
       # @return (see #option)
-      def mentionable(name, description, required: nil)
-        option(TYPES[:mentionable], name, description, required: required)
+      def mentionable(name, description, required: nil, name_localizations: nil, description_localizations: nil)
+        option(TYPES[:mentionable], name, description, required: required, name_localizations: name_localizations, description_localizations: description_localizations)
       end
 
       # @param name [String, Symbol] The name of the argument.
@@ -670,18 +688,22 @@ module Discordrb
       # @param min_value [Float] A minimum value for option.
       # @param max_value [Float] A maximum value for option.
       # @param autocomplete [true, false] Whether this option can dynamically show choices.
+      # @param name_localizations [Hash, nil] The localized names of the argument.
+      # @param description_localizations [Hash, nil] The localized descriptions of the argument.
       # @return (see #option)
-      def number(name, description, required: nil, min_value: nil, max_value: nil, choices: nil, autocomplete: nil)
+      def number(name, description, required: nil, min_value: nil, max_value: nil, choices: nil, autocomplete: nil, name_localizations: nil, description_localizations: nil)
         option(TYPES[:number], name, description,
-               required: required, min_value: min_value, max_value: max_value, choices: choices, autocomplete: autocomplete)
+               required: required, min_value: min_value, max_value: max_value, choices: choices, autocomplete: autocomplete, name_localizations: name_localizations, description_localizations: description_localizations)
       end
 
       # @param name [String, Symbol] The name of the argument.
       # @param description [String] A description of the argument.
       # @param required [true, false] Whether this option must be provided.
+      # @param name_localizations [Hash, nil] The localized names of the argument.
+      # @param description_localizations [Hash, nil] The localized descriptions of the argument.
       # @return (see #option)
-      def attachment(name, description, required: nil)
-        option(TYPES[:attachment], name, description, required: required)
+      def attachment(name, description, required: nil, name_localizations: nil, description_localizations: nil)
+        option(TYPES[:attachment], name, description, required: required, name_localizations: name_localizations, description_localizations: description_localizations)
       end
 
       # @!visibility private
@@ -695,10 +717,12 @@ module Discordrb
       # @param max_length [Integer] A maximum length for string option value.
       # @param channel_types [Array<Integer>] Channel types that can be provides for channel options.
       # @param autocomplete [true, false] Whether this option can dynamically show options.
+      # @param name_localizations [Hash, nil] The localized names of the argument.
+      # @param description_localizations [Hash, nil] The localized descriptions of the argument.
       # @return Hash
       def option(type, name, description, required: nil, choices: nil, options: nil, min_value: nil, max_value: nil,
-                 min_length: nil, max_length: nil, channel_types: nil, autocomplete: nil)
-        opt = { type: type, name: name, description: description }
+                 min_length: nil, max_length: nil, channel_types: nil, autocomplete: nil, name_localizations: nil, description_localizations: nil)
+        opt = { type: type, name: name, description: description, name_localizations: name_localizations, description_localizations: description_localizations }
         choices = choices.map { |option_name, value| { name: option_name, value: value } } if choices
 
         opt.merge!({ required: required, choices: choices, options: options, min_value: min_value,

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -401,10 +401,12 @@ module Discordrb
     # @param description [String] The description of this command.
     # @param default_permission [true, false] Whether this command is available with default permissions.
     # @param nsfw [true, false] Whether this command should be marked as age-restricted.
+    # @param name_localizations [Hash] The localized names of the command.
+    # @param description_localizations [Hash] The localized descriptions of the command.
     # @yieldparam (see Bot#edit_application_command)
     # @return (see Bot#edit_application_command)
-    def edit(name: nil, description: nil, default_permission: nil, nsfw: nil, &block)
-      @bot.edit_application_command(@id, server_id: @server_id, name: name, description: description, default_permission: default_permission, nsfw: nsfw, &block)
+    def edit(name: nil, description: nil, default_permission: nil, nsfw: nil, name_localizations: nil, description_localizations: nil, &block)
+      @bot.edit_application_command(@id, server_id: @server_id, name: name, description: description, default_permission: default_permission, nsfw: nsfw, name_localizations: name_localizations, description_localizations: description_localizations, &block)
     end
 
     # Delete this application command.

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -343,8 +343,14 @@ module Discordrb
     # @return [String]
     attr_reader :name
 
+    # @return [Hash, nil]
+    attr_reader :name_localizations
+
     # @return [String]
     attr_reader :description
+
+    # @return [Hash, nil]
+    attr_reader :description_localizations
 
     # @return [true, false]
     attr_reader :default_permission
@@ -366,7 +372,9 @@ module Discordrb
       @server_id = server_id&.to_i
 
       @name = data['name']
+      @name_localizations = data['name_localizations']
       @description = data['description']
+      @description_localizations = data['description_localizations']
       @default_permission = data['default_permission']
       @options = data['options']
       @nsfw = data['nsfw'] || false


### PR DESCRIPTION
# Summary

This PR adds support for registering and editing name and description localizations of application commands and their options. I took a slightly different approach than in #190, because I don’t like the additional builder.

---

## Added
* Support for registering and editing the `name_localizations` and `description_localizations` properties of application commands and their options
* Example usage of application command localizations in the slash commands example
* Support for setting `with_localizations` when calling `Discordrb::Bot#get_application_commands`.