### PR TITLE
Fix buttons and string selects without emojis breaking due to API change

### DIFF
--- a/lib/discordrb/webhooks/view.rb
+++ b/lib/discordrb/webhooks/view.rb
@@ -49,7 +49,7 @@ class Discordrb::Webhooks::View
               when Integer, String
                 emoji.to_i.positive? ? { id: emoji } : { name: emoji }
               else
-                emoji.to_h
+                emoji&.to_h
               end
 
       @components << { type: COMPONENT_TYPES[:button], label: label, emoji: emoji, style: style, custom_id: custom_id, disabled: disabled, url: url }
@@ -149,7 +149,7 @@ class Discordrb::Webhooks::View
               when Integer, String
                 emoji.to_i.positive? ? { id: emoji } : { name: emoji }
               else
-                emoji.to_h
+                emoji&.to_h
               end
 
       @options << { label: label, value: value, description: description, emoji: emoji, default: default }


### PR DESCRIPTION
Fix buttons and string selects without emojis breaking due to API change (fixes #247)

# Summary

Due to a Discord API change, buttons and string selects without emojis no longer work in the current Discordrb version (as stated in #247. This PR fixes this issue by returning nil instead of an empty hash. 
