### PR TITLE
feat: more version four endpoints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ inherit_mode:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.1
 
 # Disable line length checks
 Layout/LineLength:

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,3 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in discordrb.gemspec
 gemspec name: 'discordrb'
 gemspec name: 'discordrb-webhooks', development_group: 'webhooks'
-

--- a/discordrb-webhooks.gemspec
+++ b/discordrb-webhooks.gemspec
@@ -20,8 +20,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 1.8'
-  spec.add_dependency 'faraday_middleware', '~> 1.1.0'
+  spec.add_dependency 'faraday', '~> 2.12.0'
+  spec.add_dependency 'faraday-multipart', '~> 1.0.4'
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 3.1'
+  spec.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }
 end

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.1'
 
-  spec.add_development_dependency 'sord', '~> 6.0'
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'redcarpet', '~> 3.5' # YARD markdown formatting

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.authors       = %w[meew0 swarley]
   spec.email         = ['']
 
-  spec.summary       = 'Discord API for Ruby'
+  spec.summary       = 'Discord API for Ruby.'
   spec.description   = 'A Ruby implementation of the Discord (https://discord.com) API.'
   spec.homepage      = 'https://github.com/shardlab/discordrb'
   spec.license       = 'MIT'
@@ -19,28 +19,35 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.metadata = {
-    'changelog_uri' => 'https://github.com/shardlab/discordrb/blob/master/CHANGELOG.md'
+    'bug_tracker_uri' => 'https://github.com/shardlab/discordrb/issues',
+    'changelog_uri' => 'https://github.com/shardlab/discordrb/blob/main/CHANGELOG.md',
+    'documentation_uri' => 'https://github.com/shardlab/discordrb/wiki',
+    'source_code_uri' => 'https://github.com/shardlab/discordrb',
+    'rubygems_mfa_required' => 'true'
   }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'base64', '~> 0.2.0'
+  spec.add_dependency 'faraday', '~> 2.12.0'
+  spec.add_dependency 'faraday-multipart', '~> 1.0.4'
   spec.add_dependency 'ffi', '>= 1.9.24'
   spec.add_dependency 'opus-ruby'
-  spec.add_dependency 'faraday', '~> 1.8'
-  spec.add_dependency 'faraday_middleware', '~> 1.1.0'
   spec.add_dependency 'websocket-client-simple', '>= 0.3.0'
 
-  spec.add_dependency 'discordrb-webhooks', '~> 3.4.2'
+  spec.add_dependency 'discordrb-webhooks', '~> 4.0.0'
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 3.1'
 
+  spec.add_development_dependency 'sord', '~> 6.0'
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'redcarpet', '~> 3.5.0' # YARD markdown formatting
-  spec.add_development_dependency 'rspec', '~> 3.10.0'
-  spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 1.21.0'
+  spec.add_development_dependency 'redcarpet', '~> 3.5' # YARD markdown formatting
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.5'
+  spec.add_development_dependency 'rspec-prof', '~> 0.0'
+  spec.add_development_dependency 'rubocop', '~> 1.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.0'
-  spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'
-  spec.add_development_dependency 'simplecov', '~> 0.21.0'
-  spec.add_development_dependency 'yard', '~> 0.9.9'
+  spec.add_development_dependency 'rubocop-rake', '~> 0.6'
+  spec.add_development_dependency 'simplecov', '~> 0.21'
+  spec.add_development_dependency 'yard', '~> 0.9'
 end

--- a/lib/discordrb/api/client.rb
+++ b/lib/discordrb/api/client.rb
@@ -129,7 +129,7 @@ module Discordrb
       include WebhookEndpoints
 
       # The user agent used when making requests.
-      USER_AGENT = "DiscordBot (https://github.com/shardlab/discordrb, #{Discordrb::VERSION})".freeze
+      USER_AGENT = "DiscordBot (https://github.com/shardlab/discordrb, #{Discordrb::VERSION})"
 
       def initialize(token, version: 9)
         @conn = Faraday.new("https://discord.com/api/v#{version}") do |builder|

--- a/lib/discordrb/api/client.rb
+++ b/lib/discordrb/api/client.rb
@@ -1,15 +1,23 @@
 # frozen_string_literal: true
 
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/multipart'
 require 'discordrb/api/endpoints/application_command'
+require 'discordrb/api/endpoints/application'
 require 'discordrb/api/endpoints/audit_log'
+require 'discordrb/api/endpoints/auto_moderation'
 require 'discordrb/api/endpoints/channel'
 require 'discordrb/api/endpoints/emoji'
+require 'discordrb/api/endpoints/entitlement'
+require 'discordrb/api/endpoints/guild_scheduled_event'
 require 'discordrb/api/endpoints/guild'
 require 'discordrb/api/endpoints/guild_template'
 require 'discordrb/api/endpoints/interaction'
 require 'discordrb/api/endpoints/invite'
+require 'discordrb/api/endpoints/message'
+require 'discordrb/api/endpoints/poll'
+require 'discordrb/api/endpoints/sku'
+require 'discordrb/api/endpoints/soundboard'
 require 'discordrb/api/endpoints/stage_instance'
 require 'discordrb/api/endpoints/sticker'
 require 'discordrb/api/endpoints/user'
@@ -99,13 +107,21 @@ module Discordrb
     # Client for making HTTP requests to the Discord API.
     class Client
       include ApplicationCommandEndpoints
+      include ApplicationEndpoints
       include AuditLogEndpoints
+      include AutoModerationEndpoints
       include ChannelEndpoints
       include EmojiEndpoints
+      include EntitlementEndpoints
+      include GuildScheduledEventEndpoints
       include GuildEndpoints
       include GuildTemplateEndpoints
       include InteractionEndpoints
       include InviteEndpoints
+      include MessageEndpoints
+      include PollEndpoints
+      include SkuEndpoints
+      include SoundboardEndpoints
       include StageInstanceEndpoints
       include StickerEndpoints
       include UserEndpoints
@@ -113,7 +129,7 @@ module Discordrb
       include WebhookEndpoints
 
       # The user agent used when making requests.
-      USER_AGENT = "DiscordBot (https://github.com/shardlab/discordrb, #{Discordrb::VERSION})"
+      USER_AGENT = "DiscordBot (https://github.com/shardlab/discordrb, #{Discordrb::VERSION})".freeze
 
       def initialize(token, version: 9)
         @conn = Faraday.new("https://discord.com/api/v#{version}") do |builder|

--- a/lib/discordrb/api/client.rb
+++ b/lib/discordrb/api/client.rb
@@ -20,6 +20,7 @@ require 'discordrb/api/endpoints/sku'
 require 'discordrb/api/endpoints/soundboard'
 require 'discordrb/api/endpoints/stage_instance'
 require 'discordrb/api/endpoints/sticker'
+require 'discordrb/api/endpoints/subscription'
 require 'discordrb/api/endpoints/user'
 require 'discordrb/api/endpoints/voice'
 require 'discordrb/api/endpoints/webhook'
@@ -124,6 +125,7 @@ module Discordrb
       include SoundboardEndpoints
       include StageInstanceEndpoints
       include StickerEndpoints
+      include SubscriptionEndpoints
       include UserEndpoints
       include VoiceEndpoints
       include WebhookEndpoints

--- a/lib/discordrb/api/endpoints/application.rb
+++ b/lib/discordrb/api/endpoints/application.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Discordrb
+  module API
+    # @!discord_api https://discord.com/developers/docs/resources/application
+    module ApplicationEndpoints
+      # @!discord_api https://discord.com/developers/docs/resources/application#get-current-application
+      # @return [Hash<Symbol, Object>]
+      def get_current_application(**params)
+        request Route[:GET, '/applications/@me'], params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/application#edit-current-application
+      # @param custom_install_url [String] Default custom authorization for the URL.
+      # @param description [String] Description of the app.
+      # @param role_connections_verification_url [String] Role connection verification URL for the app.
+      # @param install_params [Hash<Symbol, Object>] Settings for the app's default in-app authorization link.
+      # @param integration_types_config [Hash] Hash containing supported install types.
+      # @param flags [Integer] Public flags for the app.
+      # @param icon [String, #read] A base64 encoded string with the image data.
+      # @param cover_image [String, #read] A base64 encoded string with the image data.
+      # @param interactions_endpoint_url [String] An endpoint an app can use to reccive interactions via the REST API.
+      # @param tags [Array<String>] Tags that describe the functionality of the app.
+      # @return [Hash<Symbol, Object>]
+      def edit_current_application(custom_install_url: :undef, description: :undef,
+                                   role_connections_verification_url: :undef, install_params: :undef,
+                                   integration_types_config: :undef, flags: :undef, icon: :undef,
+                                   cover_image: :undef, interactions_endpoint_url: :undef, tags: :undef, **rest)
+        data = {
+          custom_install_url: custom_install_url,
+          description: description,
+          role_connections_verification_url: role_connections_verification_url,
+          install_params: install_params,
+          integration_types_config: integration_types_config,
+          flags: flags,
+          icon: icon,
+          cover_image: cover_image,
+          interactions_endpoint_url: interactions_endpoint_url,
+          tags: tags,
+          **rest
+        }
+
+        request Route[:PATCH, '/applications/@me'],
+                body: filter_undef(data)
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/application-role-connection-metadata#get-application-role-connection-metadata-records
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @return [Hash<Symbol, Object>]
+      def get_application_role_connection_metadata_records(application_id, **params)
+        request Route[:GET, "/applications/#{application_id}/role-connections/metadata"],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/application-role-connection-metadata#update-application-role-connection-metadata-records
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param application_role_connection_metadata [Hash<Symbol, Object>] An application role connection metadata object.
+      # @return [Hash<Symbol, Object>]
+      def update_application_role_connection_metadata_records(application_id, application_role_connection_metadata, **rest)
+        request Route[:PUT, "/applications/#{application_id}/role-connections/metadata"],
+                body: filter_undef({ application_role_connection_metadata: application_role_connection_metadata, **rest })
+      end
+    end
+  end
+end

--- a/lib/discordrb/api/endpoints/application_command.rb
+++ b/lib/discordrb/api/endpoints/application_command.rb
@@ -12,21 +12,33 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#create-global-application-command
-      # @param application_id [Integer, String]
-      # @param name [String] 	1-32 character name
-      # @param description [String] 1-100 character description
-      # @param options [Array<Hash>] the parameters for the command
-      # @param default_permission [true, false, nil] whether the command is enabled by default when the app is added to a guild
-      # @param type [1, 2, 3] the type of command, defaults `1` if not set.
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param name [String] 1-32 character name.
+      # @param description [String] 1-100 character description.
+      # @param options [Array<Hash>] The parameters for the command.
+      # @param default_member_permissions [Integer] The bitwise permissions needed to use this command.
+      # @param type [Integer] The type of command, defaults `1` if not set.
+      # @param contexts [Integer] The contexts in which this command can be used.
+      # @param integration_types [Integer] Supported installation contexts.
+      # @param nsfw [Boolean] Whether this command should be age-restricted.
+      # @param name_localizations [Hash] Localized name of the application command.
+      # @param description_localizations [Hash] Localized description of the application command.
       # @return [Hash<Symbol, Object>]
       def create_global_application_command(application_id, name:, description:, options: :undef,
-                                            default_permission: :undef, type: :undef, **rest)
+                                            default_member_permissions: :undef, type: :undef, contexts: :undef,
+                                            integration_types: :undef, nsfw: :undef, name_localizations: :undef,
+                                            description_localizations: :undef, **rest)
         data = {
           name: name,
           description: description,
           options: options,
-          default_permission: default_permission,
+          default_member_permissions: default_member_permissions,
           type: type,
+          contexts: contexts,
+          integration_types: integration_types,
+          nsfw: nsfw,
+          name_localizations: name_localizations,
+          description_localizations: description_localizations,
           **rest
         }
 
@@ -35,28 +47,40 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#get-global-application-command
-      # @param application_id [Integer, String]
-      # @param command_id [Integer, String]
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param command_id [Integer, String] An ID that uniquely identifies an application command.
       # @return [Hash<Symbol, Object>]
       def get_global_application_command(application_id, command_id, **params)
         request Route[:GET, "/applications/#{application_id}/commands/#{command_id}"], params: params
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#edit-global-application-command
-      # @param application_id [Integer, String]
-      # @param command_id [Integer, String]
-      # @param name [String] 	1-32 character name
-      # @param description [String] 1-100 character description
-      # @param options [Array<Hash>] the parameters for the command
-      # @param default_permission [true, false, nil] whether the command is enabled by default when the app is added to a guild
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param command_id [Integer, String] An ID that uniquely identifies an application command.
+      # @param name [String] 1-32 character name.
+      # @param description [String] 1-100 character description.
+      # @param options [Array<Hash>] The parameters for the command.
+      # @param default_member_permissions [Integer] The bitwise permissions needed to use this command.
+      # @param contexts [Integer] The contexts in which this command can be used.
+      # @param integration_types [Integer] Supported installation contexts.
+      # @param nsfw [Boolean] Whether this command should be age-restricted.
+      # @param name_localizations [Hash] Localized name of the application command.
+      # @param description_localizations [Hash] Localized description of the application command.
       # @return [Hash<Symbol, Object>]
       def edit_global_application_command(application_id, command_id, name: :undef, description: :undef,
-                                          options: :undef, default_permission: :undef, **rest)
+                                          options: :undef, default_member_permissions: :undef, contexts: :undef,
+                                          integration_types: :undef, nsfw: :undef, name_localizations: :undef,
+                                          description_localizations: :undef, **rest)
         data = {
           name: name,
           description: description,
           options: options,
-          default_permission: default_permission,
+          default_member_permissions: default_member_permissions,
+          contexts: contexts,
+          integration_types: integration_types,
+          nsfw: nsfw,
+          name_localizations: name_localizations,
+          description_localizations: description_localizations,
           **rest
         }
 
@@ -65,16 +89,16 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#delete-global-application-command
-      # @param application_id [Integer, String]
-      # @param command_id [Integer, String]
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param command_id [Integer, String] An ID that uniquely identifies an application command.
       # @return [Hash<Symbol, Object>]
       def delete_global_application_command(application_id, command_id)
         request Route[:DELETE, "/applications/#{application_id}/commands/#{command_id}"]
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-global-application-commands
-      # @param application_id [Integer, String]
-      # @param commands [Array<Hash>]
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param commands [Array<Hash>] An array of application command objects.
       # @return [Array<Hash>]
       def bulk_overwrite_global_application_commands(application_id, commands)
         request Route[:PUT, "/applications/#{application_id}/commands"],
@@ -82,8 +106,8 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands
-      # @param application_id [Integer, String]
-      # @param guild_id [Integer, String]
+      # @param application_id [Integer, String] An ID that uniquely identifies an application command.
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Array<Hash<Symbol, Object>>]
       def get_guild_application_commands(application_id, guild_id, **params)
         request Route[:GET, "/applications/#{application_id}/guilds/#{guild_id}/commands"],
@@ -91,22 +115,29 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#create-guild-application-command
-      # @param application_id [Integer, String]
-      # @param guild_id [Integer, String]
-      # @param name [String]	1-32 character name
-      # @param description [String] 1-100 character description
-      # @param options [Array<Hash>, nil] the parameters for the command
-      # @param default_permission [true, false, nil] whether the command is enabled by default when the app is added to a guild
-      # @param type [1, 2, 3] the type of command, defaults 1 if not set
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param name [String] 1-32 character name.
+      # @param description [String] 1-100 character description.
+      # @param options [Array<Hash>, nil] The parameters for the command.
+      # @param default_member_permissions [Integer] The bitwise permissions needed to use this command.
+      # @param type [Integer] The type of command, defaults 1 if not set.
+      # @param nsfw [Boolean] Whether this command should be age-restricted.
+      # @param name_localizations [Hash] Localized name of the application command.
+      # @param description_localizations [Hash] Localized description of the application command.
       # @return [Hash]
       def create_guild_application_command(application_id, guild_id, name:, description:, options: :undef,
-                                           default_permission: :undef, type: :undef, **rest)
+                                           default_member_permissions: :undef, type: :undef, nsfw: :undef,
+                                           name_localizations: :undef, description_localizations: :undef, **rest)
         data = {
           name: name,
           description: description,
           options: options,
-          default_permission: default_permission,
+          default_member_permissions: default_member_permissions,
           type: type,
+          nsfw: nsfw,
+          name_localizations: name_localizations,
+          description_localizations: description_localizations,
           **rest
         }
 
@@ -115,30 +146,37 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#get-guild-application-command
-      # @param application_id [Integer, String]
-      # @param guild_id [Integer, String]
-      # @param command_id [Integer, String]
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param command_id [Integer, String] An ID that uniquely identifies an application command.
       # @return [Hash<Symbol, Object>]
       def get_guild_application_command(application_id, guild_id, command_id, **params)
         request Route[:GET, "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}"], params: params
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#edit-guild-application-command
-      # @param application_id [Integer, String]
-      # @param guild_id [Integer, String]
-      # @param command_id [Integer, String]
-      # @param name [String] 	1-32 character name
-      # @param description [String] 1-100 character description
-      # @param options [Array<Hash>] the parameters for the command
-      # @param default_permission [true, false, nil] whether the command is enabled by default when the app is added to a guild
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param command_id [Integer, String] An ID that uniquely identifies an application command.
+      # @param name [String] 1-32 character name.
+      # @param description [String] 1-100 character description.
+      # @param options [Array<Hash>] The parameters for the command.
+      # @param default_member_permissions [Integer] The bitwise permissions needed to use this command.
+      # @param nsfw [Boolean] Whether this command should be age-restricted.
+      # @param name_localizations [Hash] Localized name of the application command.
+      # @param description_localizations [Hash] Localized description of the application command.
       # @return [Hash<Symbol, Object>]
       def edit_guild_application_command(application_id, guild_id, command_id, name: :undef, description: :undef,
-                                          options: :undef, default_permission: :undef, **rest)
+                                         options: :undef, default_member_permissions: :undef, nsfw: :undef,
+                                         name_localizations: :undef, description_localizations: :undef, **rest)
         data = {
           name: name,
           description: description,
           options: options,
-          default_permission: default_permission,
+          default_member_permissions: default_member_permissions,
+          nsfw: nsfw,
+          name_localizations: name_localizations,
+          description_localizations: description_localizations,
           **rest
         }
 
@@ -147,18 +185,18 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#delete-guild-application-command
-      # @param application_id [Integer, String]
-      # @param guild_id [Integer, String]
-      # @param command_id [Integer, String]
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param command_id [Integer, String] An ID that uniquely identifies an application commmand.
       # @return [Hash<Symbol, Object>]
       def delete_guild_application_command(application_id, guild_id, command_id)
         request Route[:DELETE, "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}"]
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#bulk-overwrite-guild-application-commands
-      # @param application_id [Integer, String]
-      # @param guild_id [Integer, String]
-      # @param commands [Array<Hash>]
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param commands [Array<Hash>] An array of application commmand objects.
       # @return [Array<Hash>]
       def bulk_overwrite_guild_application_commands(application_id, guild_id, commands)
         request Route[:PUT, "/applications/#{application_id}/guilds/#{guild_id}/commands"],
@@ -166,8 +204,8 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#get-guild-application-command-permissions
-      # @param application_id [Integer, String]
-      # @param guild_id [Integer, String]
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Array<Hash>]
       def get_guild_application_command_permissions(application_id, guild_id, **params)
         request Route[:GET, "/applications/#{application_id}/guilds/#{guild_id}/commands/permissions"],
@@ -175,9 +213,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#get-application-command-permissions
-      # @param application_id [Integer, String]
-      # @param guild_id [Integer, String]
-      # @param command_id [Integer, String]
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param command_id [Integer, String] An ID that uniquely identifies an application command.
       # @return [Hash]
       def get_application_command_permissions(application_id, guild_id, command_id, **params)
         request Route[:GET, "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}/permissions"],
@@ -185,23 +223,14 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/application-commands#edit-application-command-permissions
-      # @param application_id [Integer, String]
-      # @param guild_id [Integer, String]
-      # @param command_id [Integer, String]
-      # @param permissions [Array<Hash>]
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param command_id [Integer, String] An ID that uniquely identifies an application command.
+      # @param permissions [Array<Hash>] An array of application command permissions objects.
       # @return [Hash]
       def edit_application_command_permissions(application_id, guild_id, command_id, permissions: [], **rest)
         request Route[:PUT, "/applications/#{application_id}/guilds/#{guild_id}/commands/#{command_id}/permissions"],
                 body: filter_undef({ permissions: permissions, **rest })
-      end
-
-      # @!discord_api https://discord.com/developers/docs/interactions/application-commands#batch-edit-application-command-permissions
-      # @param application_id [Integer, String]
-      # @param guild_id [Integer, String]
-      # @param permissions [Array<Hash>]
-      def batch_edit_application_command_permissions(application_id, guild_id, permissions)
-        request Route[:PUT, "/applications/#{application_id}/guilds/#{guild_id}/commands/permissions"],
-                body: permissions
       end
     end
   end

--- a/lib/discordrb/api/endpoints/audit_log.rb
+++ b/lib/discordrb/api/endpoints/audit_log.rb
@@ -2,13 +2,23 @@
 
 module Discordrb
   module API
+    # @!discord_api https://discord.com/developers/docs/resources/audit-log
     module AuditLogEndpoints
-      def get_guild_audit_log(guild_id, user_id: :undef, action_type: :undef, before: :undef, limit: :undef, **params)
+      # @!discord_api https://discord.com/developers/docs/resources/audit-log#get-guild-audit-log
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param user_id [Integer, String] Entries from a specifc user.
+      # @param action_type [Integer] Entries for a specific type of audit log action.
+      # @param before [Integer, String] Entries with an ID less than a specific audit log entry ID.
+      # @param after [Integer, String] Entries with an ID greater than a specific audit log entry ID.
+      # @param limit [Integer] Maximum number of entries to return; default is 50.
+      # @return [Array<Hash<Symbol, Object>>]
+      def get_guild_audit_log(guild_id, user_id: :undef, action_type: :undef, before: :undef, limit: :undef, after: :undef, **params)
         query = {
           user_id: user_id,
           action_type: action_type,
           before: before,
           limit: limit,
+          after: after,
           **params
         }
 

--- a/lib/discordrb/api/endpoints/auto_moderation.rb
+++ b/lib/discordrb/api/endpoints/auto_moderation.rb
@@ -48,7 +48,7 @@ module Discordrb
           **rest
         }
 
-        request Route[:POST, "/guilds/#{guild_id}/auto-moderation/rules"],
+        request Route[:POST, "/guilds/#{guild_id}/auto-moderation/rules", guild_id],
                 body: filter_undef(data),
                 reason: reason
       end
@@ -79,7 +79,7 @@ module Discordrb
           **rest
         }
 
-        request Route[:PATCH, "/guilds/#{guild_id}/auto-moderation/rules/#{auto_moderation_rule_id}"],
+        request Route[:PATCH, "/guilds/#{guild_id}/auto-moderation/rules/#{auto_moderation_rule_id}", guild_id],
                 body: filter_undef(data),
                 reason: reason
       end
@@ -90,7 +90,7 @@ module Discordrb
       # @param reason [String] The reason for deleting this rule.
       # @return [nil]
       def delete_auto_moderation_rule(guild_id, auto_moderation_rule_id, reason: :undef)
-        request Route[:DELETE, "/guilds/#{guild_id}/auto-moderation/rules/#{auto_moderation_rule_id}"],
+        request Route[:DELETE, "/guilds/#{guild_id}/auto-moderation/rules/#{auto_moderation_rule_id}", guild_id],
                 reason: reason
       end
     end

--- a/lib/discordrb/api/endpoints/auto_moderation.rb
+++ b/lib/discordrb/api/endpoints/auto_moderation.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Discordrb
+  module API
+    # @!discord_api https://discord.com/developers/docs/resources/auto-moderation
+    module AutoModerationEndpoints
+      # @!discord_api https://discord.com/developers/docs/resources/auto-moderation#list-auto-moderation-rules-for-guild
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @return [Array<Hash<Symbol, Object>>]
+      def list_auto_moderation_rules_for_guild(guild_id, **params)
+        request Route[:GET, "/guilds/#{guild_id}/auto-moderation/rules", guild_id],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/auto-moderation#get-auto-moderation-rule
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param auto_moderation_rule_id [Integer, String] An ID that uniquely identifies an auto-moderation rule.
+      # @return [Hash<Symbol, Object>]
+      def get_auto_moderation_rule(guild_id, auto_moderation_rule_id, **params)
+        request Route[:GET, "/guilds/#{guild_id}/auto-moderation/rules/#{auto_moderation_rule_id}", guild_id],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/auto-moderation#create-auto-moderation-rule
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param name [String] Name of the rule.
+      # @param event_type [1, 2] The context this rule applies to.
+      # @param trigger_type [Integer] The type of action that can trigger this rule.
+      # @param trigger_metadata [Hash] Extra data used to determine when a rule should should be triggered.
+      # @param actions [Array<Hash>] The action to perform when the rule is triggered.
+      # @param enabled [Boolean] Whether this rule is enabled or not.
+      # @param exempt_roles [Array<Integer, String>] ID of roles that should not be affected by this rule.
+      # @param exempt_channels [Array<Integer, String>] ID of channels that should not be affected by this rule.
+      # @param reason [String] The reason for creating this rule.
+      # @return [Hash<Symbol, Object>]
+      def create_auto_moderation_rule(guild_id, name:, event_type:, trigger_type:, actions:, trigger_metadata: :undef,
+                                      enabled: :undef, exempt_roles: :undef, exempt_channels: :undef, reason: :undef,
+                                      **rest)
+        data = {
+          name: name,
+          event_type: event_type,
+          trigger_type: trigger_type,
+          trigger_metadata: trigger_metadata,
+          actions: actions,
+          enabled: enabled,
+          exempt_roles: exempt_roles,
+          exempt_channels: exempt_channels,
+          **rest
+        }
+
+        request Route[:POST, "/guilds/#{guild_id}/auto-moderation/rules"],
+                body: filter_undef(data),
+                reason: reason
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/auto-moderation#modify-auto-moderation-rule
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param auto_moderation_rule_id [Integer, String] An ID that uniquely identifies an auto-moderation rule.
+      # @param name [String] Name of the rule.
+      # @param event_type [1, 2] The context this rule applies to.
+      # @param trigger_metadata [Hash] Extra data used to determine when a rule should should be triggered.
+      # @param actions [Array<Hash>] The action to perform when the rule is triggered.
+      # @param enabled [Boolean] Whether this rule is enabled or not.
+      # @param exempt_roles [Array<Integer, String>] ID of roles that should not be affected by this rule.
+      # @param exempt_channels [Array<Integer, String>] ID of channels that should not be affected by this rule.
+      # @param reason [String] The reason for editing this rule.
+      # @return [Hash<Symbol, Object>]
+      def modify_auto_moderation_rule(guild_id, auto_moderation_rule_id, name: :undef, event_type: :undef, trigger_metadata: :undef,
+                                      actions: :undef, enabled: :undef, exempt_roles: :undef, exempt_channels: :undef, reason: :undef,
+                                      **rest)
+        data = {
+          name: name,
+          event_type: event_type,
+          trigger_metadata: trigger_metadata,
+          actions: actions,
+          enabled: enabled,
+          exempt_roles: exempt_roles,
+          exempt_channels: exempt_channels,
+          **rest
+        }
+
+        request Route[:PATCH, "/guilds/#{guild_id}/auto-moderation/rules/#{auto_moderation_rule_id}"],
+                body: filter_undef(data),
+                reason: reason
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/auto-moderation#delete-auto-moderation-rule
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param auto_moderation_rule_id [Integer, String] An ID that uniquely identifies an auto-moderation rule.
+      # @param reason [String] The reason for deleting this rule.
+      # @return [nil]
+      def delete_auto_moderation_rule(guild_id, auto_moderation_rule_id, reason: :undef)
+        request Route[:DELETE, "/guilds/#{guild_id}/auto-moderation/rules/#{auto_moderation_rule_id}"],
+                reason: reason
+      end
+    end
+  end
+end

--- a/lib/discordrb/api/endpoints/channel.rb
+++ b/lib/discordrb/api/endpoints/channel.rb
@@ -5,6 +5,7 @@ module Discordrb
     # @!discord_api https://discord.com/developers/docs/resources/channel
     module ChannelEndpoints
       # @!discord_api https://discord.com/developers/docs/resources/channel#get-channel
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
       # @return [Hash<Symbol, Object>]
       def get_channel(channel_id, **params)
         request Route[:GET, "/channels/#{channel_id}", channel_id],
@@ -12,12 +13,36 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#modify-channel
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param name [String] 1-100 character name.
+      # @param icon [File, #Read] A base64 encoded string with the image data.
+      # @param type [Integer] Type of channel.
+      # @param position [Integer] Position of the channel in the channel list.
+      # @param topic [String] 0-1024 character topic.
+      # @param nsfw [Boolean] If this channel is age-restricted or not.
+      # @param rate_limit_per_user [Integer] The wait between sending messages (0-21600).
+      # @param bitrate [Intger] the bitrate of the voice or stage channel.
+      # @param user_limit [Intger] The max amount of users that can be in this voice or stage channel.
+      # @param permission_overwrites [Array<Hash>] Array of permission overwrite objects for the channel or category.
+      # @param parent_id [Integer, String] ID of the new parent category for this channel.
+      # @param rtc_region [String] Channel voice region. Defaults to auto when null.
+      # @param video_quality_mode [Integer] Camera quality mode in voice channels.
+      # @param default_auto_archive_duration [Integer] Default client duration to auto-archive new threads.
+      # @param flags [Integer] Bitfield value of channel flags to set.
+      # @param available_tags [Array<Hash>] Avalibile tags for posts in GUILD_FORUM channels.
+      # @param default_reaction_emoji [Hash] Emoji to show for reactions on posts in GUILD_FORUM channels.
+      # @param default_thread_rate_limit_per_user [Integer] Inital rate-limit-per-user for new threads.
+      # @param default_sort_order [Integer] Default sort order for GUILD_FORUM channels.
+      # @param default_forum_layout [Integer] Default forum layout for GUILD_FORUM channels.
+      # @param reason [String] The reason for modifiying this channel.
       # @return [Hash<Symbol, Object>]
       def modify_channel(channel_id,
                          name: :undef, icon: :undef, type: :undef, position: :undef, topic: :undef,
                          nsfw: :undef, rate_limit_per_user: :undef, bitrate: :undef, user_limit: :undef,
                          permission_overwrites: :undef, parent_id: :undef, rtc_region: :undef,
-                         video_quality_mode: :undef, default_auto_archive_duration: :undef, reason: :undef, **rest)
+                         video_quality_mode: :undef, default_auto_archive_duration: :undef, flags: :undef,
+                         available_tags: :undef, default_reaction_emoji: :undef, default_thread_rate_limit_per_user: :undef,
+                         default_sort_order: :undef, default_forum_layout: :undef, reason: :undef, **rest)
         data = {
           name: name,
           icon: icon,
@@ -33,6 +58,12 @@ module Discordrb
           rtc_region: rtc_region,
           video_quality_mode: video_quality_mode,
           default_auto_archive_duration: default_auto_archive_duration,
+          flags: flags,
+          available_tags: available_tags,
+          default_reaction_emoji: default_reaction_emoji,
+          default_thread_rate_limit_per_user: default_thread_rate_limit_per_user,
+          default_sort_order: default_sort_order,
+          default_forum_layout: default_forum_layout,
           **rest
         }
 
@@ -42,141 +73,20 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#deleteclose-channel
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param reason [String] Reason for deleting this channel.
       # @return [Hash<Symbol, Object>]
       def delete_channel(channel_id, reason: :undef)
         request Route[:DELETE, "/channels/#{channel_id}", channel_id],
                 reason: reason
       end
 
-      # @!discord_api https://discord.com/developers/docs/resources/channel#get-channel-messages
-      # @return [Array<Hash<Symbol, Object>>]
-      def get_channel_messages(channel_id, around: :undef, before: :undef, after: :undef, limit: :undef, **params)
-        request Route[:GET, "/channels/#{channel_id}/messages", channel_id],
-                params: filter_undef({ around: around, before: before, after: after, limit: limit, **params })
-      end
-
-      # @!discord_api https://discord.com/developers/docs/resources/channel#get-channel-message
-      # @return [Hash<Symbol, Object>]
-      def get_channel_message(channel_id, message_id, **params)
-        request Route[:GET, "/channels/#{channel_id}/message/#{message_id}", channel_id],
-                params: params
-      end
-
-      # @!discord_api https://discord.com/developers/docs/resources/channel#create-message
-      # @return [Hash<Symbol, Object>]
-      def create_message(channel_id,
-                         content: :undef, tts: :undef, files: :undef, embeds: :undef, allowed_mentions: :undef,
-                         message_reference: :undef, components: :undef, sticker_ids: :undef, **rest)
-        body = filter_undef({
-                              content: content,
-                              tts: tts,
-                              embeds: embeds,
-                              allowed_mentions: allowed_mentions,
-                              message_reference: message_reference,
-                              components: components,
-                              sticker_ids: sticker_ids,
-                              **rest
-                            })
-
-        if files
-          files = files.zip(0...files.count).map { |file, index| ["file[#{index}]", file] }.to_h
-          body = { **files, payload_json: JSON.dump(body) }
-        end
-
-        request Route[:POST, "/channels/#{channel_id}/messages", channel_id],
-                body: body
-      end
-
-      # @!discord_api https://discord.com/developers/docs/resources/channel#crosspost-message
-      # @return [Hash<Symbol, Object>]
-      def crosspost_message(channel_id, message_id, **rest)
-        request Route[:POST, "/channels/#{channel_id}/messages/#{message_id}/crosspost", channel_id],
-                body: rest
-      end
-
-      # @!discord_api https://discord.com/developers/docs/resources/channel#create-reaction
-      # @return [nil]
-      def create_reaction(channel_id, message_id, emoji)
-        request Route[:PUT, "/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}/@me", channel_id],
-                body: ''
-      end
-
-      # @!discord_api https://discord.com/developers/docs/resources/channel#delete-own-reaction
-      # @return [nil]
-      def delete_own_reaction(channel_id, message_id, emoji)
-        request Route[:DELETE, "/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}/@me", channel_id]
-      end
-
-      # @!discord_api https://discord.com/developers/docs/resources/channel#delete-user-reaction
-      # @return [nil]
-      def delete_user_reaction(channel_id, message_id, emoji, user_id)
-        request Route[:DELETE,
-                      "/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}/#{user_id}",
-                      channel_id]
-      end
-
-      # @!discord_api https://discord.com/developers/docs/resources/channel#get-reactions
-      # @return [Array<Hash<Symbol, Object>>]
-      def get_reactions(channel_id, message_id, emoji, after: :undef, limit: :undef, **params)
-        query = {
-          after: after,
-          limit: limit,
-          **params
-        }
-
-        request Route[:GET, "/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}", channel_id],
-                params: filter_undef(query)
-      end
-
-      # @!discord_api https://discord.com/developers/docs/resources/channel#delete-all-reactions
-      # @return [nil]
-      def delete_all_reactions(channel_id, message_id)
-        request Route[:DELETE, "/channels/#{channel_id}/messages/#{message_id}/reactions", channel_id]
-      end
-
-      # @!discord_api https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji
-      # @return [nil]
-      def delete_all_reactions_for_emoji(channel_id, message_id, emoji)
-        request Route[:DELETE, "/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}", channel_id]
-      end
-
-      # @!discord_api https://discord.com/developers/docs/resources/channel#edit-message
-      # @return [Hash<Symbol, Object>]
-      def edit_message(channel_id,
-                       message_id, content: :undef, embeds: :undef, flags: :undef, file: :undef,
-                       allowed_mentions: :undef, attachments: :undef, components: :undef, **rest)
-        body = filter_undef({
-                              content: content,
-                              tts: tts,
-                              embeds: embeds,
-                              allowed_mentions: allowed_mentions,
-                              message_reference: message_reference,
-                              components: components,
-                              **rest
-                            })
-
-        body = { file: file, payload_json: JSON.dump(body) } if file
-
-        request Route[:PATCH, "/channels/#{channel_id}/messages/#{message_id}", channel_id],
-                body: body
-      end
-
-      # @!discord_api https://discord.com/developers/docs/resources/channel#delete-message
-      # @return [nil]
-      def delete_message(channel_id, message_id, reason: :undef)
-        request Route[:DELETE, "/channels/#{channel_id}/messages/#{message_id}"],
-                reason: reason
-      end
-
-      # @!discord_api https://discord.com/developers/docs/resources/channel#bulk-delete-messages
-      # @return [nil]
-      def bulk_delete_messages(channel_id, messages, reason: :undef)
-        request Route[:POST, "/channels/#{channel_id}/messages/bulk-delete", channel_id],
-                body: messages,
-                reason: reason
-      end
-
       # @!discord_api https://discord.com/developers/docs/resources/channel#edit-channel-permissions
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param allow [String] Bitwise value of allowed permissions. Defaults to "0".
+      # @param deny [String] Bitwise value of denied permissions. Defaults to "0".
+      # @param type [Integer] 0 for a role, and 1 for a member.
+      # @param reason [String] The reason for updating this channel's permissions.
       # @return [nil]
       def edit_channel_permissions(channel_id, overwrite_id,
                                    allow: :undef, deny: :undef, type: :undef, reason: :undef, **rest)
@@ -186,6 +96,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#get-channel-invites
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
       # @return [Array<Hash<Symbol, Object>>]
       def get_channel_invites(channel_id, **params)
         request Route[:GET, "/channels/#{channel_id}/invites", channel_id],
@@ -193,6 +104,15 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#create-channel-invite
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param max_age [Integer] How long this invite lasts before expiring in seconds.
+      # @param max_uses [Integer] Max number of times this invite can be used; 0-100.
+      # @param temporary [Boolean] If this invite only grants temporary membership.
+      # @param unique [Boolean] Whether to avoid using a similar type of invite.
+      # @param target_type [Integer] Type of target for voice channels.
+      # @param target_user_id [Integer, String] ID of the user's stream to display.
+      # @param target_application_id [Integer, String] ID of the embedded application to open.
+      # @param reason [String] The reason for making this invite.
       # @return [Hash<Symbol, Object>]
       def create_channel_invite(channel_id,
                                 max_age: :undef, max_uses: :undef, temporary: :undef, unique: :undef,
@@ -215,20 +135,26 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#delete-channel-permission
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param overwrite_id [Integer, String] An ID that uniquely identifies a channel overwrite.
+      # @param reason [String] The reason for deleting this permission overwrite.
       # @return [nil]
       def delete_channel_permission(channel_id, overwrite_id, reason: :undef)
         request Route[:DELETE, "/channels/#{channel_id}/permissions/#{overwrite_id}", channel_id],
                 reason: reason
       end
 
-      # @!discord_api https://discord.com/developers/docs/resources/channel#follow-news-channel
+      # @!discord_api https://discord.com/developers/docs/resources/channel#follow-announcement-channel
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param webhook_channel_id [Integer, String] ID of the channel to target.
       # @return [Hash<Symbol, Object>]
-      def follow_news_channel(channel_id, webhook_channel_id:)
+      def follow_announcement_channel(channel_id, webhook_channel_id:)
         request Route[:POST, "/channels/#{channel_id}/followers", channel_id],
                 body: { webhook_channel_id: webhook_channel_id }
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
       # @return [nil]
       def trigger_typing_indicator(channel_id, **rest)
         request Route[:POST, "/channels/#{channel_id}/typing", channel_id],
@@ -236,6 +162,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#get-pinned-messages
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
       # @return [Array<Hash<Symbol, Object>>]
       def get_pinned_messages(channel_id, **params)
         request Route[:GET, "/channels/#{channel_id}/pins", channel_id],
@@ -243,6 +170,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#pin-message
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @param reason [String] The reason for pinning this message.
       # @return [nil]
       def pin_message(channel_id, message_id, reason: :undef)
         request Route[:PUT, "/channels/#{channel_id}/pins/#{message_id}", channel_id],
@@ -251,6 +181,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#unpin-message
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @param reason [String] The reason for un-pinning this message.
       # @return [nil]
       def unpin_message(channel_id, message_id, reason: :undef)
         request Route[:DELETE, "/channels/#{channel_id}/pins/#{message_id}", channel_id],
@@ -258,12 +191,19 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#start-thread-with-message
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param name [String] 1-100 character name.
+      # @param auto_archive_duration [Integer] The thread won't show in the channel list once this duration is reached.
+      # @param rate_limit_per_user [Integer] Slowmode, or amount of seconds a user has to wait between messages.
+      # @param reason [String] The reason for starting this thread.
       # @return [Hash<Symbol, Object>]
       def start_thread_with_message(channel_id, message_id,
-                                    name:, auto_archive_duration: :undef, reason: :undef, **rest)
+                                    name:, auto_archive_duration: :undef, rate_limit_per_user: :undef,
+                                    reason: :undef, **rest)
         data = {
           name: name,
           auto_archive_duration: auto_archive_duration,
+          rate_limit_per_user: rate_limit_per_user,
           **rest
         }
 
@@ -273,16 +213,24 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#start-thread-without-message
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param name [String] 1-100 character name.
+      # @param auto_archive_duration [Integer] The thread won't show in the channel list once this duration is reached.
+      # @param type [Integer] Type of thread to make.
+      # @param invitable [Boolean] If non-moderators can add other non-moderators to this thread.
+      # @param rate_limit_per_user [Integer] Slowmode, or amount of seconds a user has to wait between messages.
+      # @param reason [String] The reason for starting this thread.
       # @return [Hash<Symbol, Object>]
       def start_thread_without_message(channel_id,
                                        name:, auto_archive_duration: :undef, type: :undef, invitable: :undef,
-                                       reason: :undef, **rest)
+                                       rate_limit_per_user: :undef, reason: :undef, **rest)
         data = {
           name: name,
           auto_archive_duration: auto_archive_duration,
           type: type,
           invitable: invitable,
-          **reason
+          rate_limit_per_user: rate_limit_per_user,
+          **rest
         }
 
         request Route[:POST, "/channels/#{channel_id}/threads", channel_id],
@@ -290,7 +238,42 @@ module Discordrb
                 reason: reason
       end
 
+      # rubocop:disable Style/MapToHash
+      # @!discord_api https://discord.com/developers/docs/resources/channel#start-thread-in-forum-or-media-channel
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param name [String] 1-100 character name.
+      # @param auto_archive_duration [Integer] The thread won't show in the channel list once this duration is reached.
+      # @param message [Hash] The first message in a forum or media channel.
+      # @param files [File] File contents being sent.
+      # @param applied_tags [Array] ID's of tags to apply.
+      # @param rate_limit_per_user [Integer] Slowmode, or amount of seconds a user has to wait between messages.
+      # @param reason [String] The reason for starting this thread in forum or media channel.
+      # @return [Hash<Symbol, Object>]
+      def start_thread_in_forum_or_media_channel(channel_id,
+                                                 name:, message:, auto_archive_duration: :undef, applied_tags: :undef,
+                                                 files: :undef, rate_limit_per_user: :undef, reason: :undef, **rest)
+        body = filter_undef({
+                              name: name,
+                              auto_archive_duration: auto_archive_duration,
+                              message: message,
+                              applied_tags: applied_tags,
+                              rate_limit_per_user: rate_limit_per_user,
+                              **rest
+                            })
+
+        if files
+          files = files.zip(0...files.count).map { |file, index| ["file[#{index}]", file] }.to_h
+          body = { **files, payload_json: JSON.dump(body) }
+        end
+
+        request Route[:POST, "/channels/#{channel_id}/threads", channel_id],
+                body: body,
+                reason: reason
+      end
+      # rubocop:enable Style/MapToHash
+
       # @!discord_api https://discord.com/developers/docs/resources/channel#join-thread
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
       # @return [nil]
       def join_thread(channel_id)
         request Route[:PUT, "/channels/#{channel_id}/thread-members/@me", channel_id],
@@ -298,37 +281,53 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#add-thread-member
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
       # @return [nil]
       def add_thread_member(channel_id, user_id)
         request Route[:PUT, "/channels/#{channel_id}/thread-members/#{user_id}", channel_id]
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#leave-thread
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
       # @return [nil]
       def leave_thread(channel_id)
         request Route[:DELETE, "/channels/#{channel_id}/thread-members/@me", channel_id]
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#remove-thread-member
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
       # @return [nil]
       def remove_thread_member(channel_id, user_id)
         request Route[:DELETE, "/channels/#{channel_id}/thread-members/#{user_id}", channel_id]
       end
 
-      # @!discord_api https://discord.com/developers/docs/resources/channel#remove-thread-member
-      # @return [Array<Hash<Symbol, Object>>]
-      def list_thread_members(channel_id, **params)
-        request Route[:GET, "/channels/#{channel_id}/thread-members", channel_id],
-                params: params
+      # @!discord_api https://discord.com/developers/docs/resources/channel#get-thread-member
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
+      # @param with_member [Boolean] Whether to return guild member object.
+      # @return [nil]
+      def get_thread_member(channel_id, user_id, with_member: :undef, **params)
+        request Route[:GET, "/channels/#{channel_id}/thread-members/#{user_id}", channel_id],
+                params: filter_undef({ with_member: with_member, **params })
       end
 
-      # @!discord_api https://discord.com/developers/docs/resources/channel#list-thread-members
+      # @!discord_api https://discord.com/developers/docs/resources/channel#remove-thread-member
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param with_member [Boolean] hether to return guild member object.
+      # @param before [Integer, String] Thread members to get after this user ID.
+      # @param limit [Integer] 1-100 max number of thread members to return.
       # @return [Array<Hash<Symbol, Object>>]
-      def list_active_threads(channel_id, **params)
-        request Route[:GET, "/channels/#{channel_id}/threads/active", channel_id]
+      def list_thread_members(channel_id, with_member: :undef, before: :undef, limit: :undef, **params)
+        request Route[:GET, "/channels/#{channel_id}/thread-members", channel_id],
+                params: filter_undef({ with_member: with_member, before: before, limit: limit, **params })
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#list-public-archived-threads
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param before [Time] Threads archived before this timestamp.
+      # @param limit [Integer] Max number of threads to return.
       # @return [Array<Hash<Symbol, Object>>]
       def list_public_archived_threads(channel_id, before: :undef, limit: :undef, **params)
         request Route[:GET, "/channels/#{channel_id}/threads/archived/public", channel_id],
@@ -336,6 +335,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#list-private-archived-threads
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param before [Time] Threads archived before this timestamp.
+      # @param limit [Integer] Max number of threads to return.
       # @return [Array<Hash<Symbol, Object>>]
       def list_private_archived_threads(channel_id, before: :undef, limit: :undef, **params)
         request Route[:GET, "/channels/#{channel_id}/threads/archived/private", channel_id],
@@ -343,6 +345,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/channel#list-joined-private-archived-threads
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param before [Integer, String] Threads before this ID.
+      # @param limit [Integer] Max number of threads to return.
       # @return [Array<Hash<Symbol, Object>>]
       def list_joined_private_archived_threads(channel_id, before: :undef, limit: :undef, **params)
         request Route[:GET, "/channels/#{channel_id}/users/@me/threads/archived/private"],

--- a/lib/discordrb/api/endpoints/emoji.rb
+++ b/lib/discordrb/api/endpoints/emoji.rb
@@ -5,6 +5,7 @@ module Discordrb
     # @!discord_api https://discord.com/developers/docs/resources/emoji
     module EmojiEndpoints
       # @!discord_api https://discord.com/developers/docs/resources/emoji#list-guild-emojis
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Array<Hash<Symbol, Object>>]
       def list_guild_emojis(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/emojis", guild_id],
@@ -12,6 +13,8 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/emoji#get-guild-emoji
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param emoji_id [Integer, String] An ID that uniquely identifies an emoji.
       # @return [Hash<Symbol, Object>]
       def get_guild_emoji(guild_id, emoji_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/emojis/#{emoji_id}", guild_id],
@@ -19,6 +22,11 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/emoji#create-guild-emoji
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param name [String] Character name of the new emoji.
+      # @param image [String, #read] A base64 encoded string with the image data.
+      # @param roles [Array] Roles that can use this emoji.
+      # @param reason [String] The reason for creating this emoji.
       # @return [Hash<Symbol, Object>]
       def create_guild_emoji(guild_id, name:, image:, roles: :undef, reason: :undef, **rest)
         data = {
@@ -34,6 +42,11 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/emoji#modify-guild-emoji
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param emoji_id [Integer, String] An ID that uniquely identifies an emoji.
+      # @param name [String] The new name of this emoji.
+      # @param roles [Array] Roles that can use this emoji.
+      # @param reason [String] The reason for updating this emoji.
       # @return [Hash<Symbol, Object>]
       def modify_guild_emoji(guild_id, emoji_id, name: :undef, roles: :undef, reason: :undef, **rest)
         data = {
@@ -48,10 +61,69 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/emoji#delete-guild-emoji
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param emoji_id [Integer, String] An ID that uniquely identifies an emoji.
+      # @param reason [String] The reason for deleting this emoji.
       # @return [nil]
       def delete_guild_emoji(guild_id, emoji_id, reason: :undef)
         request Route[:DELETE, "/guilds/#{guild_id}/emojis/#{emoji_id}"],
                 reason: reason
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/emoji#list-application-emojis
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @return [Array<Hash<Symbol, Object>>]
+      def list_application_emojis(application_id, **params)
+        request Route[:GET, "/applications/#{application_id}/emojis", application_id],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/emoji#get-application-emoji
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param emoji_id [Integer, String] An ID that uniquely identifies an emoji.
+      # @return [Hash<Symbol, Object>]
+      def get_application_emoji(application_id, emoji_id, **params)
+        request Route[:GET, "/applications/#{application_id}/emojis/#{emoji_id}", application_id],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/emoji#create-application-emoji
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param name [String] Name of the new application emoji.
+      # @param image [String, #read] A base64 encoded string with the image data.
+      # @return [Hash<Symbol, Object>]
+      def create_application_emoji(application_id, name:, image:, **rest)
+        data = {
+          name: name,
+          image: image,
+          **rest
+        }
+
+        request Route[:POST, "/applications/#{application_id}/emojis"],
+                body: filter_undef(data)
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/emoji#modify-application-emoji
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param emoji_id [Integer, String] An ID that uniquely identifies an emoji.
+      # @param name [String] The new name of this application emoji
+      # @return [Hash<Symbol, Object>]
+      def modify_application_emoji(application_id, emoji_id, name: :undef, **rest)
+        data = {
+          name: name,
+          **rest
+        }
+
+        request Route[:PATCH, "/applications/#{application_id}/emojis/#{emoji_id}"],
+                body: filter_undef(data)
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/emoji#delete-application-emoji
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param emoji_id [Integer, String] An ID that uniquely identifies an emoji.
+      # @return [nil]
+      def delete_application_emoji(application_id, emoji_id)
+        request Route[:DELETE, "/applications/#{application_id}/emojis/#{emoji_id}"]
       end
     end
   end

--- a/lib/discordrb/api/endpoints/emoji.rb
+++ b/lib/discordrb/api/endpoints/emoji.rb
@@ -99,7 +99,7 @@ module Discordrb
           **rest
         }
 
-        request Route[:POST, "/applications/#{application_id}/emojis"],
+        request Route[:POST, "/applications/#{application_id}/emojis", application_id],
                 body: filter_undef(data)
       end
 
@@ -114,7 +114,7 @@ module Discordrb
           **rest
         }
 
-        request Route[:PATCH, "/applications/#{application_id}/emojis/#{emoji_id}"],
+        request Route[:PATCH, "/applications/#{application_id}/emojis/#{emoji_id}", application_id],
                 body: filter_undef(data)
       end
 
@@ -123,7 +123,7 @@ module Discordrb
       # @param emoji_id [Integer, String] An ID that uniquely identifies an emoji.
       # @return [nil]
       def delete_application_emoji(application_id, emoji_id)
-        request Route[:DELETE, "/applications/#{application_id}/emojis/#{emoji_id}"]
+        request Route[:DELETE, "/applications/#{application_id}/emojis/#{emoji_id}", application_id]
       end
     end
   end

--- a/lib/discordrb/api/endpoints/entitlement.rb
+++ b/lib/discordrb/api/endpoints/entitlement.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Discordrb
+  module API
+    # @!discord_api https://discord.com/developers/docs/resources/entitlement
+    module EntitlementEndpoints
+      # @!discord_api https://discord.com/developers/docs/resources/entitlement#list-entitlements
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @return [Array<Hash<Symbol, Object>>]
+      def list_entitlements(application_id, **params)
+        request Route[:GET, "/applications/#{application_id}/entitlements", application_id],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/entitlement#consume-an-entitlement
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param entitlement_id [Integer, String] An ID that uniquely identifies an entitlement.
+      # @return [Array<Hash<Symbol, Object>>]
+      def consume_an_entitlement(application_id, entitlement_id, **rest)
+        request Route[:POST, "/applications/#{application_id}/entitlements/#{entitlement_id}", application_id],
+                body: filter_undef(**rest)
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/entitlement#create-test-entitlement
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param sku_id [Integer, String] An ID that uniquely identifies a SKU.
+      # @param owner_id [Integer, String] The ID of the user or guild to grant this entitlement to.
+      # @param owner_type [1, 2] The type of entitlement to create.
+      # @return [Array<Hash<Symbol, Object>>]
+      def create_test_entitlement(application_id, sku_id:, owner_id:, owner_type:, **rest)
+        data = {
+          sku_id: sku_id,
+          owner_id: owner_id,
+          owner_type: owner_type,
+          **rest
+        }
+
+        request Route[:POST, "/applications/#{application_id}/entitlements", application_id],
+                body: filter_undef(data)
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/entitlement#delete-test-entitlement
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param entitlement_id [Integer, String] An ID that uniquely identifies an entitlement.
+      # @return [nil]
+      def delete_test_entitlement(application_id, entitlement_id)
+        request Route[:DELETE, "/applications/#{application_id}/entitlements/#{entitlement_id}"]
+      end
+    end
+  end
+end

--- a/lib/discordrb/api/endpoints/guild.rb
+++ b/lib/discordrb/api/endpoints/guild.rb
@@ -5,14 +5,24 @@ module Discordrb
     # @!discord_api https://discord.com/developers/docs/resources/guild
     module GuildEndpoints
       # @!discord_api https://discord.com/developers/docs/resources/guild#create-guild
+      # @param name [String] 2-100 character name.
+      # @param icon [String, #read] A base64 encoded string with the image data.
+      # @param verification_level [Integer] Required verification level for members; 0-4.
+      # @param default_message_notifications [Integer] Default message notification level; 0-1.
+      # @param explicit_content_filter [Integer] Explicit content filter level; 0-2.
+      # @param roles [Array<Hash<Symbol, Object>>] Array of new roles to create.
+      # @param channels [Array<Hash>] Array of new channels to create.
+      # @param afk_channel_id [Integer, String] ID for the AFK channel.
+      # @param afk_timeout [Integer] AFK timeout in seconds.
+      # @param system_channel_id [Integer, String] Where messages such as welcomes and boosts should be posted.
+      # @param system_channel_flags [Integer] Bitwise value of system channel flags.
       # @return [Hash<Symbol, Object>]
-      def create_guild(name:, region: :undef, icon: :undef, verification_level: :undef,
+      def create_guild(name:, icon: :undef, verification_level: :undef,
                        default_message_notifications: :undef, explicit_content_filter: :undef, roles: :undef,
                        channels: :undef, afk_channel_id: :undef, afk_timeout: :undef, system_channel_id: :undef,
                        system_channel_flags: :undef, **rest)
         data = {
           name: name,
-          region: region,
           icon: icon,
           verification_level: verification_level,
           default_message_notifications: default_message_notifications,
@@ -31,13 +41,16 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param with_counts [Boolean] Whether to include an approximate member count.
       # @return [Hash<Symbol, Object>]
-      def get_guild(guild_id, **params)
+      def get_guild(guild_id, with_counts: :undef, **params)
         request Route[:GET, "/guilds/#{guild_id}", guild_id],
-                params: params
+                params: filter_undef({ with_counts: with_counts, **params })
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-preview
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Hash<Symbol, Object>]
       def get_guild_preview(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/preview", guild_id],
@@ -45,18 +58,40 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#modify-guild
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param name [String] 2-100 character name.
+      # @param verification_level [String] Required verification level for members; 0-4.
+      # @param default_message_notifications [Integer] Default message notification level; 0-1.
+      # @param explicit_content_filter [Integer] Explicit content filter level; 0-2.
+      # @param afk_channel_id [Integer, String] ID for the AFK channel.
+      # @param afk_timeout [Integer] AFK timeout in seconds.
+      # @param icon [String, #read] A base64 encoded string with the image data.
+      # @param owner_id [Integer, String] ID of the new guild owner.
+      # @param splash [String, #read] A base64 encoded string with the image data.
+      # @param discovery_splash [String, #read] A base64 encoded string with the image data.
+      # @param banner [String, #read] A base64 encoded string with the image data.
+      # @param system_channel_id [Integer, String] Where messages such as welcomes and boosts should be posted.
+      # @param system_channel_flags [Integer] Bitwise value of system channel flags.
+      # @param rules_channel_id [Integer, String] ID of the channel to mark as that guild's rules channels.
+      # @param public_updates_channel_id [Integer, String] ID of the channel where server staff reccive updates from Discord.
+      # @param preferred_locale [String] preferred locale of a guild used in server discovery. Default is "en-US".
+      # @param features [Array<String>] Array of strings that specifiy enabled features for this guild.
+      # @param description [String] Description for this guild.
+      # @param premium_progress_bar_enabled [Boolean] Whether the boost progress bar should be visible.
+      # @param safety_alerts_channel_id [Integer, String] Channel where safety alerts should be sent from Discord.
+      # @param reason [String] The reason for modifiying this guild.
       # @return [Hash<Symbol, Object>]
-      def modify_guild(guild_id, name: :undef, region: :undef, verification_level: :undef,
+      def modify_guild(guild_id, name: :undef, verification_level: :undef,
                        default_message_notifications: :undef, explicit_content_filter: :undef, afk_channel_id: :undef,
                        afk_timeout: :undef, icon: :undef, owner_id: :undef, splash: :undef, discovery_splash: :undef,
                        banner: :undef, system_channel_id: :undef, system_channel_flags: :undef,
                        rules_channel_id: :undef, public_updates_channel_id: :undef, preferred_locale: :undef,
-                       features: :undef, description: :undef, **rest)
+                       features: :undef, description: :undef, premium_progress_bar_enabled: :undef,
+                       safety_alerts_channel_id: :undef, reason: :undef, **rest)
         data = {
           name: name,
-          region: region,
           verification_level: verification_level,
-          default_message_notifications:default_message_notifications,
+          default_message_notifications: default_message_notifications,
           explicit_content_filter: explicit_content_filter,
           afk_channel_id: afk_channel_id,
           afk_timeout: afk_timeout,
@@ -72,20 +107,25 @@ module Discordrb
           preferred_locale: preferred_locale,
           features: features,
           description: description,
+          premium_progress_bar_enabled: premium_progress_bar_enabled,
+          safety_alerts_channel_id: safety_alerts_channel_id,
           **rest
         }
 
         request Route[:PATCH, "/guilds/#{guild_id}", guild_id],
-                body: filter_undef(data)
+                body: filter_undef(data),
+                reason: reason
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#delete-guild
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [nil]
       def delete_guild(guild_id)
         request Route[:DELETE, "/guilds/#{guild_id}", guild_id]
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-channels
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Array<Hash<Symbol, Object>>]
       def get_guild_channels(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/channels", guild_id],
@@ -93,10 +133,33 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#create-guild-channel
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param name [String] 1-100 character name.
+      # @param type [Integer] Type of channel to create.
+      # @param topic [String] 0-1024 character topic.
+      # @param bitrate [Integer] Bitrate in bits of the voice channel.
+      # @param user_limit [Integer] Max amount of users that can be in this voice channel.
+      # @param rate_limit_per_user [Integer] Time between 0-21600 that a user has to wait between messages.
+      # @param position [Integer] Sorting position of the channel.
+      # @param permission_overwrites [Array<Hash<Symbol, Object>>] Permission overwrites for this channel.
+      # @param parent_id [Integer, String] The parent category of this channel.
+      # @param nsfw [Boolean] Whether this channel is age-restricted or not.
+      # @param rtc_region [String] Voice region of the voice channel.
+      # @param video_quality_mode [Integer] Camera quality mode of the voice channel.
+      # @param default_auto_archive_duration [Integer] Default client duration to auto-archive new threads.
+      # @param default_reaction_emoji [Hash<Symbol, Object>] Emoji to show for reactions on posts in GUILD_FORUM channels.
+      # @param available_tags [Array<Hash<Symbol, Object>>] Avalibile tags for posts in GUILD_FORUM channels.
+      # @param default_sort_order [Integer] Default sort order for GUILD_FORUM channels.
+      # @param default_forum_layout [Integer] Default forum layout for GUILD_FORUM channels.
+      # @param default_thread_rate_limit_per_user [Integer] Inital rate-limit-per-user for new threads.
+      # @param reason [String] The reason for creating this channel.
       # @return [Hash<Symbol, Object>]
       def create_guild_channel(guild_id, name:, type: :undef, topic: :undef, bitrate: :undef, user_limit: :undef,
                                rate_limit_per_user: :undef, position: :undef, permission_overwrites: :undef,
-                               parent_id: :undef, nsfw: :undef, reason: :undef, **rest)
+                               parent_id: :undef, nsfw: :undef, rtc_region: :undef, video_quality_mode: :undef,
+                               default_auto_archive_duration: :undef, default_reaction_emoji: :undef,
+                               available_tags: :undef, default_sort_order: :undef, default_forum_layout: :undef,
+                               default_thread_rate_limit_per_user: :undef, reason: :undef, **rest)
         data = {
           name: name,
           type: type,
@@ -108,6 +171,14 @@ module Discordrb
           permission_overwrites: permission_overwrites,
           parent_id: parent_id,
           nsfw: nsfw,
+          rtc_region: rtc_region,
+          video_quality_mode: video_quality_mode,
+          default_auto_archive_duration: default_auto_archive_duration,
+          default_reaction_emoji: default_reaction_emoji,
+          available_tags: available_tags,
+          default_sort_order: default_sort_order,
+          default_forum_layout: default_forum_layout,
+          default_thread_rate_limit_per_user: default_thread_rate_limit_per_user,
           **rest
         }
 
@@ -117,21 +188,25 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param channels [Array<Hash<Symbol, Object>>] An array of channel objects.
       # @return [nil]
-      def modify_guild_channel_positions(guild_id, channels, reason: :undef)
+      def modify_guild_channel_positions(guild_id, channels)
         request Route[:PATCH, "/guilds/#{guild_id}/channels", guild_id],
-                body: channels,
-                reason: reason
+                body: channels
       end
 
-      # @!discord_api https://discord.com/developers/docs/resources/guild#list-active-threads
+      # @!discord_api https://discord.com/developers/docs/resources/guild#list-active-guild-threads
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Hash<Symbol,Object>]
-      def list_active_threads(guild_id, **params)
+      def list_active_guild_threads(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/threads/active"],
                 params: params
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-member
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
       # @return [Hash<Symbol, Object>]
       def get_guild_member(guild_id, user_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/members/#{user_id}", guild_id],
@@ -139,6 +214,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-preview
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param limit [Integer] 1-1000 max number of members to return.
+      # @param after [Integer, String] Highest user ID on the previous page.
       # @return [Array<Hash<Symbol, Object>>]
       def list_guild_members(guild_id, limit: :undef, after: :undef, **params)
         request Route[:GET, "/guilds/#{guild_id}/members", guild_id],
@@ -146,6 +224,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#search-guild-members
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param query [String] Usernames or nicknames to search against.
+      # @param limit [Integer] 1-1000 max number of members to return.
       # @return [Array<Hash<Symbol, Object>>]
       def search_guild_members(guild_id, query:, limit: :undef, **params)
         request Route[:GET, "/guilds/#{guild_id}/members/search", guild_id],
@@ -153,6 +234,13 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#add-guild-member
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
+      # @param access_token [String] oauth2 access token with the guilds.join scope.
+      # @param nick [String] The nickname they should be assigned.
+      # @param roles [Array<Integer, String>] Array of role ID's to assign to the member.
+      # @param mute [Boolean] Whether this user should be muted in voice channels.
+      # @param deaf [Boolean] Whether this user should be deafened in voice channels.
       # @return [Hash<Symbol, Object>]
       def add_guild_member(guild_id, user_id, access_token:, nick: :undef, roles: :undef, mute: :undef, deaf: :undef,
                            **rest)
@@ -170,15 +258,25 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#modify-guild-member
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
+      # @param nick [String] The user's new nickname.
+      # @param roles [Array<Integer, String>] Array of role ID's to assign to the member.
+      # @param mute [Boolean] Whether this user should be muted in voice channels.
+      # @param deaf [Boolean] Whether this user should be deafened in voice channels.
+      # @param channel_id [Integer, String] ID of the voice channel to move the user to.
+      # @param communication_disabled_until [Time] When the user's timeout should expire.
+      # @param reason [String] The reason for modifiying this guild member.
       # @return [Hash<Symbol, Object>]
       def modify_guild_member(guild_id, user_id, nick: :undef, roles: :undef, mute: :undef, deaf: :undef,
-                              channel_id: :undef, reason: :undef, **rest)
+                              channel_id: :undef, communication_disabled_until: :undef, reason: :undef, **rest)
         data = {
           nick: nick,
           roles: roles,
           mute: mute,
           deaf: deaf,
           channel_id: channel_id,
+          communication_disabled_until: communication_disabled_until,
           **rest
         }
 
@@ -188,6 +286,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#modify-current-member
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param nick [String] The user's new nickname.
+      # @param reason [String] The reason for modifiying yourself.
       # @return [Hash<Symbol, Object>]
       def modify_current_member(guild_id, nick: :undef, reason: :undef, **rest)
         request Route[:PATCH, "/guilds/#{guild_id}/members/@me", guild_id],
@@ -196,6 +297,10 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#add-guild-member-role
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
+      # @param role_id [Integer, String] An ID that uniquely identifies a role.
+      # @param reason [String] The reason for adding a role to this member.
       # @return [nil]
       def add_guild_member_role(guild_id, user_id, role_id, reason: :undef)
         request Route[:PUT, "/guilds/#{guild_id}/members/#{user_id}/roles/#{role_id}", guild_id],
@@ -204,6 +309,10 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#remove-guild-member-role
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
+      # @param role_id [Integer, String] An ID that uniquely identifies a role.
+      # @param reason [String] The reason for removing a role from this member.
       # @return [nil]
       def remove_guild_member_role(guild_id, user_id, role_id, reason: :undef)
         request Route[:DELETE, "/guilds/#{guild_id}/members/#{user_id}/roles/#{role_id}", guild_id],
@@ -211,6 +320,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#remove-guild-member
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
+      # @param reason [String] The reason for removing this member.
       # @return [nil]
       def remove_guild_member(guild_id, user_id, reason: :undef)
         request Route[:DELETE, "/guilds/#{guild_id}/members/#{user_id}", guild_id],
@@ -218,13 +330,19 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-bans
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param limit [Integer] Max number of banned users to return up to 1000.
+      # @param before [Integer, String] Get users only before this ID.
+      # @param after [Integer, String] Get users only after this ID.
       # @return [Array<Hash<Symbol, Object>>]
-      def get_guild_bans(guild_id, **params)
+      def get_guild_bans(guild_id, limit: :undef, before: :undef, after: :undef, **params)
         request Route[:GET, "/guilds/#{guild_id}/bans", guild_id],
-                params: params
+                params: filter_undef({ limit: limit, before: before, after: after, **params })
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-ban
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
       # @return [Hash<Symbol, Object>]
       def get_guild_ban(guild_id, user_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/bans/#{user_id}", guild_id],
@@ -232,28 +350,70 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#create-guild-ban
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
+      # @param delete_message_seconds [Integer] Number between 0-604800 to delete messages for.
       # @return [nil]
-      def create_guild_ban(guild_id, user_id, delete_message_days: :undef, reason: :undef, **rest)
+      def create_guild_ban(guild_id, user_id, delete_message_seconds: :undef, reason: :undef, **rest)
         request Route[:PUT, "/guilds/#{guild_id}/bans/#{user_id}", guild_id],
-                body: filter_undef({ delete_message_days: delete_message_days, **rest }),
+                body: filter_undef({ delete_message_seconds: delete_message_seconds, **rest }),
                 reason: reason
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#remove-guild-ban
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
+      # @param reason [String] The reason for removing this user's ban.
       # @return [nil]
       def remove_guild_ban(guild_id, user_id, reason: :undef)
         request Route[:DELETE, "/guilds/#{guild_id}/bans/#{user_id}", guild_id],
                 reason: reason
       end
 
+      # @!discord_api https://discord.com/developers/docs/resources/guild#bulk-guild-ban
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param user_ids [Array<String>] An array containing user ID's to ban.
+      # @param delete_message_seconds [Integer] Number between 0-604800 to delete messages for.
+      # @return [Hash<Symbol, Object>]
+      def bulk_guild_ban(guild_id, user_ids, delete_message_seconds: :undef, reason: :undef, **rest)
+        data = {
+          user_ids: user_ids,
+          delete_message_seconds: delete_message_seconds,
+          **rest
+        }
+
+        request Route[:POST, "/guilds/#{guild_id}/bulk-ban", guild_id],
+                body: filter_undef(data),
+                reason: reason
+      end
+
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-roles
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Array<Hash<Symbol, Object>>]
       def get_guild_roles(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/roles", guild_id],
                 params: params
       end
 
+      # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-role
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param role_id [Integer, String] An ID that uniquely identifies a role.
+      # @return [Array<Hash<Symbol, Object>>]
+      def get_guild_role(guild_id, role_id, **params)
+        request Route[:GET, "/guilds/#{guild_id}/roles/#{role_id}", guild_id],
+                params: params
+      end
+
       # @!discord_api https://discord.com/developers/docs/resources/guild#create-guild-role
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param name [String] Name of the role to create.
+      # @param permissions [String] Bitwise permissions for this role.
+      # @param color [Integer] An RGB color value for this role.
+      # @param hoist [Boolean] Whether this role's members should be displayed seperately in the sidebar.
+      # @param icon [String, #read] An icon to display next to this role.
+      # @param unicode_emoji [String] Unicode emoji for the role.
+      # @param mentionable [Boolean] Whether everyone should be able to mention this role.
+      # @param reason [String] The reason for creating this role.
       # @return [Hash<Symbol, Object>]
       def create_guild_role(guild_id, name: :undef, permissions: :undef, color: :undef, hoist: :undef, icon: :undef,
                             unicode_emoji: :undef, mentionable: :undef, reason: :undef, **rest)
@@ -274,6 +434,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#modify-guild-role-positions
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param roles [Array<Hash<Symbol, Object>>] Role objects sorted in their new positions.
+      # @param reason [String] The reason for modifiying the positions of this role.
       # @return [Array<Hash<Symbol, Object>>]
       def modify_guild_role_positions(guild_id, roles, reason: :undef)
         request Route[:PATCH, "/guilds/#{guild_id}/roles", guild_id],
@@ -282,6 +445,16 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#modify-guild-role
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param role_id [Integer, String] An ID that uniquely identifies a role.
+      # @param name [String] New name of the role.
+      # @param permissions [String] Bitwise permissions for this role.
+      # @param color [Integer] An RGB color value for this role.
+      # @param hoist [Boolean] Whether this role's members should be displayed seperately in the sidebar.
+      # @param icon [String, #read] An icon to display next to this role.
+      # @param unicode_emoji [String] Unicode emoji for the role.
+      # @param mentionable [Boolean] Whether everyone should be able to mention this role.
+      # @param reason [String] The reason for modifiying this role.
       # @return [Hash<Symbol, Object>]
       def modify_guild_role(guild_id, role_id, name: :undef, permissions: :undef, color: :undef, hoist: :undef,
                             icon: :undef, unicode_emoji: :undef, mentionable: :undef, reason: :undef, **rest)
@@ -301,7 +474,21 @@ module Discordrb
                 reason: reason
       end
 
+      # @!discord_api https://discord.com/developers/docs/resources/guild#modify-guild-mfa-level
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param level [Integer] The new MFA level; either 0 or 1.
+      # @param reason [String] The reason for modifiying the MFA level.
+      # @return [Intger]
+      def modify_guild_mfa_level(guild_id, level:, reason: :undef, **rest)
+        request Route[:POST, "/guilds/#{guild_id}/mfa", guild_id],
+                body: filter_undef({ level: level, **rest }),
+                reason: reason
+      end
+
       # @!discord_api https://discord.com/developers/docs/resources/guild#delete-guild-role
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param role_id [Integer, String] An ID that uniquely identifies a role.
+      # @param reason [String] The reason for deleting this role.
       # @return [nil]
       def delete_guild_role(guild_id, role_id, reason: :undef)
         request Route[:DELETE, "/guilds/#{guild_id}/roles/#{role_id}", guild_id],
@@ -309,6 +496,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-prune-count
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param days [Integer] Number of days between 1-30 to count for.
+      # @param include_roles [String] comma-delimited array of role ID's.
       # @return [Hash<Symbol, Object>]
       def get_guild_prune_count(guild_id, days: :undef, include_roles: :undef, **params)
         request Route[:GET, "/guilds/#{guild_id}/prune", guild_id],
@@ -316,6 +506,11 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#begin-guild-prune
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param days [Integer] Number of days between 1-30 to prune for.
+      # @param compute_prune_count [Boolean] Whether to return the prune key.
+      # @param include_roles [Array<String, Integer>] Array of role ID's to include.
+      # @param reason [String] The reason for initiating a prune.
       # @return [Hash<Symbol, Object>]
       def begin_guild_prune(guild_id, days: :undef, compute_prune_count: :undef, include_roles: :undef, reason: :undef,
                             **rest)
@@ -332,6 +527,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-voice-regions
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Array<Hash<Symbol, Object>>]
       def get_guild_voice_regions(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/regions", guild_id],
@@ -339,6 +535,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-invites
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Array<Hash<Symbol, Object>>]
       def get_guild_invites(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/invites", guild_id],
@@ -346,6 +543,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-integrations
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Array<Hash<Symbol, Object>>]
       def get_guild_integrations(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/integrations", guild_id],
@@ -353,6 +551,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#delete-guild-integration
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param integration_id [Integer, String] An ID that uniquely identifies an integration.
+      # @param reason [String] The reason for deleting this integration.
       # @return [nil]
       def delete_guild_integration(guild_id, integration_id, reason: :undef)
         request Route[:DELETE, "/guilds/#{guild_id}/integrations/#{integration_id}", guild_id],
@@ -360,6 +561,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-widget-settings
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Hash<Symbol, Object>]
       def get_guild_widget_settings(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/widget", guild_id],
@@ -367,6 +569,10 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#modify-guild-widget
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param enabled [Boolean] Whether the widget is enabled.
+      # @param channel_id [Integer, String] The channel ID of the widget.
+      # @param reason [String] The reason for modifiying the guild widget.
       # @return [Hash<Symbol, Object>]
       def modify_guild_widget(guild_id, enabled: :undef, channel_id: :undef, reason: :undef, **rest)
         request Route[:PATCH, "/guilds/#{guild_id}/widget", guild_id],
@@ -375,6 +581,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-widget
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Hash<Symbol, Object>]
       def get_guild_widget(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/widget.json", guild_id],
@@ -382,6 +589,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-vanity-url
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Hash<Symbol, Object>]
       def get_guild_vanity_url(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/vanity-url", guild_id],
@@ -389,6 +597,8 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-widget-image
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param style [String] Style of the widget image to return.
       # @return [String]
       def get_guild_widget_image(guild_id, style: :undef, **params)
         request Route[:GET, "/guilds/#{guild_id}/widget.png", guild_id],
@@ -396,6 +606,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-welcome-screen
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Hash<Symbol, Object>]
       def get_guild_welcome_screen(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/welcome-screen", guild_id],
@@ -403,6 +614,11 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild#modify-guild-welcome-screen
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param enabled [Boolean] Whether the welcome screen should be enabled.
+      # @param welcome_channels [Array<Symbol, Object>] Array of welcome screen channel objects.
+      # @param description [String] Server description to show on the welcome screen.
+      # @param reason [String] The reason for modifiying the welcome screen.
       # @return [Hash<Symbol, Object>]
       def modify_guild_welcome_screen(guild_id, enabled: :undef, welcome_channels: :undef, description: :undef,
                                       reason: :undef, **rest)
@@ -418,32 +634,34 @@ module Discordrb
                 reason: reason
       end
 
-      # @!discord_api https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state
-      # @return [nil]
-      def modify_current_user_voice_state(guild_id, channel_id: :undef, suppress: :undef,
-                                          request_to_speak_timestamp: :undef, **rest)
-        data = {
-          channel_id: channel_id,
-          suppress: suppress,
-          request_to_speak_timestamp: request_to_speak_timestamp,
-          **rest
-        }
-
-        request Route[:PATCH, "/guilds/#{guild_id}/voice-states/@me", guild_id],
-                body: filter_undef(data)
+      # @!discord_api https://discord.com/developers/docs/resources/guild#get-guild-onboarding
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @return [Hash<Symbol, Object>]
+      def get_guild_onboarding(guild_id, **params)
+        request Route[:GET, "/guilds/#{guild_id}/onboarding", guild_id],
+                params: params
       end
 
-      # @!discord_api https://discord.com/developers/docs/resources/guild#modify-user-voice-state
-      # @return [nil]
-      def modify_user_voice_state(guild_id, user_id, channel_id: :undef, suppress: :undef, **rest)
+      # @!discord_api https://discord.com/developers/docs/resources/guild#modify-guild-onboarding
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # prompts [Hash] Array of onboarding prompt objects.
+      # default_channel_ids [Array<Integer, String>] Array of channel ID's members get added to by default.
+      # enabled [Boolean] Whether onboarding is enabled or not.
+      # reason [String] Reason for modifiying this server's onboarding.
+      # @return [Hash<Symbol, Object>]
+      def modify_guild_onboarding(guild_id, prompts:, default_channel_ids:, enabled:, mode:,
+                                  reason: :undef, **rest)
         data = {
-          channel_id: channel_id,
-          suppress: suppress,
+          prompts: prompts,
+          default_channel_ids: default_channel_ids,
+          enabled: enabled,
+          mode: mode,
           **rest
         }
 
-        request Route[:PATCH, "/guilds/#{guild_id}/voice-states/#{user_id}", guild_id],
-                body: filter_undef(data)
+        request Route[:PUT, "/guilds/#{guild_id}/onboarding", guild_id],
+                body: filter_undef(data),
+                reason: reason
       end
     end
   end

--- a/lib/discordrb/api/endpoints/guild.rb
+++ b/lib/discordrb/api/endpoints/guild.rb
@@ -663,6 +663,23 @@ module Discordrb
                 body: filter_undef(data),
                 reason: reason
       end
+
+      # @!discord_api https://discord.com/developers/docs/resources/guild#modify-guild-incident-actions
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param invites_disabled_until [Time, nil] An ISO8601 timestamp indicating when invites will be enabled again.
+      # @param dms_disabled_until [Time, nil] An ISO8601 timestamp indicating when DMs will be enabled again.
+      # @return [Hash<Symbol, Object>]
+      def modify_guild_incident_actions(guild_id, invites_disabled_until: :undef,
+                                        dms_disabled_until: :undef, **rest)
+        data = {
+          invites_disabled_until: invites_disabled_until,
+          dms_disabled_until: dms_disabled_until,
+          **rest
+        }
+
+        request Route[:PUT, "/guilds/#{guild_id}/incident-actions", guild_id],
+                body: filter_undef(data)
+      end
     end
   end
 end

--- a/lib/discordrb/api/endpoints/guild_scheduled_event.rb
+++ b/lib/discordrb/api/endpoints/guild_scheduled_event.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module Discordrb
+  module API
+    # @!discord_api https://discord.com/developers/docs/resources/guild-scheduled-event
+    module GuildScheduledEventEndpoints
+      # @!discord_api https://discord.com/developers/docs/resources/guild-scheduled-event#list-scheduled-events-for-guild
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @return [Hash<Symbol, Object>]
+      def list_scheduled_events_for_guild(guild_id, **params)
+        request Route[:GET, "/guilds/#{guild_id}/scheduled-events", guild_id],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/auto-moderation#get-guild-scheduled-event
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param guild_scheduled_event_id [Integer, String] An ID that uniquely identifies a scheduled event.
+      # @return [Hash<Symbol, Object>]
+      def get_guild_scheduled_event(guild_id, guild_scheduled_event_id, **params)
+        request Route[:GET, "/guilds/#{guild_id}/scheduled-events/#{guild_scheduled_event_id}", guild_id],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/guild-scheduled-event#create-guild-scheduled-event
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param channel_id [Integer, String] The channel ID for this scheduled event.
+      # @param entity_metadata [String] Location of the event. Required for external event types.
+      # @param name [String] Name of the event.
+      # @param privacy_level [Integer] Who the scheduled event can be accessed by.
+      # @param scheduled_start_time [Time] A time object that indicates when to start the event.
+      # @param scheduled_end_time [Time] A time object that indicates when to end the event.
+      # @param description [String] Description of the scheduled event.
+      # @param entity_type [Integer] The location of the event; E.g. voice, stage-instance, etc.
+      # @param image [String, #read] A base64 encoded string with the image data.
+      # @param recurrence_rule [Hash] A recurrence rule object. See the offical API docs for more info.
+      # @param reason [String] The reason for creating this scheduled event.
+      # @return [Hash<Symbol, Object>]
+      def create_guild_scheduled_event(guild_id, name:, channel_id: :undef, entity_metadata: :undef, privacy_level: :undef,
+                                       scheduled_start_time: :undef, scheduled_end_time: :undef, description: :undef,
+                                       entity_type: :undef, image: :undef, recurrence_rule: :undef, reason: :undef, **rest)
+        data = {
+          channel_id: channel_id,
+          entity_metadata: entity_metadata,
+          name: name,
+          privacy_level: privacy_level,
+          scheduled_start_time: scheduled_start_time,
+          scheduled_end_time: scheduled_end_time,
+          description: description,
+          entity_type: entity_type,
+          image: image,
+          recurrence_rule: recurrence_rule,
+          **rest
+        }
+
+        request Route[:POST, "/guilds/#{guild_id}/scheduled-events"],
+                body: filter_undef(data),
+                reason: reason
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/guild-scheduled-event#modify-guild-scheduled-event
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param guild_scheduled_event_id [Integer, String] An ID that uniquely identifies a scheduled event.
+      # @param channel_id [Integer, String] The channel ID for this scheduled event.
+      # @param entity_metadata [String] Location of the event. Required for external event types.
+      # @param name [String] New name of the event.
+      # @param privacy_level [Integer] Who the scheduled event can be accessed by.
+      # @param scheduled_start_time [Time] A time object that indicates when to start the event.
+      # @param scheduled_end_time [Time] A time object that indicates when to end the event.
+      # @param description [String] Description of the scheduled event.
+      # @param entity_type [Integer] The location of the event; E.g. voice, stage-instance, etc.
+      # @param image [String, #read] A base64 encoded string with the image data.
+      # @param recurrence_rule [Hash] A recurrence rule object. See the offical API docs for more info.
+      # @param reason [String] The reason for updating this scheduled event.
+      # @return [Hash<Symbol, Object>]
+      def modify_guild_scheduled_event(guild_id, guild_scheduled_event_id:, channel_id: :undef, entity_metadata: :undef,
+                                       name: :undef, privacy_level: :undef, scheduled_start_time: :undef, scheduled_end_time: :undef,
+                                       description: :undef, entity_type: :undef, status: :undef, image: :undef, recurrence_rule: :undef,
+                                       reason: :undef, **rest)
+        data = {
+          channel_id: channel_id,
+          entity_metadata: entity_metadata,
+          name: name,
+          privacy_level: privacy_level,
+          scheduled_start_time: scheduled_start_time,
+          scheduled_end_time: scheduled_end_time,
+          description: description,
+          entity_type: entity_type,
+          status: status,
+          image: image,
+          recurrence_rule: recurrence_rule,
+          **rest
+        }
+
+        request Route[:PATCH, "/guilds/#{guild_id}/scheduled-events/#{guild_scheduled_event_id}"],
+                body: filter_undef(data),
+                reason: reason
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/guild-scheduled-event#delete-guild-scheduled-event
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param guild_scheduled_event_id [Integer, String] An ID that uniquely identifies a scheduled event.
+      # @return [nil]
+      def delete_guild_scheduled_event(guild_id, guild_scheduled_event_id)
+        request Route[:DELETE, "/guilds/#{guild_id}/scheduled-events/#{guild_scheduled_event_id}"]
+      end
+    end
+  end
+end

--- a/lib/discordrb/api/endpoints/guild_template.rb
+++ b/lib/discordrb/api/endpoints/guild_template.rb
@@ -5,6 +5,7 @@ module Discordrb
     # @!discord_api https://discord.com/developers/docs/resources/guild-template
     module GuildTemplateEndpoints
       # @!discord_api https://discord.com/developers/docs/resources/guild-template#get-guild-template
+      # @param template_code [String] A code that creates a guild based on another guild.
       # @return [Hash<Symbol, Object>]
       def get_guild_template(template_code, **params)
         request Route[:GET, "/guilds/templates/#{template_code}"],
@@ -12,13 +13,16 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild-template#create-guild-from-guild-template
+      # @param template_code [String] A code that creates a guild based on another guild.
+      # @param icon [String, #read] A base64 encoded string with the image data.
       # @return [Hash<Symbol, Object>]
-      def create_guild_from_template(template_code, **rest)
+      def create_guild_from_template(template_code, icon: :undef, **rest)
         request Route[:POST, "/guilds/templates/#{template_code}"],
-                body: rest
+                body: filter_undef({ icon: icon, **rest })
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild-template#get-guild-templates
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Array<Hash<Symbol, Object>>]
       def get_guild_templates(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/templates", guild_id],
@@ -26,6 +30,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild-template#create-guild-template
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param name [String] 1-100 character name.
+      # @param description [String]  0-120 character description.
       # @return [Hash<Symbol, Object>]
       def create_guild_template(guild_id, name:, description: :undef, **rest)
         request Route[:POST, "/guilds/#{guild_id}/templates", guild_id],
@@ -33,6 +40,8 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild-template#sync-guild-template
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param template_code [String] A code that creates a guild based on another guild.
       # @return [Hash<Symbol, Object>]
       def sync_guild_template(guild_id, template_code)
         request Route[:PUT, "/guilds/#{guild_id}/templates/#{template_code}"],
@@ -40,13 +49,19 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild-template#modify-guild-template
-      # @return [Hash<Symbol, Object>]
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param template_code [String] A code that creates a guild based on another guild.
+      # @param name [String] 1-100 character name.
+      # @param description [String] 0-120 character description.
+      # @return [Hash<Symbol, Object>].
       def modify_guild_template(guild_id, template_code, name: :undef, description: :undef, **rest)
         request Route[:PATCH, "/guilds/#{guild_id}/templates/#{template_code}"],
                 body: filter_undef({ name: name, description: description, **rest })
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/guild-template#delete-guild-template
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param template_code [String] A code that creates a guild based on another guild.
       # @return [Hash<Symbol, Object>]
       def delete_guild_template(guild_id, template_code)
         request Route[:DELETE, "/guilds/#{guild_id}/templates/#{template_code}"]

--- a/lib/discordrb/api/endpoints/interaction.rb
+++ b/lib/discordrb/api/endpoints/interaction.rb
@@ -46,10 +46,10 @@ module Discordrb
       # @param components [Array<Hash>] Array of component objects.
       # @param poll [Hash<Object>] A poll request object.
       # @return [Hash]
-      def edit_original_interaction_response(id, token, content: :undef, embeds: :undef, allowed_mentions: :undef,
+      def edit_original_interaction_response(id, token, type: :undef, content: :undef, embeds: :undef, allowed_mentions: :undef,
                                              flags: :undef, components: :undef, poll: :undef, **rest)
         body = {
-          content: content, embeds: embeds, allowed_mentions: allowed_mentions,
+          type: type, content: content, embeds: embeds, allowed_mentions: allowed_mentions,
           flags: flags, components: components, poll: poll, **rest
         }
 

--- a/lib/discordrb/api/endpoints/interaction.rb
+++ b/lib/discordrb/api/endpoints/interaction.rb
@@ -1,24 +1,27 @@
+# frozen_string_literal: true
 
 module Discordrb
   module API
     # @!discord_api https://discord.com/developers/docs/interactions/receiving-and-responding#interactions
     module InteractionEndpoints
       # @!discord_api https://discord.com/developers/docs/interactions/slash-commands#create-interaction-response
-      # @param id [Integer, String]
-      # @param token [String]
-      # @param type [Integer]
-      # @param content [String]
-      # @param tts [true, false]
-      # @param embeds [Array<Hash>]
-      # @param allowed_mentions [Hash]
-      # @param flags [Integer]
-      # @param components [Array<Hash>]
+      # @param id [Integer, String] An ID that uniquely identifies an interaction.
+      # @param token [String] A token to enable a response to an interaction.
+      # @param type [Integer] Type of interaction.
+      # @param content [String] Message content.
+      # @param tts [Boolean] Whether the response is TTS.
+      # @param embeds [Array<Hash>] Embed objects to include.
+      # @param allowed_mentions [Hash] Allowed mentions object.
+      # @param flags [Integer] Bitfield value of message flags.
+      # @param components [Array<Hash>] Array of component objects.
+      # @param poll [Hash] A poll request object.
       # @return [Hash]
       def create_interaction_response(id, token, type:, content: :undef, tts: :undef, embeds: :undef,
-                                      allowed_mentions: :undef, flags: :undef, components: :undef, **rest)
+                                      custom_id: :undef, title: :undef, allowed_mentions: :undef, flags: :undef,
+                                      components: :undef, poll: :undef, **rest)
         body = {
           type: type, content: content, tts: tts, embeds: embeds, allowed_mentions: allowed_mentions,
-          flags: flags, components: components, **rest
+          custom_id: custom_id, title: title, flags: flags, components: components, poll: poll, **rest
         }
 
         request Route[:POST, "/interactions/#{id}/#{token}/callback"],
@@ -26,37 +29,99 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/slash-commands#get-original-interaction-response
-      # @param id [Integer, String]
-      # @param token [String]
+      # @param id [Integer, String] An ID that uniquely identifies an application.
+      # @param token [String] A token to enable a response to an interaction.
       # @return [Hash]
       def get_original_interaction_response(id, token)
         get_webhook_message(id, token, '@original')
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
-      # @param id [Integer, String]
-      # @param token [String]
-      # @param content [String]
-      # @param embeds [Array<Hash>]
-      # @param allowed_mentions [Hash]
-      # @param flags [Integer]
-      # @param components [Array<Hash>]
+      # @param id [Integer, String] An ID that uniquely identifies an application.
+      # @param token [String] A token to enable a response to an interaction.
+      # @param content [String] Message content.
+      # @param embeds [Array<Hash>] Embed objects to include.
+      # @param allowed_mentions [Hash] Allowed mentions object.
+      # @param flags [Integer] Bitfield value of message flags.
+      # @param components [Array<Hash>] Array of component objects.
+      # @param poll [Hash<Object>] A poll request object.
       # @return [Hash]
       def edit_original_interaction_response(id, token, content: :undef, embeds: :undef, allowed_mentions: :undef,
-                                             flags: :undef, components: :undef, **rest)
+                                             flags: :undef, components: :undef, poll: :undef, **rest)
         body = {
-          type: type, content: content, embeds: embeds, allowed_mentions: allowed_mentions,
-          flags: flags, components: components, **rest
+          content: content, embeds: embeds, allowed_mentions: allowed_mentions,
+          flags: flags, components: components, poll: poll, **rest
         }
 
         edit_webhook_message(id, token, '@original', **body)
       end
 
       # @!discord_api https://discord.com/developers/docs/interactions/slash-commands#delete-original-interaction-response
-      # @param id [Integer, String]
-      # @param token [String]
+      # @param id [Integer, String] An ID that uniquely identifies an application.
+      # @param token [String] A token to enable a response to an interaction.
+      # @return [nil]
       def delete_original_interaction_response(id, token)
         delete_webhook_message(id, token, '@original')
+      end
+
+      # @!discord_api https://discord.com/developers/docs/interactions/receiving-and-responding#create-followup-message
+      # @param id [Integer, String] An ID that uniquely identifies an application.
+      # @param token [String] A token to enable a response to an interaction.
+      # @param content [String] Message content.
+      # @param tts [Boolean] Whether the response is TTS.
+      # @param embeds [Array<Hash>] Embed objects to include.
+      # @param allowed_mentions [Hash] Allowed mentions object.
+      # @param components [Array<Hash>] Array of component objects.
+      # @param flags [Integer] Bitfield value of message flags.
+      # @param applied_tags [Array<Integer, String>] Array of ID tags to apply to a forum.
+      # @param poll [Hash<Object>] A poll request object.
+      # @return [Hash]
+      def create_followup_message(id, token, content: :undef, tts: :undef, embeds: :undef, allowed_mentions: :undef,
+                                  components: :undef, flags: :undef, applied_tags: :undef, poll: :undef, **rest)
+        body = {
+          wait: true, content: content, tts: tts, embeds: embeds, allowed_mentions: allowed_mentions,
+          flags: flags, components: components, applied_tags: applied_tags, poll: poll, **rest
+        }
+
+        execute_webhook(id, token, **body)
+      end
+
+      # @!discord_api https://discord.com/developers/docs/interactions/receiving-and-responding#get-followup-message
+      # @param id [Integer, String] An ID that uniquely identifies an application.
+      # @param token [String] A token to enable a response to an interaction.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @return [Hash]
+      def get_followup_message(id, token, message_id)
+        get_webhook_message(id, token, message_id)
+      end
+
+      # @!discord_api https://discord.com/developers/docs/interactions/receiving-and-responding#edit-followup-message
+      # @param id [Integer, String] An ID that uniquely identifies an application.
+      # @param token [String] A token to enable a response to an interaction.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @param content [String] Message content.
+      # @param embeds [Array<Hash>] Embed objects to include.
+      # @param allowed_mentions [Hash] Allowed mentions object.
+      # @param components [Array<Hash>] Array of component objects.
+      # @param poll [Hash<Object>] A poll request object.
+      # @return [Hash]
+      def edit_followup_message(id, token, message_id, content: :undef, embeds: :undef, allowed_mentions: :undef,
+                                components: :undef, poll: :undef, **rest)
+        body = {
+          content: content, embeds: embeds, allowed_mentions: allowed_mentions,
+          components: components, poll: poll, **rest
+        }
+
+        edit_webhook_message(id, token, message_id, **body)
+      end
+
+      # @!discord_api https://discord.com/developers/docs/interactions/receiving-and-responding#delete-followup-message
+      # @param id [Integer, String] An ID that uniquely identifies an application.
+      # @param token [String] A token to enable a response to an interaction.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @return [nil]
+      def delete_followup_message(id, token, message_id)
+        delete_webhook_message(id, token, message_id)
       end
     end
   end

--- a/lib/discordrb/api/endpoints/interaction.rb
+++ b/lib/discordrb/api/endpoints/interaction.rb
@@ -46,10 +46,10 @@ module Discordrb
       # @param components [Array<Hash>] Array of component objects.
       # @param poll [Hash<Object>] A poll request object.
       # @return [Hash]
-      def edit_original_interaction_response(id, token, type: :undef, content: :undef, embeds: :undef, allowed_mentions: :undef,
+      def edit_original_interaction_response(id, token, content: :undef, embeds: :undef, allowed_mentions: :undef,
                                              flags: :undef, components: :undef, poll: :undef, **rest)
         body = {
-          type: type, content: content, embeds: embeds, allowed_mentions: allowed_mentions,
+          content: content, embeds: embeds, allowed_mentions: allowed_mentions,
           flags: flags, components: components, poll: poll, **rest
         }
 
@@ -76,10 +76,10 @@ module Discordrb
       # @param applied_tags [Array<Integer, String>] Array of ID tags to apply to a forum.
       # @param poll [Hash<Object>] A poll request object.
       # @return [Hash]
-      def create_followup_message(id, token, content: :undef, tts: :undef, embeds: :undef, allowed_mentions: :undef,
-                                  components: :undef, flags: :undef, applied_tags: :undef, poll: :undef, **rest)
+      def create_followup_message(id, token, wait: false, content: :undef, tts: :undef, embeds: :undef, components: :undef,
+                                  allowed_mentions: :undef, flags: :undef, applied_tags: :undef, poll: :undef, **rest)
         body = {
-          wait: true, content: content, tts: tts, embeds: embeds, allowed_mentions: allowed_mentions,
+          wait: wait, content: content, tts: tts, embeds: embeds, allowed_mentions: allowed_mentions,
           flags: flags, components: components, applied_tags: applied_tags, poll: poll, **rest
         }
 

--- a/lib/discordrb/api/endpoints/invite.rb
+++ b/lib/discordrb/api/endpoints/invite.rb
@@ -10,7 +10,7 @@ module Discordrb
       # @param with_expiration [Boolean] Whether this invite should contain its expiration date.
       # @param guild_scheduled_event_id [Boolean] The ID of the scheduled event to include with this invite.
       # @return [Hash<Symbol, Object>]
-      def get_invite(invite_code, with_counts: :undef, with_expiration: :undef, guild_scheduled_event_id: :undef, **_params)
+      def get_invite(invite_code, with_counts: :undef, with_expiration: :undef, guild_scheduled_event_id: :undef, **rest)
         data = {
           with_counts: with_counts,
           with_expiration: with_expiration,

--- a/lib/discordrb/api/endpoints/invite.rb
+++ b/lib/discordrb/api/endpoints/invite.rb
@@ -1,15 +1,30 @@
+# frozen_string_literal: true
+
 module Discordrb
   module API
     # @!discord_api https://discord.com/developers/docs/resources/invite
     module InviteEndpoints
       # @!discord_api https://discord.com/developers/docs/resources/invite#get-invite
+      # @param invite_code [String] A code used to add a user to a guild.
+      # @param with_counts [Boolean] Whether this invite should contain an approximate member count.
+      # @param with_expiration [Boolean] Whether this invite should contain its expiration date.
+      # @param guild_scheduled_event_id [Boolean] The ID of the scheduled event to include with this invite.
       # @return [Hash<Symbol, Object>]
-      def get_invite(invite_code, **params)
+      def get_invite(invite_code, with_counts: :undef, with_expiration: :undef, guild_scheduled_event_id: :undef, **_params)
+        data = {
+          with_counts: with_counts,
+          with_expiration: with_expiration,
+          guild_scheduled_event_id: guild_scheduled_event_id,
+          **rest
+        }
+
         request Route[:GET, "/invites/#{invite_code}"],
-                params: params
+                params: filter_undef(data)
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/invite#delete-invite
+      # @param invite_code [String] A code used to add a user to a guild.
+      # @param reason [String] The reason for deleting this invite code.
       # @return [Hash<Symbol, Object>]
       def delete_invite(invite_code, reason: :undef)
         request Route[:DELETE, "/invites/#{invite_code}"],

--- a/lib/discordrb/api/endpoints/message.rb
+++ b/lib/discordrb/api/endpoints/message.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+module Discordrb
+  module API
+    # @!discord_api https://discord.com/developers/docs/resources/message
+    module MessageEndpoints
+      # @!discord_api https://discord.com/developers/docs/resources/message#get-channel-messages
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param around [Integer, String] Messages around this ID.
+      # @param before [Integer, String] Messages before this ID.
+      # @param after [Integer, String] Messages after this ID.
+      # @param limit [Integer] 1-100 max number of messages to get.
+      # @return [Array<Hash<Symbol, Object>>]
+      def get_channel_messages(channel_id, around: :undef, before: :undef, after: :undef, limit: :undef, **params)
+        request Route[:GET, "/channels/#{channel_id}/messages", channel_id],
+                params: filter_undef({ around: around, before: before, after: after, limit: limit, **params })
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/message#get-channel-message
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @return [Hash<Symbol, Object>]
+      def get_channel_message(channel_id, message_id, **params)
+        request Route[:GET, "/channels/#{channel_id}/message/#{message_id}", channel_id],
+                params: params
+      end
+
+      # rubocop:disable Style/MapToHash
+      # @!discord_api https://discord.com/developers/docs/resources/message#create-message
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param content [String] Message content up to 2,000 characters.
+      # @param nonce [Integer, String] Unique number Used to verifiy if a message was sent.
+      # @param tts [Boolean] Whether this is a TTS message.
+      # @param files [File] File contents being sent.
+      # @param embeds [Array<Hash>] Up to 10 embed objects to include.
+      # @param allowed_mentions [Hash] An allowed mentions object.
+      # @param message_reference [Hash] Whether this message should be a reply or forward.
+      # @param components [Array<Hash>] Message components to include.
+      # @param sticker_ids [Array] ID of up to 3 stickers.
+      # @param flags [Integer] Bitfield value of message flags.
+      # @param enforce_nonce [Boolean] Whether the nonce should be enforced.
+      # @param poll [Hash] A poll request object.
+      # @return [Hash<Symbol, Object>]
+      def create_message(channel_id,
+                         content: :undef, nonce: :undef, tts: :undef, files: :undef, embeds: :undef, allowed_mentions: :undef,
+                         message_reference: :undef, components: :undef, sticker_ids: :undef, flags: :undef,
+                         enforce_nonce: :undef, poll: :undef, **rest)
+        body = filter_undef({
+                              content: content,
+                              nonce: nonce,
+                              tts: tts,
+                              embeds: embeds,
+                              allowed_mentions: allowed_mentions,
+                              message_reference: message_reference,
+                              components: components,
+                              sticker_ids: sticker_ids,
+                              flags: flags,
+                              enforce_nonce: enforce_nonce,
+                              poll: poll,
+                              **rest
+                            })
+
+        if files
+          files = files.zip(0...files.count).map { |file, index| ["file[#{index}]", file] }.to_h
+          body = { **files, payload_json: JSON.dump(body) }
+        end
+
+        request Route[:POST, "/channels/#{channel_id}/messages", channel_id],
+                body: body
+      end
+      # rubocop:enable Style/MapToHash
+
+      # @!discord_api https://discord.com/developers/docs/resources/message#crosspost-message
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @return [Hash<Symbol, Object>]
+      def crosspost_message(channel_id, message_id, **rest)
+        request Route[:POST, "/channels/#{channel_id}/messages/#{message_id}/crosspost", channel_id],
+                body: rest
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/message#create-reaction
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @param emoji [String] An URL encoded emoji. Custom emojis should be in the name:id format.
+      # @return [nil]
+      def create_reaction(channel_id, message_id, emoji)
+        request Route[:PUT, "/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}/@me", channel_id],
+                body: ''
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/message#delete-own-reaction
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @param emoji [String] An URL encoded emoji. Custom emojis should be in the name:id format.
+      # @return [nil]
+      def delete_own_reaction(channel_id, message_id, emoji)
+        request Route[:DELETE, "/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}/@me", channel_id]
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/message#delete-user-reaction
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @param emoji [String] An URL encoded emoji. Custom emojis should be in the name:id format.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
+      # @return [nil]
+      def delete_user_reaction(channel_id, message_id, emoji, user_id)
+        request Route[:DELETE,
+                      "/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}/#{user_id}",
+                      channel_id]
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/message#get-reactions
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @param emoji [String] An URL encoded emoji. Custom emojis should be in the name:id format.
+      # @param after [Integer, String] Users after this user ID.
+      # @param limit [Integer] 1-100 max number of users to get.
+      # @param type [Integer] Type of reaction.
+      # @return [Array<Hash<Symbol, Object>>]
+      def get_reactions(channel_id, message_id, emoji, after: :undef, limit: :undef, type: :undef, **params)
+        query = {
+          after: after,
+          limit: limit,
+          type: type,
+          **params
+        }
+
+        request Route[:GET, "/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}", channel_id],
+                params: filter_undef(query)
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/message#delete-all-reactions
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @return [nil]
+      def delete_all_reactions(channel_id, message_id)
+        request Route[:DELETE, "/channels/#{channel_id}/messages/#{message_id}/reactions", channel_id]
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/message#delete-all-reactions-for-emoji
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @param emoji [String] An URL encoded emoji. Custom emojis should be in the name:id format.
+      # @return [nil]
+      def delete_all_reactions_for_emoji(channel_id, message_id, emoji)
+        request Route[:DELETE, "/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}", channel_id]
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/message#edit-message
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @param content [String] Message content up to 2,000 characters.
+      # @param embeds [Array<Hash>] Up to 10 embed objects to add.
+      # @param flags [Integer] Bitfield value of message flags.
+      # @param files [File] File contents being added.
+      # @param allowed_mentions [Hash] An allowed mentions object.
+      # @param components [Array<Hash>] Message components to add.
+      # @return [Hash<Symbol, Object>]
+      def edit_message(channel_id,
+                       message_id, content: :undef, embeds: :undef, flags: :undef,
+                       files: :undef, allowed_mentions: :undef, components: :undef,
+                       **rest)
+        body = filter_undef({
+                              content: content,
+                              tts: tts,
+                              embeds: embeds,
+                              allowed_mentions: allowed_mentions,
+                              message_reference: message_reference,
+                              components: components,
+                              flags: flags,
+                              **rest
+                            })
+
+        body = { files: files, payload_json: JSON.dump(body) } if files
+
+        request Route[:PATCH, "/channels/#{channel_id}/messages/#{message_id}", channel_id],
+                body: body
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/message#delete-message
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @param reason [String] The reason for deleting this message.
+      # @return [nil]
+      def delete_message(channel_id, message_id, reason: :undef)
+        request Route[:DELETE, "/channels/#{channel_id}/messages/#{message_id}"],
+                reason: reason
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/message#bulk-delete-messages
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param messages [Array] An array containing 2-100 message ID's to delete.
+      # @param reason [String] The reason for deleting these messages.
+      # @return [nil]
+      def bulk_delete_messages(channel_id, messages, reason: :undef)
+        request Route[:POST, "/channels/#{channel_id}/messages/bulk-delete", channel_id],
+                body: messages,
+                reason: reason
+      end
+    end
+  end
+end

--- a/lib/discordrb/api/endpoints/poll.rb
+++ b/lib/discordrb/api/endpoints/poll.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Discordrb
+  module API
+    # @!discord_api https://discord.com/developers/docs/resources/poll
+    module PollEndpoints
+      # @!discord_api https://discord.com/developers/docs/resources/poll#get-answer-voters
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @param answer_id [Integer, String] An ID that uniquely identifies a poll answer.
+      # @param after [Integer, String] Gets users after this user ID.
+      # @param limit [Integer] Max number of users between 1-100 to return.
+      # @return [Array<Hash<Symbol, Object>>]
+      def get_answer_voters(channel_id, message_id, answer_id, after: :undef, limit: :undef, **params)
+        request Route[:GET, "/channels/#{channel_id}/polls/#{message_id}/answer/#{answer_id}", channel_id],
+                params: filter_undef({ after: after, limit: limit, **params })
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/poll#end-poll
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @return [Array<Hash<Symbol, Object>>]
+      def end_poll(channel_id, message_id, **rest)
+        request Route[:POST, "/channels/#{channel_id}/polls/#{message_id}/expire", channel_id],
+                body: rest
+      end
+    end
+  end
+end

--- a/lib/discordrb/api/endpoints/sku.rb
+++ b/lib/discordrb/api/endpoints/sku.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Discordrb
+  module API
+    # @!discord_api https://discord.com/developers/docs/resources/sku
+    module SkuEndpoints
+      # @!discord_api https://discord.com/developers/docs/resources/sku#list-skus
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @return [Array<Hash<Symbol, Object>>]
+      def list_skus(application_id, **params)
+        request Route[:GET, "/applications/#{application_id}/skus", application_id],
+                params: params
+      end
+    end
+  end
+end

--- a/lib/discordrb/api/endpoints/soundboard.rb
+++ b/lib/discordrb/api/endpoints/soundboard.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module Discordrb
+  module API
+    # @!discord_api https://discord.com/developers/docs/resources/soundboard
+    module SoundboardEndpoints
+      # @!discord_api https://discord.com/developers/docs/resources/soundboard#send-soundboard-sound
+      # @param channel_id [String, Integer] An ID that uniquely identifies a channel.
+      # @param sound_id [String, Integer] ID of the sound to play.
+      # @param source_guild_id [String, Integer] ID of the guild the sound is from.
+      # @return [nil]
+      def send_soundboard_sound(channel_id, sound_id, source_guild_id: :undef, **rest)
+        request Route[:POST, "/channels/#{channel_id}/send-soundboard-sound", channel_id],
+                body: filter_undef({ sound_id: sound_id, source_guild_id: source_guild_id, **rest })
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/soundboard#list-default-soundboard-sounds
+      # @return [Array<Hash<Symbol, Object>>]
+      def list_default_soundboard_sounds(**params)
+        request Route[:GET, '/soundboard-default-sounds'],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/soundboard#list-guild-soundboard-sounds
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @return [Array<Hash<Symbol, Object>>]
+      def list_guild_soundboard_sounds(guild_id, **params)
+        request Route[:GET, "/guilds/#{guild_id}/soundboard-sounds"],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/soundboard#get-guild-soundboard-sound
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param sound_id [Integer, String] An ID that uniquely identifies a soundboard sound.
+      # @return [Hash<Symbol, Object>]
+      def get_guild_soundboard_sound(guild_id, sound_id, **params)
+        request Route[:GET, "/guilds/#{guild_id}/soundboard-sounds/#{sound_id}"],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/soundboard#create-guild-soundboard-sound
+      # @param guild_id [String, Integer] An ID that uniquely identifies a channel.
+      # @param name [String] 2-32 character name of the soundboard sound.
+      # @param sound [String, #read] A base64 encoded string with the sound data.
+      # @param volume [Integer] 0-1 volume of the sound.
+      # @param emoji_id [String, Integer] ID of the custom emoji for this sound.
+      # @param emoji_name [String] Unicode character of the standard emoji for this sound.
+      # @param reason [String] The reason for creating this soundboard sound.
+      # @return [Hash<Symbol, Object>]
+      def create_guild_soundboard_sound(guild_id, name:, sound:, volume: :undef,
+                                        emoji_id: :undef, emoji_name: :undef, reason: :undef,
+                                        **rest)
+        data = {
+          name: name,
+          sound: sound,
+          volume: volume,
+          emoji_id: emoji_id,
+          emoji_name: emoji_name,
+          **rest
+        }
+
+        request Route[:POST, "/guilds/#{guild_id}/soundboard-sounds", guild_id],
+                body: filter_undef(data),
+                reason: reason
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/soundboard#modify-guild-soundboard-sound
+      # @param guild_id [String, Integer] An ID that uniquely identifies a channel.
+      # @param sound_id [String, Integer] An ID that uniquely identifies a soundboard sound.
+      # @param name [String] 2-32 character name of the soundboard sound.
+      # @param volume [Integer] 0-1 volume of the sound.
+      # @param emoji_id [String, Integer] ID of the custom emoji for this sound.
+      # @param emoji_name [String] Unicode character of the standard emoji for this sound.
+      # @param reason [String] The reason for modifiying this soundboard sound.
+      # @return [Hash<Symbol, Object>]
+      def modifiy_guild_soundboard_sound(guild_id, sound_id, name: :undef, volume: :undef,
+                                         emoji_id: :undef, emoji_name: :undef, reason: :undef,
+                                         **rest)
+        data = {
+          name: name,
+          volume: volume,
+          emoji_id: emoji_id,
+          emoji_name: emoji_name,
+          **rest
+        }
+
+        request Route[:PATCH, "/guilds/#{guild_id}/soundboard-sounds/#{sound_id}", guild_id],
+                body: filter_undef(data),
+                reason: reason
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/soundboard#delete-guild-soundboard-sound
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param sound_id [Integer, String] An ID that uniquely identifies a soundboard sound.
+      # @param reason [String] The reason for deleting this soundboard sound.
+      # @return [Hash<Symbol, Object>]
+      def delete_guild_soundboard_sound(guild_id, sound_id, reason: :undef)
+        request Route[:DELETE, "/guilds/#{guild_id}/soundboard-sounds/#{sound_id}"],
+                reason: reason
+      end
+    end
+  end
+end

--- a/lib/discordrb/api/endpoints/stage_instance.rb
+++ b/lib/discordrb/api/endpoints/stage_instance.rb
@@ -5,12 +5,21 @@ module Discordrb
     # @!discord_api https://discord.com/developers/docs/resources/stage-instance
     module StageInstanceEndpoints
       # @!discord_api https://discord.com/developers/docs/resources/stage-instance#create-stage-instance
+      # @param channel_id [Integer, String] An ID of a stage channel.
+      # @param topic [String] 1-120 character description;
+      # @param privacy_level [Integer] Who this stage instance is visible to.
+      # @param send_start_notification [Boolean] Whether @everyone should be pinged when the stage instance begins.
+      # @param guild_scheduled_event_id [Integer, String] A scheduled event associated with this stage instance.
+      # @param reason [String] The reason for creating this stage instance.
       # @return [Hash<Symbol, Object>]
-      def create_stage_instance(channel_id:, topic:, privacy_level: :undef, reason: :undef, **rest)
+      def create_stage_instance(channel_id, topic:, privacy_level: :undef, send_start_notification: :undef,
+                                guild_scheduled_event_id: :undef, reason: :undef, **rest)
         data = {
           channel_id: channel_id,
           topic: topic,
           privacy_level: privacy_level,
+          send_start_notification: send_start_notification,
+          guild_scheduled_event_id: guild_scheduled_event_id,
           **rest
         }
 
@@ -20,6 +29,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/stage-instance#get-stage-instance
+      # @param channel_id [Integer, String] An ID of a stage channel.
       # @return [Hash<Symbol, Object>]
       def get_stage_instance(channel_id, **params)
         request Route[:GET, "/stage-instances/#{channel_id}", channel_id],
@@ -27,6 +37,10 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/stage-instance#modify-stage-instance
+      # @param channel_id [Integer, String] An ID of a stage channel.
+      # @param topic [String] 1-120 character description.
+      # @param privacy_level [Integer] Who this stage instance is visible to.
+      # @param reason [String] The reason for modifiying this stage instance.
       # @return [Hash<Symbol, Object>]
       def modify_stage_instance(channel_id, topic: :undef, privacy_level: :undef, reason: :undef, **rest)
         data = {
@@ -41,6 +55,8 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance
+      # @param channel_id [Integer, String] An ID of a stage channel.
+      # @param reason [String] The reason for deleting this stage instance.
       # @return [untyped]
       def delete_stage_instance(channel_id, reason: :undef)
         request Route[:DELETE, "/stage-instances/#{channel_id}", channel_id],

--- a/lib/discordrb/api/endpoints/sticker.rb
+++ b/lib/discordrb/api/endpoints/sticker.rb
@@ -5,6 +5,7 @@ module Discordrb
     # @!discord_api https://discord.com/developers/docs/resources/sticker
     module StickerEndpoints
       # @!discord_api https://discord.com/developers/docs/resources/sticker#get-sticker
+      # @param sticker_id [String, Integer] An ID that uniquely identifies a sticker.
       # @return [Hash<Symbol, Object>]
       def get_sticker(sticker_id, **params)
         request Route[:GET, "/stickers/#{sticker_id}"],
@@ -19,6 +20,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/sticker#list-guild-stickers
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Array<Hash<Symbol, Object>>]
       def list_guild_stickers(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/stickers", guild_id],
@@ -26,6 +28,8 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/sticker#get-guild-sticker
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param sticker_id [String, Integer] An ID that uniquely identifies a sticker.
       # @return [Hash<Symbol, Object>]
       def get_guild_sticker(guild_id, sticker_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/stickers/#{sticker_id}", guild_id],
@@ -33,6 +37,12 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/sticker#create-guild-sticker
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param name [String] Name of the sticker.
+      # @param description [String] Description of the sticker.
+      # @param tags [string] Autocomplete tags, max 200 characters.
+      # @param file [File] PNG, APNG, GIF, or Lottie file.
+      # @param reason [String] The reason the for creating sticker.
       # @return [Hash<Symbol, Object>]
       def create_guild_sticker(guild_id, name:, description:, tags:, file:, reason: :undef, **rest)
         data = {
@@ -49,6 +59,12 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/sticker#modify-guild-sticker
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param sticker_id [String, Integer] An ID that uniquely identifies a sticker.
+      # @param name [String] Name of the sticker.
+      # @param description [String] Description of the sticker.
+      # @param tags [string] Autocomplete tags, max 200 characters.
+      # @param reason [String] The reason the for modifiying this sticker.
       # @return [Hash<Symbol, Object>]
       def modify_guild_sticker(guild_id, sticker_id,
                                name: :undef, description: :undef, tags: :undef, reason: :undef, **rest)
@@ -67,7 +83,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/sticker#delete-guild-sticker
-      # @return nil
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param sticker_id [String, Integer] An ID that uniquely identifies a sticker.
+      # @return [nil]
       def delete_guild_sticker(guild_id, sticker_id, reason: :undef)
         request Route[:PATCH, "/guilds/#{guild_id}/stickers/#{sticker_id}", guild_id],
                 reason: reason

--- a/lib/discordrb/api/endpoints/sticker.rb
+++ b/lib/discordrb/api/endpoints/sticker.rb
@@ -12,10 +12,18 @@ module Discordrb
                 params: params
       end
 
-      # @!discord_api https://discord.com/developers/docs/resources/sticker#list-nitro-sticker-packs
+      # @!discord_api https://discord.com/developers/docs/resources/sticker#list-sticker-packs
       # @return [Array<Hash<Symbol, Object>>]
-      def list_nitro_sticker_packs(**params)
+      def list_sticker_packs(**params)
         request Route[:GET, '/sticker-packs'],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/sticker#get-sticker-pack
+      # @param pack_id [Integer, String] An ID that uniquely identifies a sticker pack.
+      # @return [Hash<Symbol, Object>]
+      def get_sticker_pack(pack_id, **params)
+        request Route[:GET, "/sticker-packs/#{pack_id}"],
                 params: params
       end
 

--- a/lib/discordrb/api/endpoints/subscription.rb
+++ b/lib/discordrb/api/endpoints/subscription.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Discordrb
+  module API
+    # @!discord_api https://discord.com/developers/docs/resources/subscription
+    module SubscriptionEndpoints
+      # @!discord_api https://discord.com/developers/docs/resources/subscription#list-sku-subscriptions
+      # @param sku_id [Integer, String] An ID that uniquely identifies a stock keeping unit.
+      # @return [Array<Hash<Symbol, Object>>]
+      def list_sku_subscriptions(sku_id, **params)
+        request Route[:GET, "/skus/#{sku_id}/subscriptions"], params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/subscription#get-sku-subscription
+      # @param sku_id [Integer, String] An ID that uniquely identifies a stock keeping unit.
+      # @param subscription_id [Integer, String] An ID that uniquely a subscription.
+      # @return [Array<Hash<Symbol, Object>>]
+      def get_sku_subscription(sku_id, subscription_id, **params)
+        request Route[:GET, "/skus/#{sku_id}/subscriptions/#{subscription_id}"], params: params
+      end
+    end
+  end
+end

--- a/lib/discordrb/api/endpoints/user.rb
+++ b/lib/discordrb/api/endpoints/user.rb
@@ -11,7 +11,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/user#get-user
-      # @param user_id [Integer, String]
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
       # @return [Hash<Symbol, Object>]
       def get_user(user_id, **params)
         request Route[:GET, "/users/#{user_id}"],
@@ -19,8 +19,8 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/user#modify-current-user
-      # @param username [String]
-      # @param avatar [String, nil]
+      # @param username [String] New name of the current user. May randomize the discriminator.
+      # @param avatar [String, read] A base64 encoded string with the image data.
       # @return [Hash<Symbol, Object>]
       def modify_current_user(username: :undef, avatar: :undef, **rest)
         request Route[:PATCH, '/users/@me'],
@@ -35,14 +35,14 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/user#leave-guild
-      # @param guild_id [Integer, String]
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Hash<Symbol, Object>]
       def leave_guild(guild_id)
         request Route[:DELETE, "/users/@me/guilds/#{guild_id}"]
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/user#create-dm
-      # @param recipient_id [Integer, String]
+      # @param recipient_id [Integer, String] The user to open a DM with.
       # @return [Hash<Symbol, Object>]
       def create_dm(recipient_id, **rest)
         request Route[:POST, '/users/@me/channels'], body: { recipient_id: recipient_id, **rest }
@@ -52,6 +52,32 @@ module Discordrb
       # @return [Hash<Symbol, Object>]
       def get_current_user_connections(**params)
         request Route[:GET, '/users/@me/connections'], params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/user#get-current-user-application-role-connection
+      # @return [Hash<Symbol, Object>]
+      def get_current_user_application_role_connections(application_id, **params)
+        request Route[:GET, "/users/@me/applications/#{application_id}/role-connection"],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/user#update-current-user-application-role-connection
+      # @param application_id [Integer, String] An ID that uniquely identifies an application.
+      # @param platform_name [String] Max 50 character name of a connected platform.
+      # @param platform_username [String] Max 100 character username of a connected platform.
+      # @param metadata [Hash<Symbol, Object>] Max 100 character Role connection metadata keys for a connected platform.
+      # @return [Hash<Symbol, Object>]
+      def update_current_user_application_role_connections(application_id, platform_name: :undef, platform_username: :undef,
+                                                           metadata: :undef, **params)
+        data = {
+          platform_name: platform_name,
+          platform_username: platform_username,
+          metadata: metadata,
+          **params
+        }
+
+        request Route[:PUT, "/users/@me/applications/#{application_id}/role-connection"],
+                body: filter_undef(data)
       end
     end
   end

--- a/lib/discordrb/api/endpoints/user.rb
+++ b/lib/discordrb/api/endpoints/user.rb
@@ -21,7 +21,7 @@ module Discordrb
       # @!discord_api https://discord.com/developers/docs/resources/user#modify-current-user
       # @param username [String] New name of the current user. May randomize the discriminator.
       # @param avatar [String] A base64 encoded string with the image data.
-      # @param banner [String] A base64 encoded string with the image data. 
+      # @param banner [String] A base64 encoded string with the image data.
       # @return [Hash<Symbol, Object>]
       def modify_current_user(username: :undef, avatar: :undef, banner: banner, **rest)
         request Route[:PATCH, '/users/@me'],

--- a/lib/discordrb/api/endpoints/user.rb
+++ b/lib/discordrb/api/endpoints/user.rb
@@ -20,11 +20,12 @@ module Discordrb
 
       # @!discord_api https://discord.com/developers/docs/resources/user#modify-current-user
       # @param username [String] New name of the current user. May randomize the discriminator.
-      # @param avatar [String, read] A base64 encoded string with the image data.
+      # @param avatar [String] A base64 encoded string with the image data.
+      # @param banner [String] A base64 encoded string with the image data. 
       # @return [Hash<Symbol, Object>]
-      def modify_current_user(username: :undef, avatar: :undef, **rest)
+      def modify_current_user(username: :undef, avatar: :undef, banner: banner, **rest)
         request Route[:PATCH, '/users/@me'],
-                body: filter_undef({ username: username, avatar: avatar, **rest })
+                body: filter_undef({ username: username, avatar: avatar, banner: banner, **rest })
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/user#get-current-user-guilds

--- a/lib/discordrb/api/endpoints/voice.rb
+++ b/lib/discordrb/api/endpoints/voice.rb
@@ -10,6 +10,58 @@ module Discordrb
         request Route[:GET, '/voice/regions'],
                 params: params
       end
+
+      # @!discord_api https://discord.com/developers/docs/resources/voice#get-current-user-voice-state
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @return [Array<Hash<Symbol, Object>>]
+      def get_current_user_voice_state(guild_id, **params)
+        request Route[:GET, "/guilds/#{guild_id}/voice-states/@me"],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/voice#get-user-voice-state
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
+      # @return [Array<Hash<Symbol, Object>>]
+      def get_user_voice_state(guild_id, user_id, **params)
+        request Route[:GET, "/guilds/#{guild_id}/voice-states/#{user_id}"],
+                params: params
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param suppress [Boolean] Whether the current user should be suppressed.
+      # @param request_to_speak_timestamp [Time] User's request to speak timestamp.
+      # @return [nil]
+      def modify_current_user_voice_state(guild_id, channel_id: :undef, suppress: :undef,
+                                          request_to_speak_timestamp: :undef, **rest)
+        data = {
+          channel_id: channel_id,
+          suppress: suppress,
+          request_to_speak_timestamp: request_to_speak_timestamp,
+          **rest
+        }
+
+        request Route[:PATCH, "/guilds/#{guild_id}/voice-states/@me", guild_id],
+                body: filter_undef(data)
+      end
+
+      # @!discord_api https://discord.com/developers/docs/resources/voice#modify-user-voice-state
+      # @param channel_id [Integer, String] An ID that uniquely identifies a channel.
+      # @param user_id [Integer, String] An ID that uniquely identifies a user.
+      # @param suppress [Boolean] Whether the user should be suppressed.
+      # @return [nil]
+      def modify_user_voice_state(guild_id, user_id, channel_id: :undef, suppress: :undef, **rest)
+        data = {
+          channel_id: channel_id,
+          suppress: suppress,
+          **rest
+        }
+
+        request Route[:PATCH, "/guilds/#{guild_id}/voice-states/#{user_id}", guild_id],
+                body: filter_undef(data)
+      end
     end
   end
 end

--- a/lib/discordrb/api/endpoints/webhook.rb
+++ b/lib/discordrb/api/endpoints/webhook.rb
@@ -5,6 +5,10 @@ module Discordrb
     # @!discord_api https://discord.com/developers/docs/resources/webhook
     module WebhookEndpoints
       # @!discord_api https://discord.com/developers/docs/resources/webhook#create-webhook
+      # @param channel_id [String, Integer] An ID that uniquely identifies a channel.
+      # @param name [String] 1-80 character name of the webhook to create.
+      # @param avatar [String, #read] A base64 encoded string with the image data.
+      # @param reason [String] The reason for creating this webhook.
       # @return [Hash<Symbol, Object>]
       def create_webhook(channel_id, name: :undef, avatar: :undef, reason: :undef, **rest)
         request Route[:POST, "/channels/#{channel_id}/webhooks", channel_id],
@@ -13,6 +17,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/webhook#get-channel-webhooks
+      # @param channel_id [String, Integer] An ID that uniquely identifies a channel.
       # @return [Array<Hash<Symbol, Object>>]
       def get_channel_webhooks(channel_id, **params)
         request Route[:GET, "/channels/#{channel_id}/webhooks", channel_id],
@@ -20,6 +25,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/webhook#get-guild-webhooks
+      # @param guild_id [Integer, String] An ID that uniquely identifies a guild.
       # @return [Array<Hash<Symbol, Object>>]
       def get_guild_webhooks(guild_id, **params)
         request Route[:GET, "/guilds/#{guild_id}/webhooks", guild_id],
@@ -27,6 +33,7 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/webhook#get-webhook
+      # @param webhook_id [Integer, String] An ID that uniquely identifies a webhook.
       # @return [Hash<Symbol, Object>]
       def get_webhook(webhook_id, **params)
         request Route[:GET, "/webhooks/#{webhook_id}", webhook_id],
@@ -34,6 +41,8 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/webhook#get-webhook-with-token
+      # @param webhook_id [Integer, String] An ID that uniquely identifies a webhook.
+      # @param webhook_token [String] The secure token of the webhook.
       # @return [Hash<Symbol, Object>]
       def get_webhook_with_token(webhook_id, webhook_token, **params)
         request Route[:GET, "/webhooks/#{webhook_id}/#{webhook_token}", webhook_id, :get_webhooks_id_token],
@@ -41,6 +50,10 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/webhook#modify-webhook
+      # @param webhook_id [Integer, String] An ID that uniquely identifies a webhook.
+      # @param name [String] Default name of the webhook.
+      # @param avatar [String, #read] A base64 encoded string with the image data.
+      # @param channel_id [String, Integer] New channel ID to move this webhook to.
       # @return [Hash<Symbol, Object>]
       def modify_webhook(webhook_id, name: :undef, avatar: :undef, channel_id: :undef, **rest)
         request Route[:PATCH, "/webhooks/#{webhook_id}", webhook_id],
@@ -48,13 +61,19 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/webhook#modify-webhook-with-token
+      # @param webhook_id [Integer, String] An ID that uniquely identifies a webhook.
+      # @param webhook_token [String] The secure token of the webhook.
+      # @param name [String] Default name of the webhook.
+      # @param avatar [String, #read] A base64 encoded string with the image data.
       # @return [Hash<Symbol, Object>]
-      def modify_webhook_with_token(webhook_id, webhook_token, name: :undef, avatar: :undef, channel_id: :undef, **rest)
+      def modify_webhook_with_token(webhook_id, webhook_token, name: :undef, avatar: :undef, **rest)
         request Route[:PATCH, "/webhooks/#{webhook_id}/#{webhook_token}", webhook_id, :patch_webhooks_id_token],
                 body: filter_undef({ name: name, avatar: avatar, channel_id: channel_id, **rest })
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/webhook#delete-webhook
+      # @param webhook_id [Integer, String] An ID that uniquely identifies a webhook.
+      # @param reason [String] The reason for deleting this webhook.
       # @return [nil]
       def delete_webhook(webhook_id, reason: :undef)
         request Route[:DELETE, "/webhooks/#{webhook_id}", webhook_id],
@@ -62,6 +81,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token
+      # @param webhook_id [Integer, String] An ID that uniquely identifies a webhook.
+      # @param webhook_token [String] The secure token of the webhook.
+      # @param reason [String] The reason for deleting this webhook.
       # @return [nil]
       def delete_webhook_with_token(webhook_id, webhook_token, reason: :undef)
         request Route[:DELETE, "/webhooks/#{webhook_id}/#{webhook_token}", webhook_id, :delete_webhook_id_token],
@@ -69,18 +91,23 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/webhook#execute-webhook
+      # @param webhook_id [Integer, String] An ID that uniquely identifies a webhook.
+      # @param webhook_token [String] The secure token of the webhook.
       # @return [nil, Hash<Symbol, Object>]
       def execute_webhook(webhook_id, webhook_token, wait: :undef, thread_id: :undef, content: :undef, username: :undef,
-                          avatar_url: :undef, tts: :undef, file: :undef, embeds: :undef, allowed_mentions: :undef,
-                          components: :undef, params: {}, **rest)
+                          avatar_url: :undef, tts: :undef, file: :undef, flags: :undef, embeds: :undef, allowed_mentions: :undef,
+                          components: :undef, applied_tags: :undef, poll: :undef, params: {}, **rest)
         data = {
           content: content,
           username: username,
           avatar_url: avatar_url,
           tts: tts,
+          flags: flags,
           embeds: embeds,
           allowed_mentions: allowed_mentions,
           components: components,
+          applied_tags: applied_tags,
+          poll: poll,
           **rest
         }
 
@@ -92,6 +119,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/webhook#get-webhook-message
+      # @param webhook_id [Integer, String] An ID that uniquely identifies a webhook.
+      # @param webhook_token [String] The secure token of the webhook.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
       # @return [Hash<Symbol, Object>]
       def get_webhook_message(webhook_id, webhook_token, message_id, **params)
         request Route[:GET, "/webhooks/#{webhook_id}/#{webhook_token}/messages/#{message_id}", webhook_id, :get_webhooks_id_token_messages_id],
@@ -99,6 +129,15 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/webhook#edit-webhook-message
+      # @param webhook_id [Integer, String] An ID that uniquely identifies a webhook.
+      # @param webhook_token [String] The secure token of the webhook.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
+      # @param content [String] Message content up to 2,000 characters.
+      # @param embeds [Array<Hash>] Up to 10 embed objects to include.
+      # @param file [File] File contents being sent.
+      # @param allowed_mentions [Hash] An allowed mentions object.
+      # @param attachments [File] Attatched files.
+      # @param components [Array<Hash>] An array of message components to include.
       # @return [Hash<Symbol, Object>]
       def edit_webhook_message(webhook_id, webhook_token, message_id, content: :undef, embeds: :undef, file: :undef,
                                allowed_mentions: :undef, attachments: :undef, components: :undef, **rest)
@@ -118,6 +157,9 @@ module Discordrb
       end
 
       # @!discord_api https://discord.com/developers/docs/resources/webhook#delete-webhook-message
+      # @param webhook_id [Integer, String] An ID that uniquely identifies a webhook.
+      # @param webhook_token [String] The secure token of the webhook.
+      # @param message_id [Integer, String] An ID that uniquely identifies a message.
       # @return [nil]
       def delete_webhook_message(webhook_id, webhook_token, message_id)
         request Route[:DELETE, "/webhooks/#{webhook_id}/#{webhook_token}/messages/#{message_id}", webhook_id, :delete_webhooks_id_token_messages_id]

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'zlib'
-require 'set'
 
 require 'discordrb/api/client'
 require 'discordrb/events/message'
@@ -808,7 +807,7 @@ module Discordrb
     private
 
     def file_to_file_part(file, content_type = 'binary/octet-stream', filename = nil)
-      Faraday::FilePart.new(file, content_type, filename)
+      Faraday::Multipart::FilePart.new(file, content_type, filename)
     end
 
     # Throws a useful exception if there's currently no gateway connection.

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -20,7 +20,6 @@ require 'discordrb/events/webhooks'
 require 'discordrb/events/invites'
 require 'discordrb/events/interactions'
 
-
 require 'discordrb/errors'
 require 'discordrb/data'
 require 'discordrb/await'

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -167,7 +167,7 @@ module Discordrb
       yield(builder, view) if block_given?
 
       components ||= view
-      data = {content: content, embeds: embeds, allowed_mentions: allowed_mentions, components: components&.to_a }
+      data = { content: content, embeds: embeds, allowed_mentions: allowed_mentions, components: components&.to_a }
       data = builder.to_json_hash.merge(data.compact)
       resp = @bot.client.edit_original_interaction_response(@application_id, @token, **data)
 

--- a/lib/discordrb/webhooks/builder.rb
+++ b/lib/discordrb/webhooks/builder.rb
@@ -41,7 +41,7 @@ module Discordrb::Webhooks
     def file=(file)
       raise ArgumentError, 'Embeds and files are mutually exclusive!' unless @embeds.empty?
 
-      @file = Faraday::Multipart::FilePart(file, 'binary/octet-stream')
+      @file = Faraday::Multipart::FilePart.new(file, 'binary/octet-stream')
     end
 
     # Adds an embed to this message.

--- a/lib/discordrb/webhooks/builder.rb
+++ b/lib/discordrb/webhooks/builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'faraday'
+require 'faraday/multipart'
 require 'discordrb/webhooks/embeds'
 
 module Discordrb::Webhooks
@@ -40,7 +41,7 @@ module Discordrb::Webhooks
     def file=(file)
       raise ArgumentError, 'Embeds and files are mutually exclusive!' unless @embeds.empty?
 
-      @file = Faraday::FilePart.new(file, 'binary/octet-stream')
+      @file = Faraday::Multipart::FilePart(file, 'binary/octet-stream')
     end
 
     # Adds an embed to this message.

--- a/lib/discordrb/webhooks/client.rb
+++ b/lib/discordrb/webhooks/client.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/multipart'
 require 'json'
 
 require 'discordrb/webhooks/builder'


### PR DESCRIPTION
# Summary
Separates out all the endpoint related changes in the [previous 4.0 commit](https://github.com/shardlab/discordrb/pull/276/files) into their own commit. Has that added benefit of a slightly less shitty commit history.
## Added
`Discordrb::API::ApplicationEndpoints`
`Discordrb::API::AutoModerationEndpoints`
`Discordrb::API::EntitlementEndpoints`
`Discordrb::API::GuildScheduledEventEndpoints`
`Discordrb::API::PollEndpoints`
`Discordrb::API::SkuEndpoints`
`Discordrb::API::SoundboardEndpoints`
`Faraday/Multipart` gem.
`Base64` gem as an explicit dependency.
Yard documentation for API endpoints.
## Changed
Bumped the dependency versions and Gem-specs.
Separated out the message endpoints into their own module: `Discordrb::API::MessageEndpoints`
Separated out guild voice endpoints into their own module: `Discordrb::API::VoiceEndpoints`
## Removed
`Faraday_middleware` gem as it has been deprecated.