### PR TITLE
Fix Rubocop Failing Tests

### DIFF
--- a/lib/discordrb/data/overwrite.rb
+++ b/lib/discordrb/data/overwrite.rb
@@ -65,7 +65,9 @@ module Discordrb
 
     # Comparison by attributes [:id, :type, :allow, :deny]
     def ==(other)
+      # rubocop:disable Lint/Void
       false unless other.is_a? Discordrb::Overwrite
+      # rubocop:enable Lint/Void
       id == other.id &&
         type == other.type &&
         allow == other.allow &&

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -136,7 +136,9 @@ module Discordrb
 
     # Comparison based on permission bits
     def ==(other)
+      # rubocop:disable Lint/Void
       false unless other.is_a? Discordrb::Permissions
+      # rubocop:enable Lint/Void
       bits == other.bits
     end
   end


### PR DESCRIPTION
# Summary

Fixes these Rubocop offenses that are causing circle-ci tests to fail when making PR's.

```
xxxxxx@xxxxx discordrb % bundle exec rubocop
Inspecting 127 files
....................................................W.....................................W....................................

Offences:

lib/discordrb/data/overwrite.rb:68:7: W: Lint/Void: Literal false used in void context.
      false unless other.is_a? Discordrb::Overwrite
      ^^^^^
lib/discordrb/permissions.rb:139:7: W: Lint/Void: Literal false used in void context.
      false unless other.is_a? Discordrb::Permissions
      ^^^^^
```

## Added

```
      # rubocop:disable Lint/Void
      false unless other.is_a? Discordrb::Permissions
      # rubocop:enable Lint/Void
```



## Changed

## Deprecated

## Removed

## Fixed

Rubocop offenses. 