### PR TITLE
add min/max_length support for string option and min/max_value for integer

### DIFF
--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -466,19 +466,25 @@ module Discordrb
       # @param name [String, Symbol] The name of the argument.
       # @param description [String] A description of the argument.
       # @param required [true, false] Whether this option must be provided.
+      # @param min_length [Integer] A minimum length for option value.
+      # @param max_length [Integer] A maximum length for option value.
       # @param choices [Hash, nil] Available choices, mapped as `Name => Value`.
       # @return (see #option)
-      def string(name, description, required: nil, choices: nil)
-        option(TYPES[:string], name, description, required: required, choices: choices)
+      def string(name, description, required: nil, min_length: nil, max_length: nil, choices: nil)
+        option(TYPES[:string], name, description,
+               required: required, min_length: min_length, max_length: max_length, choices: choices)
       end
 
       # @param name [String, Symbol] The name of the argument.
       # @param description [String] A description of the argument.
       # @param required [true, false] Whether this option must be provided.
+      # @param min_value [Integer] A minimum value for option.
+      # @param max_value [Integer] A maximum value for option.
       # @param choices [Hash, nil] Available choices, mapped as `Name => Value`.
       # @return (see #option)
-      def integer(name, description, required: nil, choices: nil)
-        option(TYPES[:integer], name, description, required: required, choices: choices)
+      def integer(name, description, required: nil, min_value: nil, max_value: nil, choices: nil)
+        option(TYPES[:integer], name, description,
+               required: required, min_value: min_value, max_value: max_value, choices: choices)
       end
 
       # @param name [String, Symbol] The name of the argument.
@@ -526,6 +532,8 @@ module Discordrb
       # @param name [String, Symbol] The name of the argument.
       # @param description [String] A description of the argument.
       # @param required [true, false] Whether this option must be provided.
+      # @param min_value [Float] A minimum value for option.
+      # @param max_value [Float] A maximum value for option.
       # @return (see #option)
       def number(name, description, required: nil, min_value: nil, max_value: nil, choices: nil)
         option(TYPES[:number], name, description,
@@ -547,15 +555,18 @@ module Discordrb
       # @param required [true, false] Whether this option must be provided.
       # @param min_value [Integer, Float] A minimum value for integer and number options.
       # @param max_value [Integer, Float] A maximum value for integer and number options.
+      # @param min_length [Integer] A minimum length for string option value.
+      # @param max_length [Integer] A maximum length for string option value.
       # @param channel_types [Array<Integer>] Channel types that can be provides for channel options.
       # @return Hash
       def option(type, name, description, required: nil, choices: nil, options: nil, min_value: nil, max_value: nil,
-                 channel_types: nil)
+                 min_length: nil, max_length: nil, channel_types: nil)
         opt = { type: type, name: name, description: description }
         choices = choices.map { |option_name, value| { name: option_name, value: value } } if choices
 
         opt.merge!({ required: required, choices: choices, options: options, min_value: min_value,
-                     max_value: max_value, channel_types: channel_types }.compact)
+                     max_value: max_value, min_length: min_length, max_length: max_length,
+                     channel_types: channel_types }.compact)
 
         @options << opt
         opt


### PR DESCRIPTION
# Summary

Add missing supported arguments for string and integer option types

## Added

* `string` - add support for `min_length` & `max_length` arguments
* `integer` - add support for `min_value` & `max_value` arguments
* `number` - add documentation for `min_value` & `max_value` arguments

## Example code

```rb
BOT.register_application_command(:test, "test command") do |cmd|
  cmd.integer("integer", "integer option", required: false, min_value: -5, max_value: 5)
  cmd.number("number", "number option", required: false, min_value: -3.14, max_value: 3.14)
  cmd.string("string", "string option", required: false, min_length: 8, max_length: 32)
end

BOT.application_command(:test) do |event|
  integer = event.options["integer"]
  number = event.options["number"]
  string = event.options["string"]

  event.respond(ephemeral: true) do |msg|
    msg.add_embed do |embed|
      embed.description = <<~MSG
        integer: #{integer}
        number: #{number}
        string: #{string}
      MSG
    end
  end
end
```