### PR TITLE
Custom Intents

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -106,9 +106,10 @@ module Discordrb
     #   to Discord's gateway. `:none` will request that no payloads are received compressed (not recommended for
     #   production bots). `:large` will request that large payloads are received compressed. `:stream` will request
     #   that all data be received in a continuous compressed stream.
-    # @param intents [:all, :unprivileged, Array<Symbol>, :none] Gateway intents that this bot requires. `:all` will
+    # @param intents [:all, :unprivileged, Array<Symbol>, :none, Integer] Gateway intents that this bot requires. `:all` will
     #   request all intents. `:unprivileged` will request only intents that are not defined as "Privileged". `:none`
-    #   will request no intents. An array of symbols will request only those intents specified.
+    #   will request no intents. An array of symbols will request only those intents specified. An integer value will request
+    #   exactly all the intents specified in the bitwise value.
     # @see Discordrb::INTENTS
     def initialize(
       log_mode: :normal,

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1712,6 +1712,8 @@ module Discordrb
     end
 
     def calculate_intents(intents)
+      intents = [intents] unless intents.is_a? Array
+
       intents.reduce(0) do |sum, intent|
         case intent
         when Symbol


### PR DESCRIPTION
# Summary
Add support for passing in a custom integer value for Gateway intents.

## Added

in `calculate_intents`
```ruby
      intents = [intents] unless intents.is_a? Array
```