### PR TITLE
fix: don't send heartbeats unless we're connected

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1101,12 +1101,15 @@ module Discordrb
       server_id = data['guild_id'].to_i
       server = self.server(server_id)
 
-      member = server.member(data['user']['id'].to_i)
-      member.update_roles(data['roles'])
-      member.update_nick(data['nick'])
-      member.update_global_name(data['user']['global_name']) if data['user']['global_name']
-      member.update_boosting_since(data['premium_since'])
-      member.update_communication_disabled_until(data['communication_disabled_until'])
+      if (member = server.member(data['user']['id'].to_i))
+        member.update_roles(data['roles'])
+        member.update_nick(data['nick'])
+        member.update_global_name(data['user']['global_name']) if data['user']['global_name']
+        member.update_boosting_since(data['premium_since'])
+        member.update_communication_disabled_until(data['communication_disabled_until'])
+      else
+        Discordrb::LOGGER.warn("update_guild_member attempted to access a member which doesn't exist! Not sure what happened here, ignoring.")
+      end
     end
 
     # Internal handler for GUILD_MEMBER_DELETE
@@ -1241,6 +1244,8 @@ module Discordrb
         init_cache
 
         @profile = Profile.new(data['user'], self)
+
+        @client_id ||= data['application']['id']&.to_i
 
         # Initialize servers
         @servers = {}

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -109,7 +109,7 @@ module Discordrb::Commands
         spaces_allowed: attributes[:spaces_allowed].nil? ? false : attributes[:spaces_allowed],
 
         # Webhooks allowed to trigger commands
-        webhook_commands: attributes[:webhook_commands].nil? ? true : attributes[:webhook_commands],
+        webhook_commands: attributes[:webhook_commands].nil? || attributes[:webhook_commands],
 
         channels: attributes[:channels] || [],
 
@@ -153,7 +153,9 @@ module Discordrb::Commands
             command = command.aliased_command
             command_name = command.name
           end
+          # rubocop:disable Lint/ReturnInVoidContext
           return "The command `#{command_name}` does not exist!" unless command
+          # rubocop:enable Lint/ReturnInVoidContext
 
           desc = command.attributes[:description] || '*No description available*'
           usage = command.attributes[:usage]
@@ -257,17 +259,9 @@ module Discordrb::Commands
         next arg if types[i].nil? || types[i] == String
 
         if types[i] == Integer
-          begin
-            Integer(arg, 10)
-          rescue ArgumentError
-            nil
-          end
+          Integer(arg, 10, exception: false)
         elsif types[i] == Float
-          begin
-            Float(arg)
-          rescue ArgumentError
-            nil
-          end
+          Float(arg, exception: false)
         elsif types[i] == Time
           begin
             Time.parse arg
@@ -295,11 +289,7 @@ module Discordrb::Commands
             nil
           end
         elsif types[i] == Rational
-          begin
-            Rational(arg)
-          rescue ArgumentError
-            nil
-          end
+          Rational(arg, exception: false)
         elsif types[i] == Range
           begin
             if arg.include? '...'

--- a/lib/discordrb/commands/parser.rb
+++ b/lib/discordrb/commands/parser.rb
@@ -32,10 +32,10 @@ module Discordrb::Commands
         channels: attributes[:channels] || nil,
 
         # Whether this command is usable in a command chain
-        chain_usable: attributes[:chain_usable].nil? ? true : attributes[:chain_usable],
+        chain_usable: attributes[:chain_usable].nil? || attributes[:chain_usable],
 
         # Whether this command should show up in the help command
-        help_available: attributes[:help_available].nil? ? true : attributes[:help_available],
+        help_available: attributes[:help_available].nil? || attributes[:help_available],
 
         # Description (for help command)
         description: attributes[:description] || nil,

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -944,8 +944,10 @@ module Discordrb
 
     private
 
+    # rubocop:disable Lint/UselessConstantScoping
     # For bulk_delete checking
     TWO_WEEKS = 86_400 * 14
+    # rubocop:enable Lint/UselessConstantScoping
 
     # Deletes a list of messages on this channel using bulk delete.
     def bulk_delete(ids, strict = false, reason = nil)

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -457,7 +457,7 @@ module Discordrb
               @bot.raise_heartbeat_event
               heartbeat
             else
-              LOGGER.debug("Tried to send a heartbeat without being connected! Ignoring, we should be fine.")
+              LOGGER.debug('Tried to send a heartbeat without being connected! Ignoring, we should be fine.')
             end
           else
             sleep 1
@@ -661,7 +661,9 @@ module Discordrb
       LOGGER.log_exception(e)
     end
 
+    # rubocop:disable Lint/UselessConstantScoping 
     ZLIB_SUFFIX = "\x00\x00\xFF\xFF".b.freeze
+    # rubocop:enable Lint/UselessConstantScoping 
 
     def handle_message(msg)
       case @compress_mode
@@ -794,12 +796,14 @@ module Discordrb
       handle_close(e)
     end
 
+    # rubocop:disable Lint/UselessConstantScoping 
     # Close codes that are unrecoverable, after which we should not try to reconnect.
     # - 4003: Not authenticated. How did this happen?
     # - 4004: Authentication failed. Token was wrong, nothing we can do.
     # - 4011: Sharding required. Currently requires developer intervention.
     # - 4014: Use of disabled privileged intents.
     FATAL_CLOSE_CODES = [4003, 4004, 4011, 4014].freeze
+    # rubocop:enable Lint/UselessConstantScoping 
 
     def handle_close(e)
       @bot.__send__(:raise_event, Events::DisconnectEvent.new(@bot))

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -661,9 +661,9 @@ module Discordrb
       LOGGER.log_exception(e)
     end
 
-    # rubocop:disable Lint/UselessConstantScoping 
+    # rubocop:disable Lint/UselessConstantScoping
     ZLIB_SUFFIX = "\x00\x00\xFF\xFF".b.freeze
-    # rubocop:enable Lint/UselessConstantScoping 
+    # rubocop:enable Lint/UselessConstantScoping
 
     def handle_message(msg)
       case @compress_mode
@@ -796,14 +796,14 @@ module Discordrb
       handle_close(e)
     end
 
-    # rubocop:disable Lint/UselessConstantScoping 
+    # rubocop:disable Lint/UselessConstantScoping
     # Close codes that are unrecoverable, after which we should not try to reconnect.
     # - 4003: Not authenticated. How did this happen?
     # - 4004: Authentication failed. Token was wrong, nothing we can do.
     # - 4011: Sharding required. Currently requires developer intervention.
     # - 4014: Use of disabled privileged intents.
     FATAL_CLOSE_CODES = [4003, 4004, 4011, 4014].freeze
-    # rubocop:enable Lint/UselessConstantScoping 
+    # rubocop:enable Lint/UselessConstantScoping
 
     def handle_close(e)
       @bot.__send__(:raise_event, Events::DisconnectEvent.new(@bot))

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -452,8 +452,13 @@ module Discordrb
           # suspended (e.g. after op7)
           if (@session && !@session.suspended?) || !@session
             sleep @heartbeat_interval
-            @bot.raise_heartbeat_event
-            heartbeat
+            # Check if we're connected here, since we could possibly be waiting for a reconnect to occur.
+            if @handshaked && !@closed
+              @bot.raise_heartbeat_event
+              heartbeat
+            else
+              LOGGER.debug("Tried to send a heartbeat without being connected! Ignoring, we should be fine.")
+            end
           else
             sleep 1
           end


### PR DESCRIPTION
## Summary

This PR mainly fixes an issue where we send heartbeats without an active connection, resulting in big errors like these:

```shell
2025-05-08T21:31:53.028593137Z app[bot.1]: [ERROR : heartbeat @ 2025-05-08 21:31:53.028] An error occurred while heartbeating!
2025-05-08T21:31:53.028636171Z app[bot.1]: [ERROR : heartbeat @ 2025-05-08 21:31:53.028] Exception: #<RuntimeError: Tried to send something to the websocket while not being connected!>
2025-05-08T21:31:53.028640642Z app[bot.1]: [ERROR : heartbeat @ 2025-05-08 21:31:53.028] /app/vendor/bundle/ruby/3.4.0/bundler/gems/discordrb-557caa06b2cd/lib/discordrb/gateway.rb:831:in 'Discordrb::Gateway#send'
2025-05-08T21:31:53.028643695Z app[bot.1]: [ERROR : heartbeat @ 2025-05-08 21:31:53.028] /app/vendor/bundle/ruby/3.4.0/bundler/gems/discordrb-557caa06b2cd/lib/discordrb/gateway.rb:426:in 'Discordrb::Gateway#send_packet'
2025-05-08T21:31:53.028646558Z app[bot.1]: [ERROR : heartbeat @ 2025-05-08 21:31:53.028] /app/vendor/bundle/ruby/3.4.0/bundler/gems/discordrb-557caa06b2cd/lib/discordrb/gateway.rb:275:in 'Discordrb::Gateway#send_heartbeat'
2025-05-08T21:31:53.028649429Z app[bot.1]: [ERROR : heartbeat @ 2025-05-08 21:31:53.028] /app/vendor/bundle/ruby/3.4.0/bundler/gems/discordrb-557caa06b2cd/lib/discordrb/gateway.rb:268:in 'Discordrb::Gateway#heartbeat'
2025-05-08T21:31:53.028652560Z app[bot.1]: [ERROR : heartbeat @ 2025-05-08 21:31:53.028] /app/vendor/bundle/ruby/3.4.0/bundler/gems/discordrb-557caa06b2cd/lib/discordrb/gateway.rb:456:in 'block (2 levels) in Discordrb::Gateway#setup_heartbeats'
2025-05-08T21:31:53.028655749Z app[bot.1]: [ERROR : heartbeat @ 2025-05-08 21:31:53.028] <internal:kernel>:168:in 'Kernel#loop'
2025-05-08T21:31:53.028658691Z app[bot.1]: [ERROR : heartbeat @ 2025-05-08 21:31:53.028] /app/vendor/bundle/ruby/3.4.0/bundler/gems/discordrb-557caa06b2cd/lib/discordrb/gateway.rb:450:in 'block in Discordrb::Gateway#setup_heartbeats'
```

## Added

Incidentally while going through the Gateway documentation, I noticed the [`:READY`](https://discord.com/developers/docs/events/gateway-events#ready) event provides the application_id, which we can set in the bot.

## Fixed

Sending heartbeats without an active connection this was already getting caught by the `rescue` clause in the heartbeat loop, but the backtraces would still get flushed to the console.

Sometimes in `#update_guild_member` the member object fails to resolve and is null? I can't tell exactly when this happens, nor am I able to re-produce the problem reliably enough to say what the cause is besides this image of the stack-trace:

![IMG_7737](https://github.com/user-attachments/assets/2cee108e-9ee4-4d2f-9dde-eea12e71830e)