### PR TITLE
chore: V4.0 fully remove user account methods

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -8,7 +8,7 @@ require 'discordrb/errors'
 # List of methods representing endpoints in Discord's API
 module Discordrb::API
   # The base URL of the Discord REST API.
-  APIBASE = 'https://discord.com/api/v8'
+  APIBASE = 'https://discord.com/api/v9'
 
   # The URL of Discord's CDN
   CDN_URL = 'https://cdn.discordapp.com'
@@ -222,30 +222,6 @@ module Discordrb::API
     "#{cdn_url}/app-assets/#{application_id}/achievements/#{achievement_id}/icons/#{icon_hash}.#{format}"
   end
 
-  # Login to the server
-  def login(email, password)
-    request(
-      :auth_login,
-      nil,
-      :post,
-      "#{api_base}/auth/login",
-      email: email,
-      password: password
-    )
-  end
-
-  # Logout from the server
-  def logout(token)
-    request(
-      :auth_logout,
-      nil,
-      :post,
-      "#{api_base}/auth/logout",
-      nil,
-      Authorization: token
-    )
-  end
-
   # Create an OAuth application
   def create_oauth_application(token, name, redirect_uris)
     request(
@@ -283,20 +259,6 @@ module Discordrb::API
     )
   end
 
-  # Acknowledge that a message has been received
-  # The last acknowledged message will be sent in the ready packet,
-  # so this is an easy way to catch up on messages
-  def acknowledge_message(token, channel_id, message_id)
-    request(
-      :channels_cid_messages_mid_ack,
-      nil, # This endpoint is unavailable for bot accounts and thus isn't subject to its rate limit requirements.
-      :post,
-      "#{api_base}/channels/#{channel_id}/messages/#{message_id}/ack",
-      nil,
-      Authorization: token
-    )
-  end
-
   # Get the gateway to be used
   def gateway(token)
     request(
@@ -317,19 +279,6 @@ module Discordrb::API
       :get,
       "#{api_base}/gateway/bot",
       Authorization: token
-    )
-  end
-
-  # Validate a token (this request will fail if the token is invalid)
-  def validate_token(token)
-    request(
-      :auth_login,
-      nil,
-      :post,
-      "#{api_base}/auth/login",
-      {}.to_json,
-      Authorization: token,
-      content_type: :json
     )
   end
 

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -82,8 +82,6 @@ module Discordrb
     #   you're trying to log in as a bot.
     # @param client_id [Integer] If you're logging in as a bot, the bot's client ID. This is optional, and may be fetched
     #   from the API by calling {Bot#bot_application} (see {Application}).
-    # @param type [Symbol] This parameter lets you manually overwrite the account type. This needs to be set when
-    #   logging in as a user, otherwise discordrb will treat you as a bot account. Valid values are `:user` and `:bot`.
     # @param name [String] Your bot's name. This will be sent to Discord with any API requests, who will use this to
     #   trace the source of excessive API requests; it's recommended to set this to something if you make bots that many
     #   people will host on their servers separately.
@@ -110,7 +108,7 @@ module Discordrb
     def initialize(
       log_mode: :normal,
       token: nil, client_id: nil,
-      type: nil, name: '', fancy_log: false, suppress_ready: false, parse_self: false,
+      name: '', fancy_log: false, suppress_ready: false, parse_self: false,
       shard_id: nil, num_shards: nil, redact_token: true, ignore_bots: false,
       compress_mode: :large, intents: :all
     )
@@ -121,7 +119,6 @@ module Discordrb
 
       @client_id = client_id
 
-      @type = type || :bot
       @name = name
 
       @shard_key = num_shards ? [shard_id, num_shards] : nil
@@ -144,7 +141,7 @@ module Discordrb
                    calculate_intents(intents)
                  end
 
-      @token = process_token(@type, token)
+      @token = "Bot #{token.delete_prefix('Bot ')}"
       @gateway = Gateway.new(self, @token, @shard_key, @compress_mode, @intents)
 
       init_cache
@@ -1105,14 +1102,6 @@ module Discordrb
     ##       ##     ## ##    ##   ##  ##  ####
     ##       ##     ## ##    ##   ##  ##   ###
     ########  #######   ######   #### ##    ##
-
-    def process_token(type, token)
-      # Remove the "Bot " prefix if it exists
-      token = token[4..] if token.start_with? 'Bot '
-
-      token = "Bot #{token}" unless type == :user
-      token
-    end
 
     def handle_dispatch(type, data)
       # Check whether there are still unavailable servers and there have been more than 10 seconds since READY

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -77,7 +77,6 @@ module Discordrb::Commands
         log_mode: attributes[:log_mode],
         token: attributes[:token],
         client_id: attributes[:client_id],
-        type: attributes[:type],
         name: attributes[:name],
         fancy_log: attributes[:fancy_log],
         suppress_ready: attributes[:suppress_ready],

--- a/lib/discordrb/data/profile.rb
+++ b/lib/discordrb/data/profile.rb
@@ -42,32 +42,6 @@ module Discordrb
       @avatar_id = new_data[:avatar_id] || @avatar_id
     end
 
-    # Sets the user status setting to Online.
-    # @note Only usable on User accounts.
-    def online
-      update_profile_status_setting('online')
-    end
-
-    # Sets the user status setting to Idle.
-    # @note Only usable on User accounts.
-    def idle
-      update_profile_status_setting('idle')
-    end
-
-    # Sets the user status setting to Do Not Disturb.
-    # @note Only usable on User accounts.
-    def dnd
-      update_profile_status_setting('dnd')
-    end
-
-    alias_method(:busy, :dnd)
-
-    # Sets the user status setting to Invisible.
-    # @note Only usable on User accounts.
-    def invisible
-      update_profile_status_setting('invisible')
-    end
-
     # The inspect method is overwritten to give more useful output
     def inspect
       "<Profile user=#{super}>"

--- a/lib/discordrb/errors.rb
+++ b/lib/discordrb/errors.rb
@@ -7,7 +7,7 @@ module Discordrb
     class InvalidAuthenticationError < RuntimeError
       # Default message for this exception
       def message
-        'User login failed due to an invalid email or password!'
+        'Authentication failed due to an invalid token!'
       end
     end
 

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -51,10 +51,6 @@ module Discordrb
     # to behave correctly)
     VOICE_STATE = 4
 
-    # **Sent**: This opcode is used to ping a voice server, whatever that means. The functionality of this opcode isn't
-    # known well but non-user clients should never send it.
-    VOICE_PING = 5
-
     # **Sent**: This is the other of two possible ways to initiate a gateway session (other than {IDENTIFY}). Rather
     # than starting an entirely new session, it resumes an existing session by replaying all events from a given
     # sequence number. It should be used to recover from a connection error or anything like that when the session is


### PR DESCRIPTION
# Summary
Separates out the removal of user account login related changes in the [previous 4.0 commit](https://github.com/shardlab/discordrb/pull/276/files) into their own commit. I noticed a few other things related to user accounts, so I've attempted to deprecate them.

## Removed
`Discordrb::API.login`
`Discordrb::API.logout`
`Discordrb::Bot.process_token`
`Discordrb::API.validate_token` — This used the old `/auth/login` route.
`Discordrb::API.acknowledge_message` — This endpoint is not usable by bot accounts
`type` parameter on constructor for bot object. — Pointless to keep since only bot accounts are supported.
`OP: 5` — The comments say that a bot should never send this OP code, and I can't find anything about in the docs. This seems to be something different than voice OP 5.

Setting the status via the REST API is no longer supported so the following have been removed:

`Discordrb::Profile.online`
`Discordrb::Profile.idle`
`Discordrb::Profile.dnd`
`Discordrb::Profile.invisible`

## Updated
Updated the way we process the bot token to reflect what you've done with the API client. (This allows use to remove the `process_token` method)