### PR TITLE
feat: application emojis

### DIFF
--- a/lib/discordrb/api/application.rb
+++ b/lib/discordrb/api/application.rb
@@ -199,4 +199,68 @@ module Discordrb::API::Application
       content_type: :json
     )
   end
+
+  # Get a list of application emojis.
+  # https://discord.com/developers/docs/resources/emoji#list-application-emojis
+  def list_application_emojis(token, application_id)
+    Discordrb::API.request(
+      :applications_aid_emojis,
+      nil,
+      :get,
+      "#{Discordrb::API.api_base}/applications/#{application_id}/emojis",
+      Authorization: token
+    )
+  end
+
+  # Get an application emoji by ID.
+  # https://discord.com/developers/docs/resources/emoji#get-application-emoji
+  def get_application_emoji(token, application_id, emoji_id)
+    Discordrb::API.request(
+      :applications_aid_emojis_eid,
+      nil,
+      :get,
+      "#{Discordrb::API.api_base}/applications/#{application_id}/emojis/#{emoji_id}",
+      Authorization: token
+    )
+  end
+
+  # Create an application emoji.
+  # https://discord.com/developers/docs/resources/emoji#create-application-emoji
+  def create_application_emoji(token, application_id, name, image)
+    Discordrb::API.request(
+      :applications_aid_emojis,
+      nil,
+      :post,
+      "#{Discordrb::API.api_base}/applications/#{application_id}/emojis",
+      { name: name, image: image }.to_json,
+      Authorization: token,
+      content_type: :json
+    )
+  end
+
+  # Edit an application emoji.
+  # https://discord.com/developers/docs/resources/emoji#modify-application-emoji
+  def edit_application_emoji(token, application_id, emoji_id, name)
+    Discordrb::API.request(
+      :applications_aid_emojis_eid,
+      nil,
+      :patch,
+      "#{Discordrb::API.api_base}/applications/#{application_id}/emojis/#{emoji_id}",
+      { name: name }.to_json,
+      Authorization: token,
+      content_type: :json
+    )
+  end
+
+  # Delete an application emoji.
+  # https://discord.com/developers/docs/resources/emoji#delete-application-emoji
+  def delete_application_emoji(token, application_id, emoji_id)
+    Discordrb::API.request(
+      :applications_aid_emojis_eid,
+      nil,
+      :delete,
+      "#{Discordrb::API.api_base}/applications/#{application_id}/emojis/#{emoji_id}",
+      Authorization: token
+    )
+  end
 end

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -906,14 +906,14 @@ module Discordrb
     # @return [Array<Emoji>] Returns an array of emoji objects.
     def application_emojis
       response = JSON.parse(API::Application.list_application_emojis(@token, profile.id))
-      response['items'].map { |emoji| Emoji.new(emoji, bot, nil) }
+      response['items'].map { |emoji| Emoji.new(emoji, @bot, nil) }
     end
 
     # Fetches a single application emoji from ID.
     # @return [Emoji] Returns an emoji object.
     def get_application_emoji(emoji_id)
       response = JSON.parse(API::Application.get_application_emoji(@token, profile.id, emoji_id))
-      Emoji.new(response, bot, nil)
+      Emoji.new(response, @bot, nil)
     end
 
     # Adds a new custom emoji that can be used by this application.
@@ -928,7 +928,7 @@ module Discordrb
       end
 
       response = JSON.parse(API::Application.create_application_emoji(@token, profile.id, name, image_string))
-      Emoji.new(response, bot, nil)
+      Emoji.new(response, @bot, nil)
     end
 
     # Edits an existing application emoji.
@@ -936,7 +936,7 @@ module Discordrb
     # @return [Emoji] Returns the updated emoji object on success.
     def edit_application_emoji(emoji_id, name)
       response = JSON.parse(API::Application.edit_application_emoji(@token, profile.id, emoji_id, name))
-      Emoji.new(response, bot, nil)
+      Emoji.new(response, @bot, nil)
     end
 
     # Deletes an existing application emoji.

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -902,6 +902,49 @@ module Discordrb
       API::Application.edit_guild_command_permissions(@token, profile.id, server_id, command_id, permissions)
     end
 
+    # Fetches all the application emojis that the bot can use.
+    # @return [Array<Emoji>] Returns an array of emoji objects.
+    def application_emojis
+      response = JSON.parse(API::Application.list_application_emojis(@token, profile.id))
+      response['items'].map { |emoji| Emoji.new(emoji, bot, nil) }
+    end
+
+    # Fetches a single application emoji from ID.
+    # @return [Emoji] Returns an emoji object.
+    def get_application_emoji(emoji_id)
+      response = JSON.parse(API::Application.get_application_emoji(@token, profile.id, emoji_id))
+      Emoji.new(response, bot, nil)
+    end
+
+    # Adds a new custom emoji that can be used by this application.
+    # @param name [String] The name of emoji to create.
+    # @param image [String, #read] A base64 encoded string with the image data, or an object that responds to `#read`, such as `File`.
+    # @return [Emoji] The emoji that has been created.
+    def create_application_emoji(name, image)
+      image_string = image
+      if image.respond_to? :read
+        image_string = 'data:image/jpg;base64,'
+        image_string += Base64.strict_encode64(image.read)
+      end
+
+      response = JSON.parse(API::Application.create_application_emoji(@token, profile.id, name, image_string))
+      Emoji.new(response, bot, nil)
+    end
+
+    # Edits an existing application emoji.
+    # @param name [String] The new name of the emoji.
+    # @return [Emoji] Returns the updated emoji object on success.
+    def edit_application_emoji(emoji_id, name)
+      response = JSON.parse(API::Application.edit_application_emoji(@token, profile.id, emoji_id, name))
+      Emoji.new(response, bot, nil)
+    end
+
+    # Deletes an existing application emoji.
+    # @param emoji_id [String] Snowflake ID of the emoji to delete.
+    def delete_application_emoji(emoji_id)
+      API::Application.delete_application_emoji(@token, profile.id, emoji_id)
+    end
+
     private
 
     # Throws a useful exception if there's currently no gateway connection.


### PR DESCRIPTION
# Summary
Add support for CRUD operations on application emojis via the REST API.

## Added
API calls for application emojis.
`API::Application.list_application_emojis`
`API::Application.get_application_emoji`
`API::Application.create_application_emoji`
`API::Application.edit_application_emoji`
`API::Application.delete_application_emoji`

Abstractions for application emojis.
`Bot#application_emojis`
`Bot#get_application_emoji`
`Bot#create_application_emoji`
`Bot#edit_application_emoji`
`Bot#delete_application_emoji`
