### PR TITLE
bugfixes: emoji parsing & removing timeouts

### DIFF
--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -173,6 +173,21 @@ module Discordrb::API::Server
     )
   end
 
+  # Update the current member's properties.
+  # https://discord.com/developers/docs/resources/guild#modify-current-member
+  def update_current_member(token, server_id, nick = :undef, reason = nil)
+    Discordrb::API.request(
+      :guilds_sid_members_me,
+      server_id,
+      :patch,
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/members/@me",
+      { nick: nick }.reject { |_, v| v == :undef }.to_json,
+      Authorization: token,
+      content_type: :json,
+      'X-Audit-Log-Reason': reason
+    )
+  end
+
   # Remove user from server
   # https://discord.com/developers/docs/resources/guild#remove-guild-member
   def remove_member(token, server_id, user_id, reason = nil)

--- a/lib/discordrb/api/user.rb
+++ b/lib/discordrb/api/user.rb
@@ -28,14 +28,14 @@ module Discordrb::API::User
     )
   end
 
-  # Change the current bot's nickname on a server
-  # https://discord.com/developers/docs/resources/user#modify-current-user
+  # @deprecated Please use {Discordrb::API::Server.modify_current_member} instead.
+  # https://discord.com/developers/docs/resources/user#modify-current-user-nick
   def change_own_nickname(token, server_id, nick, reason = nil)
     Discordrb::API.request(
       :guilds_sid_members_me_nick,
       server_id, # This is technically a guild endpoint
       :patch,
-      "#{Discordrb::API.api_base}/guilds/#{server_id}/members/@me",
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/members/@me/nick",
       { nick: nick }.to_json,
       Authorization: token,
       content_type: :json,

--- a/lib/discordrb/api/user.rb
+++ b/lib/discordrb/api/user.rb
@@ -28,7 +28,7 @@ module Discordrb::API::User
     )
   end
 
-  # @deprecated Please use {Discordrb::API::Server.modify_current_member} instead.
+  # @deprecated Please use {Discordrb::API::Server.update_current_member} instead.
   # https://discord.com/developers/docs/resources/user#modify-current-user-nick
   def change_own_nickname(token, server_id, nick, reason = nil)
     Discordrb::API.request(

--- a/lib/discordrb/api/user.rb
+++ b/lib/discordrb/api/user.rb
@@ -35,7 +35,7 @@ module Discordrb::API::User
       :guilds_sid_members_me_nick,
       server_id, # This is technically a guild endpoint
       :patch,
-      "#{Discordrb::API.api_base}/guilds/#{server_id}/members/@me/nick",
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/members/@me",
       { nick: nick }.to_json,
       Authorization: token,
       content_type: :json,

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -527,7 +527,7 @@ module Discordrb
             end
           end
         elsif /(?<animated>^a|^${0}):(?<name>\w+):(?<id>\d+)/ =~ mention
-          array_to_return << (emoji(id) || Emoji.new({ 'animated' => !animated.nil?, 'name' => name, 'id' => id }, self, nil))
+          array_to_return << (emoji(id) || Emoji.new({ 'animated' => animated != '', 'name' => name, 'id' => id }, self, nil))
         end
       end
       array_to_return

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -136,7 +136,7 @@ module Discordrb
     def communication_disabled_until=(timeout_until)
       raise ArgumentError, 'A time out cannot exceed 28 days' if timeout_until && timeout_until > (Time.now + 2_419_200)
 
-      API::Server.update_member(@bot.token, @server_id, @user.id, communication_disabled_until: timeout_until.iso8601)
+      API::Server.update_member(@bot.token, @server_id, @user.id, communication_disabled_until: timeout_until&.iso8601)
     end
 
     alias_method :timeout=, :communication_disabled_until=

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -276,12 +276,9 @@ module Discordrb
     # Nicknames for other users.
     # @param nick [String, nil] The string to set the nickname to, or nil if it should be reset.
     # @param reason [String] The reason the user's nickname is being changed.
-    def set_nick(nick, reason = nil)
-      # Discord uses the empty string to signify 'no nickname' so we convert nil into that
-      nick ||= ''
-
+    def set_nick(nick, reason = nil)      
       if @user.current_bot?
-        API::User.change_own_nickname(@bot.token, @server_id, nick, reason)
+        API::Server.update_current_member(@bot.token, @server_id, nick, reason)
       else
         API::Server.update_member(@bot.token, @server_id, @user.id, nick: nick, reason: reason)
       end

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -283,7 +283,7 @@ module Discordrb
       if @user.current_bot?
         API::User.change_own_nickname(@bot.token, @server_id, nick, reason)
       else
-        API::Server.update_member(@bot.token, @server_id, @user.id, nick: nick, reason: nil)
+        API::Server.update_member(@bot.token, @server_id, @user.id, nick: nick, reason: reason)
       end
     end
 

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -588,12 +588,12 @@ module Discordrb
     # Searches a server for members that matches a username or a nickname.
     # @param name [String] The username or nickname to search for.
     # @param limit [Integer] The maximum number of members between 1-1000 to return. Returns 1 member by default.
-    # @return [Array<Member>, nil] An array of member objects that match the given parameters.
+    # @return [Array<Member>, nil] An array of member objects that match the given parameters, or nil for no members.
     def search_members(name:, limit: nil)
-      response = API::Server.search_guild_members(@bot.token, @id, name, limit)
+      response = JSON.parse(API::Server.search_guild_members(@bot.token, @id, name, limit))
       return nil if response.empty?
- 
-      JSON.parse(response).map { |member| Member.new(member, self, @bot) }
+
+      response.map { |mem| Member.new(mem, self, @bot) }
     end
 
     # Retrieve banned users from this server.

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -588,9 +588,11 @@ module Discordrb
     # Searches a server for members that matches a username or a nickname.
     # @param name [String] The username or nickname to search for.
     # @param limit [Integer] The maximum number of members between 1-1000 to return. Returns 1 member by default.
-    # @return [Array<Member>] An array of member objects that match the given parameters.
+    # @return [Array<Member>, nil] An array of member objects that match the given parameters.
     def search_members(name:, limit: nil)
       response = API::Server.search_guild_members(@bot.token, @id, name, limit)
+      return nil if response.empty?
+ 
       JSON.parse(response).map { |member| Member.new(member, self, @bot) }
     end
 

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -590,10 +590,8 @@ module Discordrb
     # @param limit [Integer] The maximum number of members between 1-1000 to return. Returns 1 member by default.
     # @return [Array<Member>] An array of member objects that match the given parameters.
     def search_members(name:, limit: nil)
-      response = JSON.parse(API::Server.search_guild_members(@bot.token, @id, name, limit))
-      return nil if response.empty?
-
-      response.map { |mem| Member.new(mem, self, @bot) }
+      response = API::Server.search_guild_members(@bot.token, @id, name, limit)
+      JSON.parse(response).map { |member| Member.new(member, self, @bot) }
     end
 
     # Retrieve banned users from this server.


### PR DESCRIPTION
## Summary
In the past couple of months, I've noticed a few small bugs related to parsing emojis, removing timeouts so I thought I'd take a crack at fixing them.

## Fixed

### Emoji Parsing
When parsing an emoji that isn't accessible via `Bot#emoji`, we previously attempted to do this:

```ruby
{ 'animated' => !animated.nil? }
```

Which won't work properly, because animated will always be some kind of string never nil, as pointed out by @Dakurei [here on Discord](https://discord.com/channels/81384788765712384/381891448884428801/1276916192849956927).

--- 
### Change Bot's Nickname
When trying to change the bot's own nickname we use the `guilds/#{server_id}/members/@me/nick` endpoint. We should probably swap to `guilds/#{server_id}/members/@me`, since the latter is what Discord seems to prefer, shown by the [deprecation warning](https://discord.com/developers/docs/resources/guild#modify-current-user-nick).

Additionally, the library previously converted `nil` to an empty string to signify the removal of a nickname. It seems like Discord has finally update the API calls to support sending `nil` since the `nick` parameter is marked as being nullable.

---
### Removing Timeouts
Previously when trying to remove a member's timeout by passing in nil, it would yield the following error:

```ruby
undefined method `iso8601' for nil
```

This is because `time` was always assumed to be a time object. We can solve this pretty easily by chucking in a  safe nav `&` before calling `#iso8601`.

---
### Wrong Return for `#search_members`
This last one was caused by me a few months ago 💀

```ruby
def search_members(name:, limit: nil)
  response = JSON.parse(API::Server.search_guild_members(@bot.token, @id, name, limit))
  return nil if response.empty?

  response.map { |mem| Member.new(mem, self, @bot) }
end
 ```
 
We probably shouldn't return `nil` here, since it's kinda inconsistent with how the lib handles other endpoints that return an array of data. I also didn't document `nil` as a valid return type for this method, so I made it simply return the empty array instead.