### PR TITLE
feature: channel pins update event

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1450,6 +1450,10 @@ module Discordrb
 
         event = ChannelRecipientRemoveEvent.new(data, self)
         raise_event(event)
+      when :CHANNEL_PINS_UPDATE
+        event = ChannelPinsUpdateEvent.new(data, self)
+        raise_event(event)
+
       when :GUILD_MEMBER_ADD
         add_guild_member(data)
 

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -635,6 +635,17 @@ module Discordrb
       register_event(ChannelSelectEvent, attributes, block)
     end
 
+    # This **event** is raised whenever a message is pinned or unpinned.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Integer, Channel] :channel A channel to match against.
+    # @option attributes [String, Integer, Server] :server A server to match against.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [ChannelPinsUpdateEvent] The event that was raised.
+    # @return [ChannelPinsUpdateEventHandler] The event handler that was registered.
+    def channel_pins_update(attributes = {}, &block)
+      register_event(ChannelPinsUpdateEvent, attributes, block)
+    end
+
     # This **event** is raised for every dispatch received over the gateway, whether supported by discordrb or not.
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String, Symbol, Regexp] :type Matches the event type of the dispatch.

--- a/lib/discordrb/events/channels.rb
+++ b/lib/discordrb/events/channels.rb
@@ -168,6 +168,39 @@ module Discordrb::Events
     end
   end
 
+  # Raised when a message is pinned or unpinned.
+  class ChannelPinsUpdateEvent < Event
+    # @return [Time, nil] Time at which the most recent pinned message was pinned.
+    attr_reader :last_pin_timestamp
+
+    # @return [Channel] The channel this event originates from.
+    attr_reader :channel
+
+    # @return [Server, nil] The server this event originates from.
+    attr_reader :server
+
+    def initialize(data, bot)
+      @bot = bot
+
+      @server = bot.server(data['guild_id']) if data['guild_id']
+      @channel = bot.channel(data['channel_id'])
+      @last_pin_timestamp = Time.iso8601(data['last_pin_timestamp']) if data['last_pin_timestamp']
+    end
+  end
+
+  # Event handler for ChannelPinsUpdateEvent.
+  class ChannelPinsUpdateEventHandler < EventHandler
+    def matches?(event)
+      # Check for the proper event type.
+      return false unless event.is_a? ChannelPinsUpdateEvent
+
+      [
+        matches_all(@attributes[:server], event.server) { |a, e| a.resolve_id == e&.id },
+        matches_all(@attributes[:channel], event.channel) { |a, e| a.resolve_id == e.id },
+      ].reduce(true, &:&)
+    end
+  end
+
   # Raised when a user is added to a private channel
   class ChannelRecipientAddEvent < ChannelRecipientEvent; end
 

--- a/lib/discordrb/events/channels.rb
+++ b/lib/discordrb/events/channels.rb
@@ -196,7 +196,7 @@ module Discordrb::Events
 
       [
         matches_all(@attributes[:server], event.server) { |a, e| a.resolve_id == e&.id },
-        matches_all(@attributes[:channel], event.channel) { |a, e| a.resolve_id == e.id },
+        matches_all(@attributes[:channel], event.channel) { |a, e| a.resolve_id == e.id }
       ].reduce(true, &:&)
     end
   end


### PR DESCRIPTION
# Summary

Adds support for receiving and listening for the channel pins update gateway event.

## Added
`Discordrb::EventContainer#channel_pins_update`
`ChannelPinsUpdateEvent`
`ChannelPinsUpdateEventHandler`
