### PR TITLE
fix: broken members on MESSAGE_CREATE due to recent changes

### DIFF
--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -427,10 +427,12 @@ module Discordrb
         @boosting_since = data['premium_since'] ? Time.parse(data['premium_since']) : nil
       end
 
-      @user.update_global_name(data['user']['global_name']) if data['user']['global_name']
-      @user.avatar_id = data['user']['avatar'] if data['user'].key('avatar')
-      @user.update_avatar_decoration(data['user']['avatar_decoration_data']) if data['user'].key?('avatar_decoration_data')
-      @user.update_collectibles(data['user']['collectibles']) if data['user'].key?('collectibles')
+      if (user = data['user'])
+        @user.update_global_name(user['global_name']) if user['global_name']
+        @user.avatar_id = user['avatar'] if user.key('avatar')
+        @user.update_avatar_decoration(user['avatar_decoration_data']) if user.key?('avatar_decoration_data')
+        @user.update_collectibles(user['collectibles']) if user.key?('collectibles')
+      end
 
       @server_avatar_decoration = process_avatar_decoration(data['avatar_decoration_data']) if data.key?('avatar_decoration_data')
     end


### PR DESCRIPTION
# Summary

Recently, we moved all of the logic for updating users from `GUILD_MEMBER_UPDATE` events into `Member#update_data`. Unfortunately, members on `MESSAGE_CREATE` events don't include a nested user, which causes things to immediately error out.

## Fixed

User serialization on `Member#update_data`