### PR TITLE
Add support for role mentions on the bot's autogenerated managed roleid.

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1321,7 +1321,7 @@ module Discordrb
         end
         # Raises a MentionEvent for a bot's managed integration role:
         # A managed role is auto-generated for any bots joined to a server with permissions > 0
-        # For this to generate an event, 
+        # For this to generate an event, set role_managed: true
         if message.role_mentions.any? { |role| role.managed? == true && role.tags.bot_id == @profile.id }
           event = MentionEvent.new(message, self)
           event.role_mention = true

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1317,6 +1317,15 @@ module Discordrb
 
         if message.mentions.any? { |user| user.id == @profile.id }
           event = MentionEvent.new(message, self)
+          event.role_mention = false
+          raise_event(event)
+        end
+        # Raises a MentionEvent for a bot's managed integration role:
+        # A managed role is auto-generated for any bots joined to a server with permissions > 0
+        # For this to generate an event, 
+        if message.role_mentions.any? { |role| role.managed? == true && role.tags.bot_id == @profile.id }
+          event = MentionEvent.new(message, self)
+          event.role_mention = true
           raise_event(event)
         end
 

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -200,6 +200,7 @@ module Discordrb
     # @option attributes [Time] :after Matches a time after the time the message was sent at.
     # @option attributes [Time] :before Matches a time before the time the message was sent at.
     # @option attributes [Boolean] :private Matches whether or not the channel is private.
+    # @option attributes [Boolean] :allow_role_mention whether the event triggers on bot managed roleid mentions.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [MentionEvent] The event that was raised.
     # @return [MentionEventHandler] the event handler that was registered.

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -264,10 +264,92 @@ module Discordrb::Events
   end
 
   # @see Discordrb::EventContainer#mention
-  class MentionEvent < MessageEvent; end
+  class MentionEvent < MessageEvent
+    attr_accessor :role_mention
+
+    def initialize(message, bot)
+      @bot = bot
+      @message = message
+      @channel = message.channel
+      @saved_message = ''
+      @file = nil
+      @filename = nil
+      @file_spoiler = nil
+      @role_mention = false
+    end
+  end
 
   # Event handler for {MentionEvent}
-  class MentionEventHandler < MessageEventHandler; end
+  class MentionEventHandler < MessageEventHandler
+    def matches?(event)
+      # Check for the proper event type
+      return false unless event.is_a? MentionEvent
+      # Ensure this is not a role mention, or if it is, then allow_role_mention == true
+      return false unless (not event.role_mention) || (@attributes[:allow_role_mention] && event.role_mention)
+
+      [
+        matches_all(@attributes[:starting_with] || @attributes[:start_with], event.content) do |a, e|
+          case a
+          when String
+            e.start_with? a
+          when Regexp
+            (e =~ a)&.zero?
+          end
+        end,
+        matches_all(@attributes[:ending_with] || @attributes[:end_with], event.content) do |a, e|
+          case a
+          when String
+            e.end_with? a
+          when Regexp
+            !(e =~ Regexp.new("#{a}$")).nil?
+          end
+        end,
+        matches_all(@attributes[:containing] || @attributes[:contains], event.content) do |a, e|
+          case a
+          when String
+            e.include? a
+          when Regexp
+            (e =~ a)
+          end
+        end,
+        matches_all(@attributes[:in], event.channel) do |a, e|
+          case a
+          when String
+            # Make sure to remove the "#" from channel names in case it was specified
+            a.delete('#') == e.name
+          when Integer
+            a == e.id
+          else
+            a == e
+          end
+        end,
+        matches_all(@attributes[:from], event.author) do |a, e|
+          case a
+          when String
+            a == e.name
+          when Integer
+            a == e.id
+          when :bot
+            e.current_bot?
+          else
+            a == e
+          end
+        end,
+        matches_all(@attributes[:with_text] || @attributes[:content] || @attributes[:exact_text], event.content) do |a, e|
+          case a
+          when String
+            e == a
+          when Regexp
+            match = a.match(e)
+            match ? (e == match[0]) : false
+          end
+        end,
+        matches_all(@attributes[:after], event.timestamp) { |a, e| a > e },
+        matches_all(@attributes[:before], event.timestamp) { |a, e| a < e },
+        matches_all(@attributes[:private], event.channel.private?) { |a, e| !e == !a }
+      ].reduce(true, &:&)
+    end
+  end
 
   # @see Discordrb::EventContainer#pm
   class PrivateMessageEvent < MessageEvent; end

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -285,7 +285,7 @@ module Discordrb::Events
       # Check for the proper event type
       return false unless event.is_a? MentionEvent
       # Ensure this is not a role mention, or if it is, then allow_role_mention == true
-      return false unless (not event.role_mention) || (@attributes[:allow_role_mention] && event.role_mention)
+      return false unless (!event.role_mention) || (@attributes[:allow_role_mention] && event.role_mention)
 
       [
         matches_all(@attributes[:starting_with] || @attributes[:start_with], event.content) do |a, e|

--- a/lib/discordrb/version.rb
+++ b/lib/discordrb/version.rb
@@ -3,5 +3,5 @@
 # Discordrb and all its functionality, in this case only the version.
 module Discordrb
   # The current version of discordrb.
-  VERSION = '3.5.0'
+  VERSION = '3.5.1'
 end

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -151,7 +151,7 @@ describe Discordrb::Bot do
       let(:user_id) { instance_double(Integer, 'user_id') }
       let(:author) { instance_double(Discordrb::User, id: user_id) }
       let(:message_fixture) { { 'author' => { 'id' => user_id }, 'channel_id' => channel_id } }
-      let(:message) { instance_double(Discordrb::Message, channel: channel, from_bot?: false, mentions: []) }
+      let(:message) { instance_double(Discordrb::Message, channel: channel, from_bot?: false, mentions: [], role_mentions: []) }
 
       before do
         allow(bot).to receive(:channel).with(channel_id).and_return(channel)


### PR DESCRIPTION
# Summary

This is to address the discrepancy when a user types the bot's exact name, and discord translates it to a role mention due to the autogenerated managed role that's created when adding a bot with permissions > 0 to a server. Below is an example of the new behavior from an `irb` session:
```Ruby
3.1.4 :003 > bot.run :async
[INFO : websocket @ 2024-06-05 09:54:55.116] Discord using gateway protocol version: 9, requested: 9
 => nil
3.1.4 :004 > bot.mention(allow_role_mention: true) do |event|
3.1.4 :005 >     puts "THIS FIRES FOR USER & ROLE MENTIONS: #{event.content}"
3.1.4 :006 > end
 => #<Discordrb::Events::MentionEventHandler:0x000055742aa345c8 @attributes={:allow_role_mention=>true}, @block=#<Proc:0x000055742aa34a00 (irb):4>>
3.1.4 :007 > bot.mention() do |event|
3.1.4 :008 >     puts "THIS ONLY FIRES FOR USER MENTIONS: #{event.content}"
3.1.4 :009 > end
 => #<Discordrb::Events::MentionEventHandler:0x000055742ab280d8 @attributes={}, @block=#<Proc:0x000055742ab282b8 (irb):7>>
3.1.4 :010 >
3.1.4 :011 > 
THIS FIRES FOR USER & ROLE MENTIONS: <@1211423563475849236> user mention test
THIS ONLY FIRES FOR USER MENTIONS: <@1211423563475849236> user mention test
THIS FIRES FOR USER & ROLE MENTIONS: <@&1211432785353637999> role mention test
```

in the above test, I sent two messages to the bot, one with a role mention and the other with a user mention. The blocks passed demonstrate that _only_ when `:allow_role_mention == true` will the event be raised upon role mentions.

All tests were run with `bundle exec rspec spec` and passed:
```
Finished in 0.27027 seconds (files took 0.38679 seconds to load)
430 examples, 0 failures, 3 pending
```

---

## Changed
-  `discordrb/events/message.rb`
- `discordrb/bot.rb`
- `discordrb/container.rb`

additionally the gemspec was updated to include the `role_mentions:` flag, to avoid a no method error but otherwise function is exactly the same.

## Fixed

You could say the `bot.mention` function has been "fixed"? Depends how you view this feature & support for Discord's managed roles.
