### PR TITLE
Bugfix - Discordrb::Message#reacted_with

### DIFF
--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -314,7 +314,7 @@ module Discordrb
 
       get_reactions = proc do |fetch_limit, after_id = nil|
         resp = API::Channel.get_reactions(@bot.token, @channel.id, @id, reaction, nil, after_id, fetch_limit)
-        return JSON.parse(resp).map { |d| User.new(d, @bot) }
+        JSON.parse(resp).map { |d| User.new(d, @bot) }
       end
 
       # Can be done without pagination


### PR DESCRIPTION
# Summary

I noticed this bug recently.
https://github.com/shardlab/discordrb/issues/60


Upon investigation, I realized that the issue stems from a misunderstanding of how `proc` works. Returning inside a `proc` causes it to return a value immediately, which prevents the loop from continuing. This appears to be a basic Ruby mistake.

After applying the fix, I ran the code locally and confirmed that it successfully retrieves users with more than 100 reactions.

Here is a simple sample to illustrate the issue.
```ruby

def proc_return_test

  proc_test = proc do |a|
    return a
  end

  val = proc_test.call(1)
  puts val
  0
end

def proc_next_test

  proc_test = proc do |a|
    next a
  end

  val = proc_test.call(1)
  puts val
  0
end


# 1
puts proc_return_test

# 1,0
puts proc_next_test


```


