### PR TITLE
Add base64 gem explicitly as dependency

### DIFF
--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'discordrb-webhooks', '~> 3.5.0'
 
+  spec.add_dependency 'base64', '~> 0.2.0'
+
   spec.required_ruby_version = '>= 3.1'
 
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'


### PR DESCRIPTION
# Summary

closes https://github.com/shardlab/discordrb/issues/256

base64 is no longer the default gem from Ruby 3.4
https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

On Ruby 3.3, we could see the warning:

```ruby
warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.
```

From Ruby 3.4, we will get the error:

```ruby
Failure/Error: require 'base64'

LoadError:
  cannot load such file -- base64
```

<!---
  Describe the general goal of your pull request here:

  - Include details about any issues you encountered that inspired
  the pull request, such as bugs or missing features.

  - If adding or changing features, include a small example that showcases
  the new behavior.

  - Reference any related issues or pull requests.

  Stuck or need help? Join the Discord! https://discord.gg/cyK3Hjm
--->

---

<!---
  List each individual change you made to the library here in the appropriate
  section in short, bulleted sentences.

  This will aid in reviewing your pull request, and for adding it to the
  changelog later.

  You may remove sections that have no items if you want.
--->

## Added

Add base64 dependency to gemspec