### PR TITLE
Bump Voice Gateway Version

### DIFF
--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -167,7 +167,7 @@ module Discordrb::Voice
   # circle around users on Discord, and obtaining UDP connection info.
   class VoiceWS
     # The version of the voice gateway that's supposed to be used.
-    VOICE_GATEWAY_VERSION = 4
+    VOICE_GATEWAY_VERSION = 8
 
     # @return [VoiceUDP] the UDP voice connection over which the actual audio data is sent.
     attr_reader :udp


### PR DESCRIPTION
# Summary

As per the [Discord API docs](https://github.com/discord/discord-api-docs/pull/7075), old voice gateway versions will be deprecated on November 18, 2024.

## Changed

Bumped the voice gateway version to version 8.