### PR TITLE
Fix bug in interaction view builder related to emojis in interaction response view builder.

### DIFF
--- a/lib/discordrb/version.rb
+++ b/lib/discordrb/version.rb
@@ -3,5 +3,5 @@
 # Discordrb and all its functionality, in this case only the version.
 module Discordrb
   # The current version of discordrb.
-  VERSION = '3.5.0'
+  VERSION = '3.5.1'
 end

--- a/lib/discordrb/webhooks/version.rb
+++ b/lib/discordrb/webhooks/version.rb
@@ -4,6 +4,6 @@
 module Discordrb
   module Webhooks
     # The current version of discordrb-webhooks.
-    VERSION = '3.5.0'
+    VERSION = '3.5.1'
   end
 end

--- a/lib/discordrb/webhooks/view.rb
+++ b/lib/discordrb/webhooks/view.rb
@@ -44,13 +44,7 @@ class Discordrb::Webhooks::View
     # @param url [String, nil] The URL, when using a link style button.
     def button(style:, label: nil, emoji: nil, custom_id: nil, disabled: nil, url: nil)
       style = BUTTON_STYLES[style] || style
-
-      emoji = case emoji
-              when Integer, String
-                emoji.to_i.positive? ? { id: emoji } : { name: emoji }
-              else
-                emoji&.to_h
-              end
+      emoji = Discordrb::Webhooks::View.get_emoji(emoji)
 
       @components << { type: COMPONENT_TYPES[:button], label: label, emoji: emoji, style: style, custom_id: custom_id, disabled: disabled, url: url }
     end
@@ -145,13 +139,7 @@ class Discordrb::Webhooks::View
     #   that responds to `#to_h` which returns a hash in the format of `{ id: Integer, name: string }`.
     # @param default [true, false, nil] Whether this is the default selected option.
     def option(label:, value:, description: nil, emoji: nil, default: nil)
-      emoji = case emoji
-              when Integer, String
-                emoji.to_i.positive? ? { id: emoji } : { name: emoji }
-              else
-                emoji&.to_h
-              end
-
+      emoji = Discordrb::Webhooks::View.get_emoji(emoji)
       @options << { label: label, value: value, description: description, emoji: emoji, default: default }
     end
 
@@ -190,5 +178,22 @@ class Discordrb::Webhooks::View
   # @!visibility private
   def to_a
     @rows.map(&:to_h)
+  end
+
+  private
+
+  # @!visibility private
+  def self.get_emoji(emoji)
+    case emoji
+    when Integer
+      raise ArgumentError, 'Emoji ID must be positive' if emoji.to_i.negative?
+      { id: emoji }
+    when String
+      { name: emoji }
+    when NilClass
+      nil
+    else
+      emoji.to_h
+    end
   end
 end


### PR DESCRIPTION
- Fix `nil` emojis producing an empty hash, which is incompatible with the Discord API.
- Deduplicate the emoji handling code in the view builder.
- Introduce a new error state to make emoji handling slightly more robust.

# Summary

As mentioned in #258, the absence of emojis in button and select menu interaction responses results in invalid API requests. This PR fixes #258 and makes select menus and buttons function as expected.

---

## Changed

- Version number of `discordrb` gem bumped to `3.5.1`
- Version number of `discordrb-webhooks` gem bumped to `3.5.1`
- De-duplicate emoji handling code in webhook interaction view builder.
- Introduce a new error state for invalid integer ID emojis that will `raise` an `ArgumentError`.

## Fixed

- Fixed emoji handling in `webhooks/view.rb` so button and select menu interaction components produce valid API requests.

The components that allow emojis have been changed to the following:

https://github.com/SirTony/discordrb/blob/431ca82578d8a1042b39d00456cd07878caaabcd/lib/discordrb/webhooks/view.rb#L47

https://github.com/SirTony/discordrb/blob/431ca82578d8a1042b39d00456cd07878caaabcd/lib/discordrb/webhooks/view.rb#L142

https://github.com/SirTony/discordrb/blob/431ca82578d8a1042b39d00456cd07878caaabcd/lib/discordrb/webhooks/view.rb#L186-L198