### PR TITLE
Add support for Application Integration Types and Interaction Context Types

### DIFF
--- a/lib/discordrb/api/application.rb
+++ b/lib/discordrb/api/application.rb
@@ -30,13 +30,13 @@ module Discordrb::API::Application
 
   # Create a global application command.
   # https://discord.com/developers/docs/interactions/slash-commands#create-global-application-command
-  def create_global_command(token, application_id, name, description, options = [], default_permission = nil, type = 1, default_member_permissions = nil, contexts = nil)
+  def create_global_command(token, application_id, name, description, options = [], default_permission = nil, type = 1, default_member_permissions = nil, contexts = nil, integration_types = nil)
     Discordrb::API.request(
       :applications_aid_commands,
       nil,
       :post,
       "#{Discordrb::API.api_base}/applications/#{application_id}/commands",
-      { name: name, description: description, options: options, default_permission: default_permission, type: type, default_member_permissions: default_member_permissions, contexts: contexts }.to_json,
+      { name: name, description: description, options: options, default_permission: default_permission, type: type, default_member_permissions: default_member_permissions, contexts: contexts, integration_types: integration_types }.to_json,
       Authorization: token,
       content_type: :json
     )
@@ -44,13 +44,13 @@ module Discordrb::API::Application
 
   # Edit a global application command.
   # https://discord.com/developers/docs/interactions/slash-commands#edit-global-application-command
-  def edit_global_command(token, application_id, command_id, name = nil, description = nil, options = nil, default_permission = nil, type = 1, default_member_permissions = nil, contexts = nil)
+  def edit_global_command(token, application_id, command_id, name = nil, description = nil, options = nil, default_permission = nil, type = 1, default_member_permissions = nil, contexts = nil, integration_types = nil)
     Discordrb::API.request(
       :applications_aid_commands_cid,
       nil,
       :patch,
       "#{Discordrb::API.api_base}/applications/#{application_id}/commands/#{command_id}",
-      { name: name, description: description, options: options, default_permission: default_permission, type: type, default_member_permissions: default_member_permissions, contexts: contexts }.compact.to_json,
+      { name: name, description: description, options: options, default_permission: default_permission, type: type, default_member_permissions: default_member_permissions, contexts: contexts, integration_types: integration_types }.compact.to_json,
       Authorization: token,
       content_type: :json
     )

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -831,7 +831,7 @@ module Discordrb
     #       end
     #     end
     #   end
-    def register_application_command(name, description, server_id: nil, default_permission: nil, type: :chat_input, default_member_permissions: nil, contexts: nil)
+    def register_application_command(name, description, server_id: nil, default_permission: nil, type: :chat_input, default_member_permissions: nil, contexts: nil, integration_types: nil)
       type = ApplicationCommand::TYPES[type] || type
 
       builder = Interactions::OptionBuilder.new
@@ -841,7 +841,7 @@ module Discordrb
       resp = if server_id
                API::Application.create_guild_command(@token, profile.id, server_id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts)
              else
-               API::Application.create_global_command(@token, profile.id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts)
+               API::Application.create_global_command(@token, profile.id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts, integration_types)
              end
       cmd = ApplicationCommand.new(JSON.parse(resp), self, server_id)
 
@@ -856,7 +856,7 @@ module Discordrb
 
     # @yieldparam [OptionBuilder]
     # @yieldparam [PermissionBuilder]
-    def edit_application_command(command_id, server_id: nil, name: nil, description: nil, default_permission: nil, type: :chat_input, default_member_permissions: nil, contexts: nil)
+    def edit_application_command(command_id, server_id: nil, name: nil, description: nil, default_permission: nil, type: :chat_input, default_member_permissions: nil, contexts: nil, integration_types: nil)
       type = ApplicationCommand::TYPES[type] || type
 
       builder = Interactions::OptionBuilder.new
@@ -867,7 +867,7 @@ module Discordrb
       resp = if server_id
                API::Application.edit_guild_command(@token, profile.id, server_id, command_id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts)
              else
-               API::Application.edit_global_command(@token, profile.id, command_id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts)
+               API::Application.edit_global_command(@token, profile.id, command_id, name, description, builder.to_a, default_permission, type, default_member_permissions, contexts, integration_types)
              end
       cmd = ApplicationCommand.new(JSON.parse(resp), self, server_id)
 

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -39,7 +39,7 @@ module Discordrb
       guild_install: 0,
       user_install: 1
     }.freeze
-  
+
     # @return [User, Member] The user that initiated the interaction.
     attr_reader :user
 

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -25,6 +25,21 @@ module Discordrb
       modal: 9
     }.freeze
 
+    # Interaction context types.
+    # @see https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-context-types
+    COMMAND_CONTEXTS = {
+      guild: 0,
+      bot_dm: 1,
+      private_channel: 2
+    }.freeze
+
+    # Application integration types.
+    # @see https://discord.com/developers/docs/resources/application#application-object-application-integration-types
+    COMMAND_INTEGRATION_TYPES = {
+      guild_install: 0,
+      user_install: 1
+    }.freeze
+  
     # @return [User, Member] The user that initiated the interaction.
     attr_reader :user
 


### PR DESCRIPTION
# Summary
Add support for [Application Integration Types](https://discord.com/developers/docs/resources/application#application-object-application-integration-types) and [Interaction Context Types](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-context-types) to allow registration of commands for chats outside guilds and the bots direct messages