### PR TITLE
Fix edit_application_command with global scope.

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -868,7 +868,7 @@ module Discordrb
       resp = if server_id
                API::Application.edit_guild_command(@token, profile.id, server_id, command_id, name, description, builder.to_a, default_permission, type)
              else
-               API::Application.edit_guild_command(@token, profile.id, command_id, name, description, builder.to_a, default_permission.type)
+               API::Application.edit_global_command(@token, profile.id, command_id, name, description, builder.to_a, default_permission, type)
              end
       cmd = ApplicationCommand.new(JSON.parse(resp), self, server_id)
 


### PR DESCRIPTION
# Summary

A condition has errors when editing globally scoped command. Firstly, #type is called on object that might be nil, which results into:
"Exception: #<NoMethodError: undefined method `type' for nil:NilClass>" in the logs.

Secondly, fix the method name itself as it should be edit_global_command, since guild commands are dealt with in previous branch.

---
Excuse the brevity of the following sections, but this is a very simple one-line fix for an error encountered when programming my bot.

* Fix copy-paste typos.

## Fixed

Fix
`Exception: #<NoMethodError: undefined method `type' for nil:NilClass>`

and (once the passed in arguments is fixed)
`Exception: #<Discordrb::Errors::UnknownError: Discordrb::Errors::UnknownError>`