### PR TITLE
Feat: search guild members

### DIFF
--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'base64', '~> 0.2.0'
   spec.add_dependency 'ffi', '>= 1.9.24'
   spec.add_dependency 'opus-ruby'
   spec.add_dependency 'rest-client', '>= 2.0.0'

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -138,6 +138,19 @@ module Discordrb::API::Server
     )
   end
 
+  # Search for a guild member
+  # https://discord.com/developers/docs/resources/guild#search-guild-members
+  def search_guild_members(token, server_id, query, limit)
+    query_string = URI.encode_www_form({ query: query, limit: limit }.compact)
+    Discordrb::API.request(
+      :guilds_sid_members,
+      server_id,
+      :get,
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/members/search?#{query_string}",
+      Authorization: token
+    )
+  end
+
   # Update a user properties
   # https://discord.com/developers/docs/resources/guild#modify-guild-member
   def update_member(token, server_id, user_id, nick: :undef, roles: :undef, mute: :undef, deaf: :undef, channel_id: :undef,

--- a/lib/discordrb/data/overwrite.rb
+++ b/lib/discordrb/data/overwrite.rb
@@ -65,7 +65,9 @@ module Discordrb
 
     # Comparison by attributes [:id, :type, :allow, :deny]
     def ==(other)
+      # rubocop:disable Lint/Void
       false unless other.is_a? Discordrb::Overwrite
+      # rubocop:enable Lint/Void
       id == other.id &&
         type == other.type &&
         allow == other.allow &&

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -587,9 +587,9 @@ module Discordrb
 
     # Searches a server for members that matches a username or a nickname.
     # @param name [String] The username or nickname to search for.
-    # @param limit [Integer] The maximum number of members between 1-1000 to return.
+    # @param limit [Integer] The maximum number of members between 1-1000 to return. Returns 1 member by default.
     # @return [Array<Member>] An array of member objects that match the given parameters.
-    def search_members(name, limit: nil)
+    def search_members(name:, limit: nil)
       response = JSON.parse(API::Server.search_guild_members(@bot.token, @id, name, limit))
       return nil if response.empty?
 

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -591,7 +591,7 @@ module Discordrb
     # @return [Array<Member>] An array of member objects that match the given parameters.
     def search_members(name, limit: nil)
       response = JSON.parse(API::Server.search_guild_members(@bot.token, @id, name, limit))
-      return nil if response.nil?
+      return nil if response.empty?
 
       response.map { |mem| Member.new(mem, self, @bot) }
     end

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -585,6 +585,17 @@ module Discordrb
       end
     end
 
+    # Searches a server for members that matches a username or a nickname.
+    # @param name [String] The username or nickname to search for.
+    # @param limit [Integer] The maximum number of members between 1-1000 to return.
+    # @return [Array<Member>] An array of member objects that match the given parameters.
+    def search_members(name, limit: nil)
+      response = JSON.parse(API::Server.search_guild_members(@bot.token, @id, name, limit))
+      return nil if response.nil?
+
+      response.map { |mem| Member.new(mem, self, @bot) }
+    end
+
     # Retrieve banned users from this server.
     # @param limit [Integer] Number of users to return (up to maximum 1000, default 1000).
     # @param before_id [Integer] Consider only users before given user id.

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -136,7 +136,9 @@ module Discordrb
 
     # Comparison based on permission bits
     def ==(other)
+      # rubocop:disable Lint/Void
       false unless other.is_a? Discordrb::Permissions
+      # rubocop:enable Lint/Void
       bits == other.bits
     end
   end


### PR DESCRIPTION
# Summary
Adds the [search guild members endpoint](https://discord.com/developers/docs/resources/guild#list-guild-members) and a corresponding abstraction for the server object.
## Added
`#search_guild_members` API call.
`#search_members` method.

## Fixed
Fixes the following warning by adding Base64 as an explicit dependency.
```
ruby/3.3.0/gems/discordrb-3.5.0/lib/discordrb/data.rb:18: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of discordrb-3.5.0 to add base64 into its gemspec.
```
