### PR TITLE
feat: resume gateway URL

### DIFF
--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -93,7 +93,7 @@ module Discordrb
     # @return [String] Used to uniquely identify this session. Mostly used when resuming connections.
     attr_reader :session_id
 
-    # @return [Integer] Incrementing integer used to detemrine the most recent event reccived from Discord.
+    # @return [Integer] Incrementing integer used to determine the most recent event reccived from Discord.
     attr_accessor :sequence
 
     # @return [String] Gateway URL used to reconnect to the gateway node that Discord wants this session to use.

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -97,7 +97,7 @@ module Discordrb
     attr_accessor :sequence
 
     # @return [String] Gateway URL used to reconnect to the gateway node that Discord wants this session to use.
-    attr_reader :resume_gateway_url
+    attr_accessor :resume_gateway_url
 
     # @!visibility private
     def initialize(session_id, resume_gateway_url)
@@ -267,6 +267,7 @@ module Discordrb
 
           # We can't send anything on zombie connections
           @pipe_broken = true
+          @session&.resume_gateway_url = nil
           reconnect
           return
         end

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -97,7 +97,7 @@ module Discordrb
     attr_accessor :sequence
 
     # @return [String] Gateway URL used to reconnect to the gateway node that Discord wants this session to use.
-    attr_accessor :resume_gateway_url
+    attr_reader :resume_gateway_url
 
     # @!visibility private
     def initialize(session_id, resume_gateway_url)
@@ -267,7 +267,6 @@ module Discordrb
 
           # We can't send anything on zombie connections
           @pipe_broken = true
-          @session&.resume_gateway_url = nil
           reconnect
           return
         end

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -90,14 +90,22 @@ module Discordrb
   # This class stores the data of an active gateway session. Note that this is different from a websocket connection -
   # there may be multiple sessions per connection or one session may persist over multiple connections.
   class Session
+    # @return [String] Used to uniquely identify this session. Mostly used when resuming connections.
     attr_reader :session_id
+
+    # @return [Integer] Incrementing integer used to detemrine the most recent event reccived from Discord.
     attr_accessor :sequence
 
-    def initialize(session_id)
+    # @return [String] Gateway URL used to reconnect to the gateway node that Discord wants this session to use.
+    attr_reader :resume_gateway_url
+
+    # @!visibility private
+    def initialize(session_id, resume_gateway_url)
       @session_id = session_id
       @sequence = 0
       @suspended = false
       @invalid = false
+      @resume_gateway_url = resume_gateway_url
     end
 
     # Flags this session as suspended, so we know not to try and send heartbeats, etc. to the gateway until we've reconnected
@@ -117,6 +125,7 @@ module Discordrb
     # Flags this session as being invalid
     def invalidate
       @invalid = true
+      @resume_gateway_url = nil
     end
 
     def invalid?
@@ -538,7 +547,7 @@ module Discordrb
     end
 
     def process_gateway
-      raw_url = find_gateway
+      raw_url = @session&.resume_gateway_url || find_gateway
 
       # Append a slash in case it's not there (I'm not sure how well WSCS handles it otherwise)
       raw_url += '/' unless raw_url.end_with? '/'
@@ -656,7 +665,9 @@ module Discordrb
       LOGGER.log_exception(e)
     end
 
+    # rubocop:disable Lint/UselessConstantScoping
     ZLIB_SUFFIX = "\x00\x00\xFF\xFF".b.freeze
+    # rubocop:enable Lint/UselessConstantScoping
 
     def handle_message(msg)
       case @compress_mode
@@ -716,7 +727,7 @@ module Discordrb
       when :READY
         LOGGER.info("Discord using gateway protocol version: #{data['v']}, requested: #{GATEWAY_VERSION}")
 
-        @session = Session.new(data['session_id'])
+        @session = Session.new(data['session_id'], data['resume_gateway_url'])
         @session.sequence = 0
         @bot.__send__(:notify_ready) if @intents && @intents.nobits?(INTENTS[:servers])
       when :RESUMED
@@ -794,7 +805,9 @@ module Discordrb
     # - 4004: Authentication failed. Token was wrong, nothing we can do.
     # - 4011: Sharding required. Currently requires developer intervention.
     # - 4014: Use of disabled privileged intents.
+    # rubocop:disable Lint/UselessConstantScoping
     FATAL_CLOSE_CODES = [4003, 4004, 4011, 4014].freeze
+    # rubocop:enable Lint/UselessConstantScoping
 
     def handle_close(e)
       @bot.__send__(:raise_event, Events::DisconnectEvent.new(@bot))


### PR DESCRIPTION
## Summary
This PR adds support for targeted switching, aka using the `resume_gateway_url` when resuming a gateway connection.

## Added
- `resume_gateway_url` argument to the initializer of `Session`.
-   Added the following line to `Session#invalidate`: `@resume_gateway_url = nil`

## Changed
- Make `Gateway#process_gateway` attempt to use the resume URL first, and then fall back to querying the Gateway URL via REST. E.g.

```ruby
 raw_url = @session&.resume_gateway_url || find_gateway
```

- I hope its alright that I added a bit of documentation for a few of the fields on the `Session` object