### PR TITLE
Ruby Webhooks EOL Version Bump

### DIFF
--- a/discordrb-webhooks.gemspec
+++ b/discordrb-webhooks.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client', '>= 2.0.0'
 
-  spec.required_ruby_version = '>= 3.1'
+  spec.required_ruby_version = '>= 3.2'
   spec.metadata = {
     'rubygems_mfa_required' => 'true'
   }


### PR DESCRIPTION
## Summary

I forgot to bump the minimum ruby version for the webhooks client 

## Changed

Minimum ruby version for the webhook client.

`3.1` --> `3.2`