### PR TITLE
fix: return raw error codes

### DIFF
--- a/lib/discordrb/errors.rb
+++ b/lib/discordrb/errors.rb
@@ -99,7 +99,7 @@ module Discordrb
     # @param code [Integer] The code to check
     # @return [Class] the error class for the given code
     def self.error_class_for(code)
-      @code_classes[code] || UnknownError
+      @code_classes[code] || Code(code)
     end
 
     # Used when Discord doesn't provide a more specific code


### PR DESCRIPTION
# Summary

Discord's API can return error codes through a code key in the JSON error. This list of error codes is pretty big and ever expanding, so I think it's okay for us to just return the raw error code if we don't have a mapping for it already