### PR TITLE
fix: allow raw and application command event handlers to co-exist

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1571,13 +1571,13 @@ module Discordrb
         when Interaction::TYPES[:command]
           event = ApplicationCommandEvent.new(data, self)
 
-          Thread.new do
-            Thread.current[:discordrb_name] = "it-#{event.interaction.id}"
+          Thread.new(event) do |evt|
+            Thread.current[:discordrb_name] = "it-#{evt.interaction.id}"
 
             begin
-              debug("Executing application command #{event.command_name}:#{event.command_id}")
+              debug("Executing application command #{evt.command_name}:#{evt.command_id}")
 
-              @application_commands[event.command_name]&.call(event)
+              @application_commands[evt.command_name]&.call(evt)
             rescue StandardError => e
               log_exception(e)
             end
@@ -1661,10 +1661,8 @@ module Discordrb
       # The existence of this array is checked before for performance reasons, since this has to be done for *every*
       # dispatch.
       if @event_handlers && @event_handlers[RawEvent]
-        # Don't assign a seperate variable named event here, because application
-        # command handlers run in a seperate thread, and by the time the thread
-        # start running, event has been re-assigned here, and the thread will error out.  
-        raise_event(RawEvent.new(type, data, self))
+        event = RawEvent.new(type, data, self)
+        raise_event(event)
       end
     rescue Exception => e
       LOGGER.error('Gateway message error!')
@@ -1694,15 +1692,15 @@ module Discordrb
     end
 
     def call_event(handler, event)
-      t = Thread.new do
+      t = Thread.new(event) do |evt|
         @event_threads ||= []
         @current_thread ||= 0
 
         @event_threads << t
         Thread.current[:discordrb_name] = "et-#{@current_thread += 1}"
         begin
-          handler.call(event)
-          handler.after_call(event)
+          handler.call(evt)
+          handler.after_call(evt)
         rescue StandardError => e
           log_exception(e)
         ensure

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1564,15 +1564,17 @@ module Discordrb
 
         case data['type']
         when Interaction::TYPES[:command]
-          event = ApplicationCommandEvent.new(data, self)
+          # We have to use a seperate variable name besides `event` here, since if we have a handler
+          # for a raw event, `event` would get re-assigned by the time the thread starts runnning.
+          cmd_event = ApplicationCommandEvent.new(data, self)
 
           Thread.new do
-            Thread.current[:discordrb_name] = "it-#{event.interaction.id}"
+            Thread.current[:discordrb_name] = "it-#{cmd_event.interaction.id}"
 
             begin
-              debug("Executing application command #{event.command_name}:#{event.command_id}")
+              debug("Executing application command #{cmd_event.command_name}:#{cmd_event.command_id}")
 
-              @application_commands[event.command_name]&.call(event)
+              @application_commands[cmd_event.command_name]&.call(cmd_event)
             rescue StandardError => e
               log_exception(e)
             end


### PR DESCRIPTION
## Summary
This PR fixes an issue where registering application command event handlers and a raw event handler would cause errors like these:

```ruby
#<Thread:0x0000000145776960 /opt/homebrew/lib/ruby/gems/3.4.0/bundler/gems/discordrb-74d6415c6e15/lib/discordrb/bot.rb:1574 run> terminated with exception (report_on_exception is true):
/opt/homebrew/lib/ruby/gems/3.4.0/bundler/gems/discordrb-74d6415c6e15/lib/discordrb/bot.rb:1575:in 'block in Discordrb::Bot#handle_dispatch': undefined method 'interaction' for an instance of Discordrb::Events::RawEvent (NoMethodError)

            Thread.current[:discordrb_name] = "it-#{event.interaction.id}"
``` 

## Fixed

Now please hear me out, but the fix to this was actually changing the name of `event` to `cmd_event`.

Application commands execute asynchronously within a thread, which means Ruby doesn't need to wait for anything in that thread to finish running and it can continue running the main program, which in our case, would be checking for a `RawEvent`:

```ruby
if @event_handlers && @event_handlers[RawEvent]
  event = RawEvent.new(type, data, self) # This reassignment here is the issue
  raise_event(event)
end
```

But, threads may not always start running as soon as they are created, i.e. the VM lock might prevent the thread from immediately running (or it could just be that PCs are very fast). Since `event` gets re-assigned right away to `RawEvent` if a handler is registered for `RawEvent`, the `event` is now a `RawEvent`, and by the time the application command thread starts executing, `event` has been re-assigned.

The simplest solution is to use a separate variable name, in order to prevent the problem of `event (ApplicationCommandEvent)` getting re-assigned to `event (RawEvent)`