### PR TITLE
GitHub Workflows & Rubocop

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -47,7 +47,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -60,6 +60,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rake
 

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -109,7 +109,7 @@ module Discordrb::Commands
         spaces_allowed: attributes[:spaces_allowed].nil? ? false : attributes[:spaces_allowed],
 
         # Webhooks allowed to trigger commands
-        webhook_commands: attributes[:webhook_commands].nil? ? true : attributes[:webhook_commands],
+        webhook_commands: attributes[:webhook_commands].nil? || attributes[:webhook_commands],
 
         channels: attributes[:channels] || [],
 
@@ -257,17 +257,9 @@ module Discordrb::Commands
         next arg if types[i].nil? || types[i] == String
 
         if types[i] == Integer
-          begin
-            Integer(arg, 10)
-          rescue ArgumentError
-            nil
-          end
+          Integer(arg, 10, exception: false)
         elsif types[i] == Float
-          begin
-            Float(arg)
-          rescue ArgumentError
-            nil
-          end
+          Float(arg, exception: false)
         elsif types[i] == Time
           begin
             Time.parse arg
@@ -295,11 +287,7 @@ module Discordrb::Commands
             nil
           end
         elsif types[i] == Rational
-          begin
-            Rational(arg)
-          rescue ArgumentError
-            nil
-          end
+          Rational(arg, exception: false)
         elsif types[i] == Range
           begin
             if arg.include? '...'

--- a/lib/discordrb/commands/parser.rb
+++ b/lib/discordrb/commands/parser.rb
@@ -32,10 +32,10 @@ module Discordrb::Commands
         channels: attributes[:channels] || nil,
 
         # Whether this command is usable in a command chain
-        chain_usable: attributes[:chain_usable].nil? ? true : attributes[:chain_usable],
+        chain_usable: attributes[:chain_usable].nil? || attributes[:chain_usable],
 
         # Whether this command should show up in the help command
-        help_available: attributes[:help_available].nil? ? true : attributes[:help_available],
+        help_available: attributes[:help_available].nil? || attributes[:help_available],
 
         # Description (for help command)
         description: attributes[:description] || nil,

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -944,8 +944,10 @@ module Discordrb
 
     private
 
+    # rubocop:disable Lint/UselessConstantScoping
     # For bulk_delete checking
     TWO_WEEKS = 86_400 * 14
+    # rubocop:enable Lint/UselessConstantScoping
 
     # Deletes a list of messages on this channel using bulk delete.
     def bulk_delete(ids, strict = false, reason = nil)

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -656,7 +656,9 @@ module Discordrb
       LOGGER.log_exception(e)
     end
 
+    # rubocop:disable Lint/UselessConstantScoping
     ZLIB_SUFFIX = "\x00\x00\xFF\xFF".b.freeze
+    # rubocop:enable Lint/UselessConstantScoping
 
     def handle_message(msg)
       case @compress_mode
@@ -794,7 +796,9 @@ module Discordrb
     # - 4004: Authentication failed. Token was wrong, nothing we can do.
     # - 4011: Sharding required. Currently requires developer intervention.
     # - 4014: Use of disabled privileged intents.
+    # rubocop:disable Lint/UselessConstantScoping
     FATAL_CLOSE_CODES = [4003, 4004, 4011, 4014].freeze
+    # rubocop:enable Lint/UselessConstantScoping
 
     def handle_close(e)
       @bot.__send__(:raise_event, Events::DisconnectEvent.new(@bot))


### PR DESCRIPTION
# Summary

- Rubocop seems to have introduced a new plugins system.
- The current Github workflows are running on a [deprecated version](https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/).

### Rubocop

Rubocop seems to have migrated over to a new [plugin system](https://docs.rubocop.org/rubocop/plugin_migration_guide.html).

- All this seems to require on our end is changed the `require:` key to `plugins:` in the yaml file.

`Lint/SuppressedExceptionInNumberConversion`
- I'm guessing this should mainly be a safe change to make. Setting `exception: false` seems to behave identically to suppressing the exception with a begin-rescue block.