### PR TITLE
Ruby 3.1 EOL & Workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,17 +27,6 @@ commands:
             - ./vendor/bundle
 
 jobs:
-  test_ruby_31:
-    docker:
-      - image: ruby:3.1-alpine
-    steps:
-      - setup-env
-      - run:
-          name: Run RSpec
-          command: bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml
-      - store_test_results:
-          path: ~/rspec
-
   test_ruby_32:
     docker:
       - image: ruby:3.2-alpine
@@ -49,10 +38,21 @@ jobs:
       - store_test_results:
           path: ~/rspec
 
-
   test_ruby_33:
     docker:
       - image: ruby:3.3-alpine
+    steps:
+      - setup-env
+      - run:
+          name: Run RSpec
+          command: bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml
+      - store_test_results:
+          path: ~/rspec
+
+
+  test_ruby_34:
+    docker:
+      - image: ruby:3.4-alpine
     steps:
       - setup-env
       - run:
@@ -125,9 +125,9 @@ jobs:
 workflows:
   test:
     jobs:
-      - test_ruby_31
       - test_ruby_32
       - test_ruby_33
+      - test_ruby_34
       - rubocop
       - yard
   deploy:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -47,7 +47,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -60,6 +60,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rake
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you enjoy using the library, consider getting involved with the community to 
 
 ## Dependencies
 
-* Ruby >= 3.1 supported
+* Ruby >= 3.2 supported
 * An installed build system for native extensions (on Windows, make sure you download the "Ruby+Devkit" version of [RubyInstaller](https://rubyinstaller.org/downloads/))
 
 ### Voice dependencies

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'discordrb-webhooks', '~> 3.5.0'
 
-  spec.required_ruby_version = '>= 3.1'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
## Summary

Since my previous attempt will most likely be superceded by another PR... 

Per [Ruby maintenance schedule](https://www.ruby-lang.org/en/downloads/branches/) version 3.1 is at its end of life, and should not be used. 

I've also bumped the version the Github workflows run on, since the version we're running is [deprecated](https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/).

Rubocop also requires minor change, since they have shifted over to a [plugin system](https://docs.rubocop.org/rubocop/plugin_migration_guide.html). If you attempt to run rubocop while developing DRB, the following warning is yielded:

```ruby
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in /root/project/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rake extension supports plugin, specify `plugins: rubocop-rake` instead of `require: rubocop-rake` in /root/project/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```