### PR TITLE
Fix InteractionCreateEvent type matching

### DIFF
--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -105,11 +105,11 @@ module Discordrb::Events
       [
         matches_all(@attributes[:type], event.type) do |a, e|
           match_type = case a
-               when String, Symbol
-                 Discordrb::Interaction::TYPES[a.to_sym]
-               else
-                 a
-               end
+                       when String, Symbol
+                         Discordrb::Interaction::TYPES[a.to_sym]
+                       else
+                         a
+                       end
           match_type == e
         end,
 

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -104,12 +104,13 @@ module Discordrb::Events
 
       [
         matches_all(@attributes[:type], event.type) do |a, e|
-          a == case a
+          match_type = case a
                when String, Symbol
-                 Discordrb::Interactions::TYPES[e.to_sym]
+                 Discordrb::Interaction::TYPES[a.to_sym]
                else
-                 e
+                 a
                end
+          match_type == e
         end,
 
         matches_all(@attributes[:server], event.interaction) do |a, e|

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -155,6 +155,66 @@ describe Discordrb::Events do
     end
   end
 
+  describe Discordrb::Events::InteractionCreateEvent do
+    let(:bot) { double('bot', server: server) }
+    let(:server) { double }
+    let(:interaction) { double('Discordrb::Interaction') }
+    let(:user) { double{'Discordrb::User'} }
+
+    shared_examples 'type name attributes' do |type, matching, non_matching|
+      it "matches #{matching} as :#{type.to_sym}" do
+        event = double('Discordrb::Events::InteractionCreateEvent', type: matching, interaction: interaction, user: user )
+        allow(event).to receive(:is_a?).with(Discordrb::Events::InteractionCreateEvent).and_return(true)
+        handler = Discordrb::Events::InteractionCreateEventHandler.new({type: type.to_sym}, double('proc'))
+        expect(handler.matches?(event)).to be_truthy
+      end
+
+      it "matches #{matching} as '#{type.to_s}'" do
+        event = double('Discordrb::Events::InteractionCreateEvent', type: matching, interaction: interaction, user: user )
+        allow(event).to receive(:is_a?).with(Discordrb::Events::InteractionCreateEvent).and_return(true)
+        handler = Discordrb::Events::InteractionCreateEventHandler.new({type: type.to_s}, double('proc'))
+        expect(handler.matches?(event)).to be_truthy
+      end
+
+      it "doesn't match #{non_matching} as :#{type.to_sym}" do
+        event = double('Discordrb::Events::InteractionCreateEvent', type: non_matching, interaction: interaction, user: user )
+        allow(event).to receive(:is_a?).with(Discordrb::Events::InteractionCreateEvent).and_return(true)
+        handler = Discordrb::Events::InteractionCreateEventHandler.new({type: type}, double('proc'))
+        expect(handler.matches?(event)).to be_falsy
+      end
+    end
+
+    shared_examples 'type value attributes' do |type, matching, non_matching|
+      it "matches #{matching}" do
+        event = double('Discordrb::Events::InteractionCreateEvent', type: matching, interaction: interaction, user: user )
+        allow(event).to receive(:is_a?).with(Discordrb::Events::InteractionCreateEvent).and_return(true)
+        handler = Discordrb::Events::InteractionCreateEventHandler.new({type: type}, double('proc'))
+        expect(handler.matches?(event)).to be_truthy
+      end
+
+      it "doesn't match #{non_matching}" do
+        event = double('Discordrb::Events::InteractionCreateEvent', type: non_matching, interaction: interaction, user: user )
+        allow(event).to receive(:is_a?).with(Discordrb::Events::InteractionCreateEvent).and_return(true)
+        handler = Discordrb::Events::InteractionCreateEventHandler.new({type: type}, double('proc'))
+        expect(handler.matches?(event)).to be_falsy
+      end
+    end
+
+    include_examples(
+      'type name attributes',
+      Discordrb::Interaction::TYPES.keys.last, # :modal_submit
+      Discordrb::Interaction::TYPES.values.last, # 5
+      Discordrb::Interaction::TYPES.values.last + 1
+    )
+
+    include_examples(
+      'type value attributes',
+      Discordrb::Interaction::TYPES.values.last, # modal_submit: 5
+      Discordrb::Interaction::TYPES.values.last, # 5
+      Discordrb::Interaction::TYPES.values.last + 1
+    )
+  end
+
   describe Discordrb::Events::MessageEventHandler do
     describe 'matches?' do
       it 'should call with empty attributes' do

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -159,43 +159,43 @@ describe Discordrb::Events do
     let(:bot) { double('bot', server: server) }
     let(:server) { double }
     let(:interaction) { double('Discordrb::Interaction') }
-    let(:user) { double{'Discordrb::User'} }
+    let(:user) { double { 'Discordrb::User' } }
 
     shared_examples 'type name attributes' do |type, matching, non_matching|
       it "matches #{matching} as :#{type.to_sym}" do
-        event = double('Discordrb::Events::InteractionCreateEvent', type: matching, interaction: interaction, user: user )
+        event = double('Discordrb::Events::InteractionCreateEvent', type: matching, interaction: interaction, user: user)
         allow(event).to receive(:is_a?).with(Discordrb::Events::InteractionCreateEvent).and_return(true)
-        handler = Discordrb::Events::InteractionCreateEventHandler.new({type: type.to_sym}, double('proc'))
+        handler = Discordrb::Events::InteractionCreateEventHandler.new({ type: type.to_sym }, double('proc'))
         expect(handler.matches?(event)).to be_truthy
       end
 
-      it "matches #{matching} as '#{type.to_s}'" do
-        event = double('Discordrb::Events::InteractionCreateEvent', type: matching, interaction: interaction, user: user )
+      it "matches #{matching} as '#{type}'" do
+        event = double('Discordrb::Events::InteractionCreateEvent', type: matching, interaction: interaction, user: user)
         allow(event).to receive(:is_a?).with(Discordrb::Events::InteractionCreateEvent).and_return(true)
-        handler = Discordrb::Events::InteractionCreateEventHandler.new({type: type.to_s}, double('proc'))
+        handler = Discordrb::Events::InteractionCreateEventHandler.new({ type: type.to_s }, double('proc')) # rubocop:disable Lint/RedundantStringCoercion
         expect(handler.matches?(event)).to be_truthy
       end
 
       it "doesn't match #{non_matching} as :#{type.to_sym}" do
-        event = double('Discordrb::Events::InteractionCreateEvent', type: non_matching, interaction: interaction, user: user )
+        event = double('Discordrb::Events::InteractionCreateEvent', type: non_matching, interaction: interaction, user: user)
         allow(event).to receive(:is_a?).with(Discordrb::Events::InteractionCreateEvent).and_return(true)
-        handler = Discordrb::Events::InteractionCreateEventHandler.new({type: type}, double('proc'))
+        handler = Discordrb::Events::InteractionCreateEventHandler.new({ type: type }, double('proc'))
         expect(handler.matches?(event)).to be_falsy
       end
     end
 
     shared_examples 'type value attributes' do |type, matching, non_matching|
       it "matches #{matching}" do
-        event = double('Discordrb::Events::InteractionCreateEvent', type: matching, interaction: interaction, user: user )
+        event = double('Discordrb::Events::InteractionCreateEvent', type: matching, interaction: interaction, user: user)
         allow(event).to receive(:is_a?).with(Discordrb::Events::InteractionCreateEvent).and_return(true)
-        handler = Discordrb::Events::InteractionCreateEventHandler.new({type: type}, double('proc'))
+        handler = Discordrb::Events::InteractionCreateEventHandler.new({ type: type }, double('proc'))
         expect(handler.matches?(event)).to be_truthy
       end
 
       it "doesn't match #{non_matching}" do
-        event = double('Discordrb::Events::InteractionCreateEvent', type: non_matching, interaction: interaction, user: user )
+        event = double('Discordrb::Events::InteractionCreateEvent', type: non_matching, interaction: interaction, user: user)
         allow(event).to receive(:is_a?).with(Discordrb::Events::InteractionCreateEvent).and_return(true)
-        handler = Discordrb::Events::InteractionCreateEventHandler.new({type: type}, double('proc'))
+        handler = Discordrb::Events::InteractionCreateEventHandler.new({ type: type }, double('proc'))
         expect(handler.matches?(event)).to be_falsy
       end
     end


### PR DESCRIPTION
# Summary

This PR fixes some bugs where matching Interactions based on type via a symbol or string wasn't working. There was a typo in the matcher block, and as far as I can call the comparison wasn't working either. Specs have been added to cover all formats described as supported in the documentation for matching Interaction types (Integer, String, and Symbol).

Example broken code before this fix:

```rb
module EventHandler
  extend Discordrb::EventContainer

  interaction_create type: :component do |event|
    event.defer
  end
end
```

This would result in `NameError: uninitialized constant Discordrb::Interactions::TYPES`

---

## Added

* Specs for `InteractionCreateEvent`

## Changed

* Matching behavior for `:type` attribute in `InteractionCreateEventHandler`

## Deprecated

## Removed

## Fixed

* `NameError: uninitialized constant Discordrb::Interactions::TYPES` in `InteractionCreateEventHandler` when matching on `:type`
* Incorrect matching logic with Strings and Symbols in `InteractionCreateEventHandler` `:type` attribute
