### PR TITLE
Message Flags

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -129,6 +129,19 @@ module Discordrb::API::Channel
     )
   end
 
+  # Suppress embeds on a message
+  def suppress_embeds(token, channel_id, message_id)
+    Discordrb::API.request(
+      :channels_cid_messages_mid,
+      channel_id,
+      :patch,
+      "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}",
+      { flags: 1 << 2 }.to_json,
+      Authorization: token,
+      content_type: :json
+    )
+  end
+
   # Delete a message
   # https://discord.com/developers/docs/resources/channel#delete-message
   def delete_message(token, channel_id, message_id, reason = nil)

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -75,8 +75,8 @@ module Discordrb::API::Channel
   # https://discord.com/developers/docs/resources/channel#create-message
   # @param attachments [Array<File>, nil] Attachments to use with `attachment://` in embeds. See
   #   https://discord.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds
-  def create_message(token, channel_id, message, tts = false, embeds = nil, nonce = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil)
-    body = { content: message, tts: tts, embeds: embeds, nonce: nonce, allowed_mentions: allowed_mentions, message_reference: message_reference, components: components&.to_a }
+  def create_message(token, channel_id, message, tts = false, embeds = nil, nonce = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = nil)
+    body = { content: message, tts: tts, embeds: embeds, nonce: nonce, allowed_mentions: allowed_mentions, message_reference: message_reference, components: components&.to_a, flags: flags }
     body = if attachments
              files = [*0...attachments.size].zip(attachments).to_h
              { **files, payload_json: body.to_json }
@@ -117,26 +117,13 @@ module Discordrb::API::Channel
 
   # Edit a message
   # https://discord.com/developers/docs/resources/channel#edit-message
-  def edit_message(token, channel_id, message_id, message, mentions = [], embeds = nil, components = nil)
+  def edit_message(token, channel_id, message_id, message, mentions = [], embeds = nil, components = nil, flags = nil)
     Discordrb::API.request(
       :channels_cid_messages_mid,
       channel_id,
       :patch,
       "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}",
-      { content: message, mentions: mentions, embeds: embeds, components: components }.to_json,
-      Authorization: token,
-      content_type: :json
-    )
-  end
-
-  # Suppress embeds on a message
-  def suppress_embeds(token, channel_id, message_id)
-    Discordrb::API.request(
-      :channels_cid_messages_mid,
-      channel_id,
-      :patch,
-      "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}",
-      { flags: 1 << 2 }.to_json,
+      { content: message, mentions: mentions, embeds: embeds, components: components, flags: flags }.reject { |_, v| v == :undef }.to_json,
       Authorization: token,
       content_type: :json
     )

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1219,7 +1219,7 @@ module Discordrb
 
     def handle_dispatch(type, data)
       # Check whether there are still unavailable servers and there have been more than 10 seconds since READY
-      if @unavailable_servers&.positive? && (Time.now - @unavailable_timeout_time) > 10 && !((@intents || 0) & INTENTS[:servers]).zero?
+      if @unavailable_servers&.positive? && (Time.now - @unavailable_timeout_time) > 10 && !(@intents || 0).nobits?(INTENTS[:servers])
         # The server streaming timed out!
         LOGGER.debug("Server streaming timed out with #{@unavailable_servers} servers remaining")
         LOGGER.debug('Calling ready now because server loading is taking a long time. Servers may be unavailable due to an outage, or your bot is on very large servers.')

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -401,15 +401,16 @@ module Discordrb
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
     # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @param components [View, Array<Hash>] Interaction components to associate with this message.
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) and SUPPRESS_NOTIFICATIONS (1 << 12) can be set.
     # @return [Message] The message that was sent.
-    def send_message(channel, content, tts = false, embeds = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil)
+    def send_message(channel, content, tts = false, embeds = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = nil)
       channel = channel.resolve_id
       debug("Sending message to #{channel} with content '#{content}'")
       allowed_mentions = { parse: [] } if allowed_mentions == false
       message_reference = { message_id: message_reference.id } if message_reference.respond_to?(:id)
       embeds = (embeds.instance_of?(Array) ? embeds.map(&:to_hash) : [embeds&.to_hash]).compact
 
-      response = API::Channel.create_message(token, channel, content, tts, embeds, nil, attachments, allowed_mentions&.to_hash, message_reference, components)
+      response = API::Channel.create_message(token, channel, content, tts, embeds, nil, attachments, allowed_mentions&.to_hash, message_reference, components, flags)
       Message.new(JSON.parse(response), self)
     end
 
@@ -424,11 +425,12 @@ module Discordrb
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
     # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @param components [View, Array<Hash>] Interaction components to associate with this message.
-    def send_temporary_message(channel, content, timeout, tts = false, embeds = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil)
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) and SUPPRESS_NOTIFICATIONS (1 << 12) can be set.
+    def send_temporary_message(channel, content, timeout, tts = false, embeds = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = nil)
       Thread.new do
         Thread.current[:discordrb_name] = "#{@current_thread}-temp-msg"
 
-        message = send_message(channel, content, tts, embeds, attachments, allowed_mentions, message_reference, components)
+        message = send_message(channel, content, tts, embeds, attachments, allowed_mentions, message_reference, components, flags)
         sleep(timeout)
         message.delete
       end
@@ -1219,7 +1221,7 @@ module Discordrb
 
     def handle_dispatch(type, data)
       # Check whether there are still unavailable servers and there have been more than 10 seconds since READY
-      if @unavailable_servers&.positive? && (Time.now - @unavailable_timeout_time) > 10 && !(@intents || 0).nobits?(INTENTS[:servers])
+      if @unavailable_servers&.positive? && (Time.now - @unavailable_timeout_time) > 10 && !((@intents || 0) & INTENTS[:servers]).zero?
         # The server streaming timed out!
         LOGGER.debug("Server streaming timed out with #{@unavailable_servers} servers remaining")
         LOGGER.debug('Calling ready now because server loading is taking a long time. Servers may be unavailable due to an outage, or your bot is on very large servers.')

--- a/lib/discordrb/data/activity.rb
+++ b/lib/discordrb/data/activity.rb
@@ -121,7 +121,7 @@ module Discordrb
 
     # @!visibility private
     def flag_set?(sym)
-      !(@flags & FLAGS[sym]).zero?
+      !@flags.nobits?(FLAGS[sym])
     end
 
     # Timestamps for the start and end of instanced activities

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -428,9 +428,10 @@ module Discordrb
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
     # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @param components [View, Array<Hash>] Interaction components to associate with this message.
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) and SUPPRESS_NOTIFICATIONS (1 << 12) can be set.
     # @return [Message] the message that was sent.
-    def send_message(content, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil)
-      @bot.send_message(@id, content, tts, embed, attachments, allowed_mentions, message_reference, components)
+    def send_message(content, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = nil)
+      @bot.send_message(@id, content, tts, embed, attachments, allowed_mentions, message_reference, components, flags)
     end
 
     alias_method :send, :send_message
@@ -444,8 +445,9 @@ module Discordrb
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
     # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @param components [View, Array<Hash>] Interaction components to associate with this message.
-    def send_temporary_message(content, timeout, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil)
-      @bot.send_temporary_message(@id, content, timeout, tts, embed, attachments, allowed_mentions, message_reference, components)
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) and SUPPRESS_NOTIFICATIONS (1 << 12) can be set.
+    def send_temporary_message(content, timeout, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = nil)
+      @bot.send_temporary_message(@id, content, timeout, tts, embed, attachments, allowed_mentions, message_reference, components, flags)
     end
 
     # Convenience method to send a message with an embed.
@@ -461,16 +463,17 @@ module Discordrb
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
     # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @param components [View, Array<Hash>] Interaction components to associate with this message.
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) and SUPPRESS_NOTIFICATIONS (1 << 12) can be set.
     # @yield [embed] Yields the embed to allow for easy building inside a block.
     # @yieldparam embed [Discordrb::Webhooks::Embed] The embed from the parameters, or a new one.
     # @return [Message] The resulting message.
-    def send_embed(message = '', embed = nil, attachments = nil, tts = false, allowed_mentions = nil, message_reference = nil, components = nil)
+    def send_embed(message = '', embed = nil, attachments = nil, tts = false, allowed_mentions = nil, message_reference = nil, components = nil, flags = nil)
       embed ||= Discordrb::Webhooks::Embed.new
       view = Discordrb::Webhooks::View.new
 
       yield(embed, view) if block_given?
 
-      send_message(message, tts, embed, attachments, allowed_mentions, message_reference, components || view.to_a)
+      send_message(message, tts, embed, attachments, allowed_mentions, message_reference, components || view.to_a, flags)
     end
 
     # Sends multiple messages to a channel

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -190,8 +190,8 @@ module Discordrb
     end
 
     # (see Channel#send_message)
-    def respond(content, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil)
-      @channel.send_message(content, tts, embed, attachments, allowed_mentions, message_reference, components)
+    def respond(content, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = nil)
+      @channel.send_message(content, tts, embed, attachments, allowed_mentions, message_reference, components, flags)
     end
 
     # Edits this message to have the specified content instead.
@@ -199,12 +199,13 @@ module Discordrb
     # @param new_content [String] the new content the message should have.
     # @param new_embeds [Hash, Discordrb::Webhooks::Embed, Array<Hash>, Array<Discordrb::Webhooks::Embed>, nil] The new embeds the message should have. If `nil` the message will be changed to have no embeds.
     # @param new_components [View, Array<Hash>] The new components the message should have. If `nil` the message will be changed to have no components.
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) can be edited.
     # @return [Message] the resulting message.
-    def edit(new_content, new_embeds = nil, new_components = nil)
+    def edit(new_content, new_embeds = nil, new_components = nil, flags = nil)
       new_embeds = (new_embeds.instance_of?(Array) ? new_embeds.map(&:to_hash) : [new_embeds&.to_hash]).compact
       new_components = new_components.to_a
 
-      response = API::Channel.edit_message(@bot.token, @channel.id, @id, new_content, [], new_embeds, new_components)
+      response = API::Channel.edit_message(@bot.token, @channel.id, @id, new_content, [], new_embeds, new_components, flags)
       Message.new(JSON.parse(response), @bot)
     end
 
@@ -299,10 +300,9 @@ module Discordrb
     # Removes embeds from the message
     # @return [Message] the resulting message.
     def suppress_embeds
-      Message.new(
-        JSON.parse(API::Channel.suppress_embeds(@bot.token, @channel.id, @id)),
-        @bot
-      )
+      flags = @flags | 1 << 2
+      response = API::Channel.edit_message(@bot.token, @channel.id, @id, @content, [], :undef, :undef, flags)
+      Message.new(JSON.parse(response), @bot)
     end
 
     # Reacts to a message.

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -73,6 +73,9 @@ module Discordrb
     # @return [Array<Component>]
     attr_reader :components
 
+    # @return [Integer] flags set on the message
+    attr_reader :flags
+
     # @!visibility private
     def initialize(data, bot)
       @bot = bot
@@ -157,6 +160,7 @@ module Discordrb
 
       @components = []
       @components = data['components'].map { |component_data| Components.from_data(component_data, @bot) } if data['components']
+      @flags = data['flags'] || 0
     end
 
     # Replies to this message with the specified content.
@@ -290,6 +294,15 @@ module Discordrb
     # @return [Array<Reaction>] the reactions
     def my_reactions
       @reactions.select(&:me)
+    end
+
+    # Removes embeds from the message
+    # @return [Message] the resulting message.
+    def suppress_embeds
+      Message.new(
+        JSON.parse(API::Channel.suppress_embeds(@bot.token, @channel.id, @id)),
+        @bot
+      )
     end
 
     # Reacts to a message.

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -137,7 +137,7 @@ module Discordrb
       @bot.debug("Members for server #{@id} not chunked yet - initiating")
 
       # If the SERVER_MEMBERS intent flag isn't set, the gateway won't respond when we ask for members.
-      raise 'The :server_members intent is required to get server members' if (@bot.gateway.intents & INTENTS[:server_members]).zero?
+      raise 'The :server_members intent is required to get server members' if @bot.gateway.intents.nobits?(INTENTS[:server_members])
 
       @bot.request_chunks(@id)
       sleep 0.05 until @chunked

--- a/lib/discordrb/data/user.rb
+++ b/lib/discordrb/data/user.rb
@@ -91,7 +91,7 @@ module Discordrb
 
     FLAGS.each do |name, value|
       define_method("#{name}?") do
-        (@public_flags & value).positive?
+        @public_flags.anybits?(value)
       end
     end
   end

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -718,7 +718,7 @@ module Discordrb
 
         @session = Session.new(data['session_id'])
         @session.sequence = 0
-        @bot.__send__(:notify_ready) if @intents && (@intents & INTENTS[:servers]).zero?
+        @bot.__send__(:notify_ready) if @intents && @intents.nobits?(INTENTS[:servers])
       when :RESUMED
         # The RESUMED event is received after a successful op 6 (resume). It does nothing except tell the bot the
         # connection is initiated (like READY would). Starting with v5, it doesn't set a new heartbeat interval anymore

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -80,7 +80,7 @@ module Discordrb
     # Initialize the instance variables based on the bitset.
     def init_vars
       FLAGS.each do |position, flag|
-        flag_set = ((@bits >> position) & 0x1) == 1
+        flag_set = (@bits >> position).allbits?(0x1)
         instance_variable_set "@#{flag}", flag_set
       end
     end
@@ -131,7 +131,7 @@ module Discordrb
     #   permissions.defined_permissions #=> [:create_instant_invite, :administrator]
     # @return [Array<Symbol>] the permissions
     def defined_permissions
-      FLAGS.filter_map { |value, name| (@bits & (1 << value)).positive? ? name : nil }
+      FLAGS.filter_map { |value, name| @bits.anybits?((1 << value)) ? name : nil }
     end
 
     # Comparison based on permission bits

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -259,4 +259,24 @@ describe Discordrb::Message do
       message.respond(content, tts, embed, attachments, allowed_mentions, message_reference, components)
     end
   end
+
+  describe '#suppress_embeds' do
+    let(:message) { described_class.new(message_data, bot) }
+    let(:message_without_embeds) do
+      message_data.merge(
+        flags: 1 << 2,
+        embeds: []
+      )
+    end
+
+    it 'removes all the embeds' do
+      expect(Discordrb::API::Channel).to receive(:suppress_embeds)
+        .with(token, channel_id, message.id).and_return(message_without_embeds.to_json)
+
+      new_message = message.suppress_embeds
+
+      expect(new_message.embeds).to be_empty
+      expect(new_message.flags).to eq(1 << 2)
+    end
+  end
 end


### PR DESCRIPTION
# Summary
Adds support for setting message flags.

## Added
``Message#Suppress_embeds``
Flags parameter to message create methods.

## Changed
Makes ``API::Channel.edit_message`` use the ``filter_undef`` method found in 4.0. I did this because otherwise the components array would get removed as I don't believe there's any way to deserialize them back into JSON, along with the fact this method is already used in 3.0 for setting and removing timeouts.
