### PR TITLE
feat: new components

### DIFF
--- a/examples/components.rb
+++ b/examples/components.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'discordrb'
+
+bot = Discordrb::Bot.new(token: ENV.fetch('BOT_TOKEN', nil), intents: [:servers])
+
+bot.register_application_command(:components, 'Components version two!', server_id: ENV.fetch('SERVER_ID', nil)) do |option|
+  option.boolean('color', 'Whether the container should include an accent color.', required: false)
+end
+
+bot.application_command(:components) do |event|
+  # Map the first 15 emojis from the server our command is
+  # called from into the formart of: "mention - name **{Integer}**".
+  emojis = event.server.emojis.values.take(15).map do |emoji|
+    "#{emoji.mention} — #{emoji.name} **(#{rand(1..500)})**\n"
+  end
+
+  # The `new_components` argument must be manually set to true
+  # to use V2 components. Doing so disables sending content and embeds.
+  event.respond(new_components: true) do |_, view|
+    # A new container is added to contain other components.
+    # We don't have to do this, since all components besides buttons
+    # and select menus can be used as top level components.
+    view.container(id: 100) do |container|
+      # A section must have either a thumbnail or a button. This is currently
+      # the only case where a button can be used without being in an action row.
+      container.section do |section|
+        section.thumbnail(media: event.server.icon_url)
+        section.text_display(text: "### Emoji Statistics for #{event.server.name}")
+        section.text_display(text: 'These are the current fake emoji stats for your server.')
+      end
+
+      # If set to true, the accent color is set to the user's highest
+      # role color, otherwise the container won't have an accent color.
+      container.color = event.user.color if event.options['color']
+
+      # A seperator can appear as a thin, translucent, grey
+      # line when setting the divider option to true. Otherwise
+      # the seperator can function as an invisible barrier to proivde
+      # spacing between other components.
+      container.seperator(divider: true, spacing: :small)
+
+      # A text display container is a container for text. Like with the content field,
+      # you can use markdown, emoji, allowed_mentions, etc.
+      container.text_display(text: emojis.empty? ? 'No Emojis!' : emojis.join)
+
+      # Try setting the spacing to `:large` to have a bigger gap between the other components.
+      container.seperator(divider: true, spacing: :small)
+
+      # We clear the existing emojis array and add a random emoji to the emojis array.
+      emojis.clear && 3.times { emojis << event.server.emojis.values.sample }
+
+      # We can add a select menu inside of our containter as shown here. Buttons
+      # can be added as well, although selects and buttons still have to be nested
+      # within an action row. but this can change in the future.
+      container.row do |row|
+        row.select_menu(custom_id: 'emojis', placeholder: 'Pick a statistic type...', min_values: 1) do |options|
+          options.option(label: 'Reaction', value: 'Reaction', description: 'View reaction statistics.', emoji: emojis.sample)
+          options.option(label: 'Message', value: 'Message', description: 'View message statistics.', emoji: emojis.sample)
+          options.option(label: 'Lowest', value: 'Lowest', description: 'View the boring emojis.', emoji: emojis.sample)
+        end
+      end
+    end
+  end
+end
+
+# This doesn't actually display any stats, but returns a placeholder message instead.
+bot.select_menu(custom_id: 'emojis') do |event|
+  case event.values.first
+  when 'Reaction', 'Message'
+    event.respond(content: "You're viewing stats for #{event.values.first}s!", ephemeral: true)
+  when 'Lowest'
+    event.respond(content: "You're viewing very boring stats!", ephemeral: true)
+  else
+    event.respond(content: 'What kind of stats...', ephemeral: true)
+  end
+end
+
+bot.run

--- a/lib/discordrb/api/interaction.rb
+++ b/lib/discordrb/api/interaction.rb
@@ -51,8 +51,8 @@ module Discordrb::API::Interaction
 
   # Edit the original response to an interaction.
   # https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
-  def edit_original_interaction_response(interaction_token, application_id, content = nil, embeds = nil, allowed_mentions = nil, components = nil, attachments = nil)
-    Discordrb::API::Webhook.token_edit_message(interaction_token, application_id, '@original', content, embeds, allowed_mentions, components, attachments)
+  def edit_original_interaction_response(interaction_token, application_id, content = nil, embeds = nil, allowed_mentions = nil, components = nil, attachments = nil, flags = nil)
+    Discordrb::API::Webhook.token_edit_message(interaction_token, application_id, '@original', content, embeds, allowed_mentions, components, attachments, flags)
   end
 
   # Delete the original response to an interaction.

--- a/lib/discordrb/api/webhook.rb
+++ b/lib/discordrb/api/webhook.rb
@@ -120,8 +120,8 @@ module Discordrb::API::Webhook
 
   # Edit a webhook message via webhook token
   # https://discord.com/developers/docs/resources/webhook#edit-webhook-message
-  def token_edit_message(webhook_token, webhook_id, message_id, content = nil, embeds = nil, allowed_mentions = nil, components = nil, attachments = nil)
-    body = { content: content, embeds: embeds, allowed_mentions: allowed_mentions, components: components }
+  def token_edit_message(webhook_token, webhook_id, message_id, content = nil, embeds = nil, allowed_mentions = nil, components = nil, attachments = nil, flags = nil)
+    body = { content: content, embeds: embeds, allowed_mentions: allowed_mentions, components: components, flags: flags }
 
     body = if attachments
              files = [*0...attachments.size].zip(attachments).to_h

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -428,7 +428,7 @@ module Discordrb
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
     # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @param components [View, Array<Hash>] Interaction components to associate with this message.
-    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) and SUPPRESS_NOTIFICATIONS (1 << 12) can be set.
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2), SUPPRESS_NOTIFICATIONS (1 << 12), and IS_COMPONENTS_V2 (1 << 15) can be set.
     # @return [Message] the message that was sent.
     def send_message(content, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = 0)
       @bot.send_message(@id, content, tts, embed, attachments, allowed_mentions, message_reference, components, flags)
@@ -445,7 +445,7 @@ module Discordrb
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
     # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @param components [View, Array<Hash>] Interaction components to associate with this message.
-    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) and SUPPRESS_NOTIFICATIONS (1 << 12) can be set.
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2), SUPPRESS_NOTIFICATIONS (1 << 12), and IS_COMPONENTS_V2 (1 << 15) can be set.
     def send_temporary_message(content, timeout, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = 0)
       @bot.send_temporary_message(@id, content, timeout, tts, embed, attachments, allowed_mentions, message_reference, components, flags)
     end
@@ -463,7 +463,7 @@ module Discordrb
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
     # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @param components [View, Array<Hash>] Interaction components to associate with this message.
-    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) and SUPPRESS_NOTIFICATIONS (1 << 12) can be set.
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2), SUPPRESS_NOTIFICATIONS (1 << 12), and IS_COMPONENTS_V2 (1 << 15) can be set.
     # @yield [embed] Yields the embed to allow for easy building inside a block.
     # @yieldparam embed [Discordrb::Webhooks::Embed] The embed from the parameters, or a new one.
     # @return [Message] The resulting message.

--- a/lib/discordrb/data/emoji.rb
+++ b/lib/discordrb/data/emoji.rb
@@ -68,6 +68,12 @@ module Discordrb
       "<Emoji name=#{name} id=#{id} animated=#{animated}>"
     end
 
+    # Converts this Emoji into a hash that can be sent back to Discord in other endpoints.
+    # @return [Hash] A hash representation of this emoji.
+    def to_h
+      id.nil? ? { name: name } : { id: id }
+    end
+
     # @!visibility private
     def process_roles(roles)
       @roles = []

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -90,11 +90,13 @@ module Discordrb
     # @param ephemeral [true, false] Whether this message should only be visible to the interaction initiator.
     # @param wait [true, false] Whether this method should return a Message object of the interaction response.
     # @param components [Array<#to_h>] An array of components.
-    # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`.
+    # @param attachments [Array<File>] Files that can be referenced in embeds and components via `attachment://file.png`.
+    # @param new_components [true, false] Whether this message includes any V2 components. Enabling this disables use content and embeds.
     # @yieldparam builder [Webhooks::Builder] An optional message builder. Arguments passed to the method overwrite builder data.
     # @yieldparam view [Webhooks::View] A builder for creating interaction components.
-    def respond(content: nil, tts: nil, embeds: nil, allowed_mentions: nil, flags: 0, ephemeral: nil, wait: false, components: nil, attachments: nil)
+    def respond(content: nil, tts: nil, embeds: nil, allowed_mentions: nil, flags: 0, ephemeral: nil, wait: false, components: nil, attachments: nil, new_components: false)
       flags |= 1 << 6 if ephemeral
+      flags |= (1 << 15) if new_components
 
       builder = Discordrb::Webhooks::Builder.new
       view = Discordrb::Webhooks::View.new
@@ -159,11 +161,13 @@ module Discordrb
     # @param ephemeral [true, false] Whether this message should only be visible to the interaction initiator.
     # @param wait [true, false] Whether this method should return a Message object of the interaction response.
     # @param components [Array<#to_h>] An array of components.
-    # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`.
+    # @param attachments [Array<File>] Files that can be referenced in embeds and components via `attachment://file.png`.
+    # @param new_components [true, false] Whether this message includes any V2 components. Enabling this disables use content and embeds.
     # @yieldparam builder [Webhooks::Builder] An optional message builder. Arguments passed to the method overwrite builder data.
     # @yieldparam view [Webhooks::View] A builder for creating interaction components.
-    def update_message(content: nil, tts: nil, embeds: nil, allowed_mentions: nil, flags: 0, ephemeral: nil, wait: false, components: nil, attachments: nil)
+    def update_message(content: nil, tts: nil, embeds: nil, allowed_mentions: nil, flags: 0, ephemeral: nil, wait: false, components: nil, attachments: nil, new_components: false)
       flags |= 1 << 6 if ephemeral
+      flags |= (1 << 15) if new_components
 
       builder = Discordrb::Webhooks::Builder.new
       view = Discordrb::Webhooks::View.new
@@ -186,11 +190,15 @@ module Discordrb
     # @param content [String] The content of the message.
     # @param embeds [Array<Hash, Webhooks::Embed>] The embeds for the message.
     # @param allowed_mentions [Hash, AllowedMentions] Mentions that can ping on this message.
+    # @param flags [Integer] Message flags.
     # @param components [Array<#to_h>] An array of components.
-    # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`.
+    # @param attachments [Array<File>] Files that can be referenced in embeds and components via `attachment://file.png`.
+    # @param new_components [true, false] Whether this message includes any V2 components. Enabling this disables use content and embeds.
     # @return [InteractionMessage] The updated response message.
     # @yieldparam builder [Webhooks::Builder] An optional message builder. Arguments passed to the method overwrite builder data.
-    def edit_response(content: nil, embeds: nil, allowed_mentions: nil, components: nil, attachments: nil)
+    def edit_response(content: nil, embeds: nil, allowed_mentions: nil, flags: 0, components: nil, attachments: nil, new_components: false)
+      flags |= (1 << 15) if new_components
+
       builder = Discordrb::Webhooks::Builder.new
       view = Discordrb::Webhooks::View.new
 
@@ -199,7 +207,7 @@ module Discordrb
 
       components ||= view
       data = builder.to_json_hash
-      resp = Discordrb::API::Interaction.edit_original_interaction_response(@token, @application_id, data[:content], data[:embeds], data[:allowed_mentions], components.to_a, attachments)
+      resp = Discordrb::API::Interaction.edit_original_interaction_response(@token, @application_id, data[:content], data[:embeds], data[:allowed_mentions], components.to_a, attachments, flags)
 
       Interactions::Message.new(JSON.parse(resp), @bot, @interaction)
     end
@@ -215,10 +223,12 @@ module Discordrb
     # @param allowed_mentions [Hash, AllowedMentions] Mentions that can ping on this message.
     # @param flags [Integer] Message flags.
     # @param ephemeral [true, false] Whether this message should only be visible to the interaction initiator.
-    # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`.
+    # @param attachments [Array<File>] Files that can be referenced in embeds and components via `attachment://file.png`.
+    # @param new_components [true, false] Whether this message includes any V2 components. Enabling this disables use content and embeds.
     # @yieldparam builder [Webhooks::Builder] An optional message builder. Arguments passed to the method overwrite builder data.
-    def send_message(content: nil, embeds: nil, tts: false, allowed_mentions: nil, flags: 0, ephemeral: false, components: nil, attachments: nil)
+    def send_message(content: nil, embeds: nil, tts: false, allowed_mentions: nil, flags: 0, ephemeral: false, components: nil, attachments: nil, new_components: false)
       flags |= 64 if ephemeral
+      flags |= (1 << 15) if new_components
 
       builder = Discordrb::Webhooks::Builder.new
       view = Discordrb::Webhooks::View.new

--- a/lib/discordrb/data/reaction.rb
+++ b/lib/discordrb/data/reaction.rb
@@ -29,5 +29,11 @@ module Discordrb
     def to_s
       id.nil? ? name : "#{name}:#{id}"
     end
+
+    # Converts this Reaction into a hash that can be sent back to Discord in other endpoints.
+    # @return [Hash] A hash representation of this reaction's emoji.
+    def to_h
+      id.nil? ? { name: name } : { id: id }
+    end
   end
 end

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -35,11 +35,11 @@ module Discordrb::Events
     end
 
     # (see Interaction#respond)
-    def respond(content: nil, tts: nil, embeds: nil, allowed_mentions: nil, flags: 0, ephemeral: nil, wait: false, components: nil, attachments: nil, &block)
+    def respond(content: nil, tts: nil, embeds: nil, allowed_mentions: nil, flags: 0, ephemeral: nil, wait: false, components: nil, attachments: nil, new_components: false, &block)
       @interaction.respond(
         content: content, tts: tts, embeds: embeds, allowed_mentions: allowed_mentions,
         flags: flags, ephemeral: ephemeral, wait: wait, components: components, attachments: attachments,
-        &block
+        new_components: new_components, &block
       )
     end
 
@@ -49,11 +49,11 @@ module Discordrb::Events
     end
 
     # (see Interaction#update_message)
-    def update_message(content: nil, tts: nil, embeds: nil, allowed_mentions: nil, flags: 0, ephemeral: nil, wait: false, components: nil, attachments: nil, &block)
+    def update_message(content: nil, tts: nil, embeds: nil, allowed_mentions: nil, flags: 0, ephemeral: nil, wait: false, components: nil, attachments: nil, new_components: false, &block)
       @interaction.update_message(
         content: content, tts: tts, embeds: embeds, allowed_mentions: allowed_mentions,
         flags: flags, ephemeral: ephemeral, wait: wait, components: components, attachments: attachments,
-        &block
+        new_components: new_components, &block
       )
     end
 
@@ -63,8 +63,11 @@ module Discordrb::Events
     end
 
     # (see Interaction#edit_response)
-    def edit_response(content: nil, embeds: nil, allowed_mentions: nil, components: nil, attachments: nil, &block)
-      @interaction.edit_response(content: content, embeds: embeds, allowed_mentions: allowed_mentions, components: components, attachments: attachments, &block)
+    def edit_response(content: nil, embeds: nil, allowed_mentions: nil, flags: 0, components: nil, attachments: nil, new_components: false, &block)
+      @interaction.edit_response(
+        content: content, embeds: embeds, allowed_mentions: allowed_mentions, components: components,
+        attachments: attachments, new_components: new_components, flags: flags, &block
+      )
     end
 
     # (see Interaction#delete_response)
@@ -73,8 +76,12 @@ module Discordrb::Events
     end
 
     # (see Interaction#send_message)
-    def send_message(content: nil, embeds: nil, tts: false, allowed_mentions: nil, flags: 0, ephemeral: nil, components: nil, attachments: nil, &block)
-      @interaction.send_message(content: content, embeds: embeds, tts: tts, allowed_mentions: allowed_mentions, flags: flags, ephemeral: ephemeral, components: components, attachments: attachments, &block)
+    def send_message(content: nil, embeds: nil, tts: false, allowed_mentions: nil, flags: 0, ephemeral: nil, components: nil, attachments: nil, new_components: false, &block)
+      @interaction.send_message(
+        content: content, embeds: embeds, tts: tts, allowed_mentions: allowed_mentions, flags: flags,
+        ephemeral: ephemeral, components: components, attachments: attachments,
+        new_components: new_components, &block
+      )
     end
 
     # (see Interaction#edit_message)

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -18,7 +18,7 @@ module Discordrb::Events
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
     # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @param components [View, Array<Hash>, nil] A collection of components to attach to the message.
-    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) and SUPPRESS_NOTIFICATIONS (1 << 12) can be set.
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2), SUPPRESS_NOTIFICATIONS (1 << 12), and IS_COMPONENTS_V2 (1 << 15) can be set.
     # @return [Discordrb::Message] the message that was sent
     def send_message(content, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = 0)
       channel.send_message(content, tts, embed, attachments, allowed_mentions, message_reference, components, flags)
@@ -33,7 +33,7 @@ module Discordrb::Events
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
     # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @param components [View, Array<Hash>, nil] A collection of components to attach to the message.
-    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) and SUPPRESS_NOTIFICATIONS (1 << 12) can be set.
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2), SUPPRESS_NOTIFICATIONS (1 << 12), and IS_COMPONENTS_V2 (1 << 15) can be set.
     # @yield [embed] Yields the embed to allow for easy building inside a block.
     # @yieldparam embed [Discordrb::Webhooks::Embed] The embed from the parameters, or a new one.
     # @return [Message] The resulting message.
@@ -49,7 +49,7 @@ module Discordrb::Events
     # @param attachments [Array<File>] Files that can be referenced in embeds via `attachment://file.png`
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
     # @param components [View, Array<Hash>, nil] A collection of components to attach to the message.
-    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) and SUPPRESS_NOTIFICATIONS (1 << 12) can be set.
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2), SUPPRESS_NOTIFICATIONS (1 << 12), and IS_COMPONENTS_V2 (1 << 15) can be set.
     def send_temporary_message(content, timeout, tts = false, embed = nil, attachments = nil, allowed_mentions = nil, components = nil, flags = 0)
       channel.send_temporary_message(content, timeout, tts, embed, attachments, allowed_mentions, components, flags)
     end

--- a/lib/discordrb/webhooks/modal.rb
+++ b/lib/discordrb/webhooks/modal.rb
@@ -9,7 +9,7 @@ class Discordrb::Webhooks::Modal
   }.freeze
 
   # This builder is used when constructing an ActionRow. All current components must be within an action row, but this can
-  # change in the future. A message can have 5 action rows, each action row can hold a weight of 5. Buttons have a weight of 1,
+  # change in the future. A message can have 10 action rows, each action row can hold a weight of 5. Buttons have a weight of 1,
   # and dropdowns have a weight of 5.
   class RowBuilder
     # A mapping of short names to types of input styles. `short` is a single line where `paragraph` is a block.

--- a/lib/discordrb/webhooks/view.rb
+++ b/lib/discordrb/webhooks/view.rb
@@ -21,11 +21,25 @@ class Discordrb::Webhooks::View
     user_select: 5,
     role_select: 6,
     mentionable_select: 7,
-    channel_select: 8
+    channel_select: 8,
+    section: 9,
+    text_display: 10,
+    thumbnail: 11,
+    media_gallery: 12,
+    file: 13,
+    seperator: 14,
+    container: 17
   }.freeze
 
-  # This builder is used when constructing an ActionRow. All current components must be within an action row, but this can
-  # change in the future. A message can have 5 action rows, each action row can hold a weight of 5. Buttons have a weight of 1,
+  # Possible size values for seperators.
+  # @see https://discord.com/developers/docs/interactions/message-components#seperator-sizes
+  SEPERATOR_SIZES = {
+    small: 1,
+    large: 2
+  }.freeze
+
+  # This builder is used when constructing an ActionRow. Button and select menu components must be within an action row, but this can
+  # change in the future. A message can have 10 action rows, each action row can hold a weight of 5. Buttons have a weight of 1,
   # and dropdowns have a weight of 5.
   class RowBuilder
     # @!visibility private
@@ -169,10 +183,325 @@ class Discordrb::Webhooks::View
     end
   end
 
-  attr_reader :rows
+  # A text display component allows you to send text.
+  class TextDisplayBuilder
+    # Set the integer ID of this component.
+    # @return [Integer, nil] integer ID of this component.
+    attr_accessor :id
+
+    # Set the content of this component.
+    # @return [String] Content of this component.
+    attr_accessor :text
+
+    # @!visibility hidden
+    def initialize(text = nil, id = nil)
+      @text = text
+      @id = id
+    end
+
+    # @!visibility private
+    def to_h
+      { type: COMPONENT_TYPES[:text_display], content: @text, id: @id }.compact
+    end
+  end
+
+  # A seperator allows you to seperate components.
+  class SeperatorBuilder
+    # Set the integer ID of this component.
+    # @return [Integer, nil] integer ID of this component.
+    attr_accessor :id
+
+    # Whether this seperator is a divider.
+    # @return [true, false] If this seperator is a divider.
+    attr_accessor :divider
+
+    # @!visibility hidden
+    def initialize(divider = nil, spacing = nil, id = nil)
+      @spacing = SEPERATOR_SIZES[spacing] || spacing
+      @divider = divider
+      @id = id
+    end
+
+    # Set the spacing of this builder.
+    # @param space [Symbol, Integer] The space of the component. See {SEPERATOR_SIZES}.
+    def spacing=(space)
+      @spacing = SEPERATOR_SIZES[space] || space
+    end
+
+    # @!visibility hidden
+    def to_h
+      { type: COMPONENT_TYPES[:seperator],
+        divider: @divider,
+        spacing: @spacing,
+        id: @id }.compact
+    end
+  end
+
+  # A file component lets you send a file. Only attachment://<filename> references
+  # are currently supported at the time of writing.
+  class FileBuilder
+    # If this file should be spoilered.
+    # @return [true, false, nil] If this file is a spoiler or not.
+    attr_accessor :spoiler
+
+    # Set the integer ID of this component.
+    # @return [Integer, nil] integer ID of this component.
+    attr_accessor :id
+
+    # @!visibility hidden
+    def initialize(file = nil, spoiler = nil, id = nil)
+      @id = id
+      @file = { url: file }
+      @spoiler = spoiler
+    end
+
+    # Set the file URL of this component.
+    # @param file [String] attachment://<filename> reference.
+    def file=(file)
+      @file[:url] = file
+    end
+
+    # @!visibility hidden
+    def to_h
+      { type: COMPONENT_TYPES[:file],
+        id: @id,
+        spoiler: @spoiler,
+        file: @file }.compact
+    end
+  end
+
+  # A media gallery container lets you group files into a gallery or a grid.
+  class MediaGalleryBuilder
+    # Set the integer ID of this component.
+    # @return [Integer, nil] integer ID of this component.
+    attr_accessor :id
+
+    # Set the items of this component.
+    # @return [Array<Hash>] Media gallery items serialized as a hash.
+    attr_accessor :items
+
+    # @!visibility hidden
+    def initialize(items = [], id = nil)
+      @id = id
+      @items = items
+    end
+
+    # Add a gallery item to this media gallery collection.
+    # @param media [String] The URL of this media item.
+    # @param description [String, nil] An optional description of this media item.
+    # @param spoiler [true, false, nil] Whether this argument should be spoilered. Defaults to false.
+    def gallery_item(media:, description: nil, spoiler: nil)
+      @items << { media: { url: media }, description: description, spoiler: spoiler }.compact
+    end
+
+    alias_method :item, :gallery_item
+
+    # @!visibility hidden
+    def to_h
+      { type: COMPONENT_TYPES[:media_gallery], items: @items }
+    end
+  end
+
+  # A section allows you to group together text display components,
+  # and optionally pair it with a button or a thumbnail. More components
+  # may be supported in the future.
+  class SectionBuilder
+    # Set the integer ID of this component.
+    # @return [Integer, nil] integer ID of this component.
+    attr_accessor :id
+
+    # @!visibility hidden
+    def initialize(components = [], accessory = nil, id = nil)
+      @components = components
+      @accessory = accessory
+      @id = id
+    end
+
+    # Add a text display component to this section.
+    # @param text [String] Content of the component.
+    def text_display(text:, id: nil)
+      @components << { type: COMPONENT_TYPES[:text_display], content: text, id: id }.compact
+    end
+
+    # Set the accessory to a thumbnail for this media gallery collection.
+    # @param media [String] The URL of the media item for this thumbnail.
+    # @param description [String, nil] An optional description of this media item.
+    # @param spoiler [true, false, nil] Whether this argument should be spoilered. Defaults to false.
+    def thumbnail(media:, description: nil, spoiler: nil)
+      @accessory = { type: COMPONENT_TYPES[:thumbnail], media: { url: media }, description: description, spoiler: spoiler }.compact
+    end
+
+    # Set the accessory to a button for this media gallery collection.
+    # @param style [Symbol, Integer] The button's style type. See {BUTTON_STYLES}
+    # @param label [String, nil] The text label for the button. Either a label or emoji must be provided.
+    # @param emoji [#to_h, String, Integer] An emoji ID, or unicode emoji to attach to the button. Can also be a object
+    # that responds to `#to_h` which returns a hash in the format of `{ id: Integer, name: string }`.
+    # @param custom_id [String] Custom IDs are used to pass state to the events that are raised from interactions.
+    # There is a limit of 100 characters to each custom_id.
+    # @param disabled [true, false] Whether this button is disabled and shown as greyed out.
+    # @param url [String, nil] The URL, when using a link style button.
+    def button(style:, label: nil, emoji: nil, custom_id: nil, disabled: nil, url: nil)
+      style = BUTTON_STYLES[style] || style
+
+      emoji = case emoji
+              when Integer, String
+                emoji.to_i.positive? ? { id: emoji } : { name: emoji }
+              else
+                emoji&.to_h
+              end
+
+      @accessory = { type: COMPONENT_TYPES[:button], label: label, emoji: emoji, style: style, custom_id: custom_id, disabled: disabled, url: url }
+    end
+
+    # @!visibility hidden
+    def to_h
+      { type: COMPONENT_TYPES[:section], components: @components, accessory: @accessory }.compact
+    end
+  end
+
+  # This builder can be used to construct a container. A container can hold several other types of components
+  # including other action rows. A container can currently have a maximum of 10 components inside of it.
+  class ContainerBuilder
+    # Set the integer ID of this component.
+    # @return [Integer, nil] integer ID of this component.
+    attr_accessor :id
+
+    # @return [Integer, nil] the colour of the bar to the side, in decimal form.
+    attr_reader :colour
+    alias_method :color, :colour
+
+    # If this container be spoilered.
+    # @return [true, false, nil] If this container is a spoiler or not.
+    attr_accessor :spoiler
+
+    # @!visibility hidden
+    def initialize(id = nil, components = [], colour = nil, spoiler = nil)
+      @components = components
+      @spoiler = spoiler
+      @id = id
+
+      process_color(colour)
+    end
+
+    # Sets the colour of the bar to the side of the embed to something new.
+    # @param value [String, Integer, {Integer, Integer, Integer}, #to_i, nil] The colour in decimal,
+    # hexadecimal, R/G/B decimal, or nil if the container should have no color.
+    def colour=(value)
+      process_color(value)
+    end
+
+    alias_method :color=, :colour=
+
+    # Add a text display component to this container.
+    # @param id [Integer, nil] Integer ID of this component.
+    # @param text [String] Set the text display of this component.
+    # @yieldparam builder [TextDisplayBuilder] The text display object is yielded to allow for modification of attributes.
+    def text_display(id: nil, text: nil)
+      builder = TextDisplayBuilder.new(text, id)
+
+      yield builder if block_given?
+
+      @components << builder
+    end
+
+    # Add a section to this container.
+    # @param id [Integer, nil] Integer ID of this section component.
+    # @param components [Array<Components>] Optional array of text display components.
+    # @param accessory [Hash, nil] Optional thumbnail or button accessory to include.
+    # @yieldparam builder [SectionBuilder] The section object is yielded to allow for modification of attributes.
+    def section(id: nil, components: [], accessory: nil)
+      builder = SectionBuilder.new(components, accessory, id)
+
+      yield builder if block_given?
+
+      @components << builder
+    end
+
+    # Add a media gallery to this container.
+    # @param id [Integer, nil] Integer ID of this media gallery component.
+    # @param items [Array<Hash>] Array of media gallery components to include.
+    # @yieldparam builder [MediaGalleryBuilder] The media gallery object is yielded to allow for modification of attributes.
+    def media_gallery(id: nil, items: [])
+      builder = MediaGalleryBuilder.new(items, id)
+
+      yield builder if block_given?
+
+      @components << builder
+    end
+
+    # Add a seperator to this container.
+    # @param id [Integer, nil] Integer ID of this seperator component.
+    # @param divider [true, false] Whether this seperator is a divider. Defaults to true.
+    # @param spacing [Integer, nil] The amount of spacing for this seperator component.
+    # @yieldparam builder [SeperatorBuilder] The seperator object is yielded to allow for modification of attributes.
+    def seperator(id: nil, divider: true, spacing: nil)
+      builder = SeperatorBuilder.new(divider, spacing, id)
+
+      yield builder if block_given?
+
+      @components << builder
+    end
+
+    # Add a file to this container.
+    # @param id [Integer, nil] Integer ID of this file component.
+    # @param file [String, nil] An attachment://<filename> reference.
+    # @param spoiler [true, false] If this file should be spoilered. Defaults to false.
+    # @yieldparam builder [FileBuilder] The file object is yielded to allow for modification of attributes.
+    def file(id: nil, file: nil, spoiler: false)
+      builder = FileBuilder.new(file, spoiler, id)
+
+      yield builder if block_given?
+
+      @components << builder
+    end
+
+    # Add an action row to this container, this allows for some interesting nesting.
+    # @yieldparam builder [RowBuilder] The row builder object is yielded to allow for addition of components.
+    def row
+      builder = RowBuilder.new
+
+      yield builder if block_given?
+
+      @components << builder
+    end
+
+    # @!visibility hidden
+    def to_h
+      { type: COMPONENT_TYPES[:container],
+        accent_color: @colour,
+        spoiler: @spoiler,
+        components: @components.map(&:to_h) }.compact
+    end
+
+    private
+
+    # @!visibility private
+    # @note for internal use only
+    # Process the color into an integer value.
+    def process_color(value)
+      if value.nil?
+        @colour = nil
+      elsif value.is_a? Integer
+        raise ArgumentError, 'Embed colour must be 24-bit!' if value >= 16_777_216
+
+        @colour = value
+      elsif value.is_a? String
+        self.colour = value.delete('#').to_i(16)
+      elsif value.is_a? Array
+        raise ArgumentError, 'Colour tuple must have three values!' if value.length != 3
+
+        self.colour = (value[0] << 16) | (value[1] << 8) | value[2]
+      else
+        self.colour = value.to_i
+      end
+    end
+  end
+
+  # @!visibility hidden
+  attr_reader :components
 
   def initialize
-    @rows = []
+    @components = []
 
     yield self if block_given?
   end
@@ -184,11 +513,96 @@ class Discordrb::Webhooks::View
 
     yield new_row
 
-    @rows << new_row
+    @components << new_row
+  end
+
+  # Add a text display component to this container.
+  # @param id [Integer, nil] Integer ID of this component.
+  # @param text [String] Set the text display of this component.
+  # @yieldparam builder [TextDisplayBuilder] The text display object is yielded to allow for modification of attributes.
+  def text_display(id: nil, text: nil)
+    builder = TextDisplayBuilder.new(text, id)
+
+    yield builder if block_given?
+
+    @components << builder
+  end
+
+  # Add a section to this container.
+  # @param id [Integer, nil] Integer ID of this section component.
+  # @param components [Array<Components>] Optional array of text display components.
+  # @param accessory [Hash, nil] Optional thumbnail or button accessory to include.
+  # @yieldparam builder [SectionBuilder] The section object is yielded to allow for modification of attributes.
+  def section(id: nil, components: [], accessory: nil)
+    builder = SectionBuilder.new(components, accessory, id)
+
+    yield builder if block_given?
+
+    @components << builder
+  end
+
+  # Add a media gallery to this container.
+  # @param id [Integer, nil] Integer ID of this media gallery component.
+  # @param items [Array<Hash>] Array of media gallery components to include.
+  # @yieldparam builder [MediaGalleryBuilder] The media gallery object is yielded to allow for modification of attributes.
+  def media_gallery(id: nil, items: [])
+    builder = MediaGalleryBuilder.new(items, id)
+
+    yield builder if block_given?
+
+    @components << builder
+  end
+
+  # Add a seperator to this container.
+  # @param id [Integer, nil] Integer ID of this seperator component.
+  # @param divider [true, false] Whether this seperator is a divider. Defaults to true.
+  # @param spacing [Integer, nil] The amount of spacing for this seperator component.
+  # @yieldparam builder [SeperatorBuilder] The seperator object is yielded to allow for modification of attributes.
+  def seperator(id: nil, divider: true, spacing: nil)
+    builder = SeperatorBuilder.new(divider, spacing, id)
+
+    yield builder if block_given?
+
+    @components << builder
+  end
+
+  # Add a file to this container.
+  # @param id [Integer, nil] Integer ID of this file component.
+  # @param file [String, nil] An attachment://<filename> reference.
+  # @param spoiler [true, false] If this file should be spoilered. Defaults to false.
+  # @yieldparam builder [FileBuilder] The file object is yielded to allow for modification of attributes.
+  def file(id: nil, file: nil, spoiler: false)
+    builder = FileBuilder.new(file, spoiler, id)
+
+    yield builder if block_given?
+
+    @components << builder
+  end
+
+  # Add a container component.
+  # @param id [Integer, nil] Integer ID of this container component.
+  # @param components [Array<Hash>] Container components to include.
+  # @param colour [String, Integer, {Integer, Integer, Integer}, #to_i, nil] The colour in decimal,
+  # hexadecimal, R/G/B decimal, or nil if the container should have no color.
+  # @param spoiler [true, false] Whether this container should be spoilered. Defaults to false.
+  # @yieldparam builder [ContainerBuilder] The container object is yielded to allow for modification of attributes.
+  def container(id: nil, components: [], colour: nil, spoiler: false)
+    builder = ContainerBuilder.new(id, components, colour, spoiler)
+
+    yield builder if block_given?
+
+    @components << builder
+  end
+
+  # @!visibility hidden
+  # @return [Array<RowBuilder>]
+  def rows
+    @components.select { |component| component.is_a?(RowBuilder) }
   end
 
   # @!visibility private
+  # @return [Array<Hash>]
   def to_a
-    @rows.map(&:to_h)
+    @components.map(&:to_h)
   end
 end


### PR DESCRIPTION
## Summary

This is my attempt at adding support for the new components that Discord plans to release in the distant future. This introduces the ability to have components besides action rows as top-level components, as well as the ability to nest action rows within other top-level components. Some potential points to discuss:

- The example admittedly isn't the best. I'm open to doing something different than what I've current added.
- `new_components` admittedly isn't the best name for setting the `IS_COMPONENTS_V2 (1 << 15)` flag.

## Added

- Builders for new components:
`Webhooks::View::TextDisplayBuilder`
`Webhooks::View::SeperatorBuilder`
`Webhooks::View::FileBuilder`
`Webhooks::View::MediaGalleryBuilder`
`Webhooks::View::SectionBuilder`
`Webhooks::View::ContainerBuilder`

- Top-level methods for new components:
`Webhooks::View#text_display`
`Webhooks::View#seperator`
`Webhooks::View#file`
`Webhooks::View#media_gallery`
`Webhooks::View#section`
`Webhooks::View#container`

- Data classes for serializing new components:
`Webhooks::View::Components::TextDisplay`
`Webhooks::View::Components::Seperator`
`Webhooks::View::Components::File`
`Webhooks::View::Components::MediaGallery`
`Webhooks::View::Components::Section`
`Webhooks::View::Components::Container`

`new_components` KWARG for interaction methods which sets the `IS_COMPONENTS_V2 (1 << 15)` flag.

## Changed

There are a couple of internal changes made to `Webhooks::View` in order to make the new components possible. (Don't worry, I've managed to maintain full backwards compatibility!)

Removal of `@rows`. Since action rows are no longer the only top-level components, it didn't make sense to have two separate instance variables since it would end up requiring some needless concatenation. E.g.

```ruby
[@rows.map(&:to_h), *@components.map(&:to_h)].reject(&:empty)
```

In its place, I've replaced it with `@components` as a way to store all top-level components. This required the removal of the `attr_reader :rows` as well. It was replaced with:

```ruby
def rows
  @components.select { |component| component.is_a?(RowBuilder) }
end
```

## Fixed

Previously, when passing in an emoji object to `RowBuilder#button` and `SelectMenuBuilder#option`, it would yield the following error:

```ruby
Exception: #<NoMethodError: undefined method `to_h' for an instance of Discordrb::Emoji>
```

As stated in the error, this is because `#to_h` wasn't defined anywhere for the emoji object. I've went ahead and defined this method.
