### PR TITLE
feat: move to aead_xchacha20_poly1305_rtpsize voice encoding

### DIFF
--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -84,7 +84,7 @@ module Discordrb::Voice
       # Header of the audio packet
       header = generate_header(sequence, time)
 
-      nonce = generate_nonce(header)
+      nonce = generate_nonce
       buf = encrypt_audio(buf, header, nonce)
       data = header + buf + nonce.byteslice(0, 4)
 
@@ -120,8 +120,6 @@ module Discordrb::Voice
     # @param nonce [String] The nonce to be used to encrypt the data
     # @return [String] the audio data, encrypted
     def encrypt_audio(buf, header, nonce)
-            # return header + box.encrypt(bytes(data), bytes(header), bytes(nonce)).ciphertext + nonce[:4]
-
       raise 'No secret key found, despite encryption being enabled!' unless @secret_key
 
       case @mode
@@ -136,9 +134,8 @@ module Discordrb::Voice
       @socket.send(packet, 0, @ip, @port)
     end
 
-    # @param header [String] The header of the packet, to be used as the nonce
     # @return [String]
-    def generate_nonce(header)
+    def generate_nonce
       case @mode
       when 'aead_xchacha20_poly1305_rtpsize'
         case @incremental_nonce

--- a/lib/discordrb/voice/sodium.rb
+++ b/lib/discordrb/voice/sodium.rb
@@ -43,10 +43,10 @@ module Discordrb::Voice
     # @param npub [FFI::Pointer] nonce pointer
     # @param k [FFI::Pointer] key pointer
     # @return [Integer] 0 on success
-    attach_function :crypto_aead_xchacha20poly1305_ietf_encrypt, [
-      :pointer, :pointer, :pointer, :ulong_long,
-      :pointer, :ulong_long,
-      :pointer, :pointer, :pointer
+    attach_function :crypto_aead_xchacha20poly1305_ietf_encrypt, %i[
+      pointer pointer pointer ulong_long
+      pointer ulong_long
+      pointer pointer pointer
     ], :int
 
     # Decrypts XChaCha20-Poly1305 AEAD-encrypted data
@@ -61,9 +61,9 @@ module Discordrb::Voice
     # @param npub [FFI::Pointer] nonce pointer
     # @param k [FFI::Pointer] key pointer
     # @return [Integer] 0 on success
-    attach_function :crypto_aead_xchacha20poly1305_ietf_decrypt, [
-      :pointer, :pointer, :pointer, :pointer, :ulong_long,
-      :pointer, :ulong_long, :pointer, :pointer
+    attach_function :crypto_aead_xchacha20poly1305_ietf_decrypt, %i[
+      pointer pointer pointer pointer ulong_long
+      pointer ulong_long pointer pointer
     ], :int
 
     # @!endgroup
@@ -94,14 +94,14 @@ module Discordrb::Voice
     # @param message [String] plaintext to encrypt
     # @param key [String] 32-byte encryption key
     # @param nonce [String] 24-byte nonce
-    # @param ad [String] optional associated data
+    # @param add [String] optional associated data
     # @return [String] ciphertext (includes the auth tag)
-    def self.encrypt(message, ad, nonce, key)
-      raise ArgumentError, "Invalid key size" unless key.bytesize == KEY_BYTES
-      raise ArgumentError, "Invalid nonce size" unless nonce.bytesize == NONCE_BYTES
+    def self.encrypt(message, add, nonce, key)
+      raise ArgumentError, 'Invalid key size' unless key.bytesize == KEY_BYTES
+      raise ArgumentError, 'Invalid nonce size' unless nonce.bytesize == NONCE_BYTES
 
       message_ptr = FFI::MemoryPointer.from_string(message)
-      ad_ptr = FFI::MemoryPointer.from_string(ad)
+      ad_ptr = FFI::MemoryPointer.from_string(add)
 
       c_len = message.bytesize + TAG_BYTES
       ciphertext = FFI::MemoryPointer.new(:uchar, c_len)
@@ -116,7 +116,7 @@ module Discordrb::Voice
         FFI::MemoryPointer.from_string(key)
       )
 
-      raise "Encryption failed" unless result.zero?
+      raise 'Encryption failed' unless result.zero?
 
       ciphertext.read_string(clen_p.read_ulong_long)
     end
@@ -126,14 +126,14 @@ module Discordrb::Voice
     # @param ciphertext [String] the encrypted data (with tag)
     # @param key [String] 32-byte decryption key
     # @param nonce [String] 24-byte nonce
-    # @param ad [String] optional associated data
+    # @param add [String] optional associated data
     # @return [String] decrypted plaintext
-    def self.decrypt(ciphertext, nonce, ad, key)
-      raise ArgumentError, "Invalid key size" unless key.bytesize == KEY_BYTES
-      raise ArgumentError, "Invalid nonce size" unless nonce.bytesize == NONCE_BYTES
+    def self.decrypt(ciphertext, nonce, add, key)
+      raise ArgumentError, 'Invalid key size' unless key.bytesize == KEY_BYTES
+      raise ArgumentError, 'Invalid nonce size' unless nonce.bytesize == NONCE_BYTES
 
       c_ptr = FFI::MemoryPointer.from_string(ciphertext)
-      ad_ptr = FFI::MemoryPointer.from_string(ad)
+      ad_ptr = FFI::MemoryPointer.from_string(add)
 
       m_ptr = FFI::MemoryPointer.new(:uchar, ciphertext.bytesize - TAG_BYTES)
       mlen_p = FFI::MemoryPointer.new(:ulong_long)
@@ -147,7 +147,7 @@ module Discordrb::Voice
         FFI::MemoryPointer.from_string(key)
       )
 
-      raise "Decryption failed" unless result.zero?
+      raise 'Decryption failed' unless result.zero?
 
       m_ptr.read_string(mlen_p.read_ulong_long)
     end


### PR DESCRIPTION
# Summary
This pull request updates the voice encryption system in the `discordrb` library to use the more secure `aead_xchacha20_poly1305_rtpsize` encryption mode, replacing the deprecated `xsalsa20_poly1305` modes. It also introduces a new implementation of encryption and decryption using the XChaCha20-Poly1305 AEAD algorithm, modernizing the library's cryptographic capabilities.

### Encryption Mode Updates

* Updated `ENCRYPTED_MODE` to use `aead_xchacha20_poly1305_rtpsize` as the default encryption mode. Removed deprecated modes from `ENCRYPTION_MODES`. (`lib/discordrb/voice/network.rb`, [lib/discordrb/voice/network.rbL25-R32](diffhunk://#diff-4a23a5636d10637621b744ed291c33a9520dfbef91bbf23baaf807af2c157057L25-R32))

### Refactoring and Enhancements in Audio Transmission

* Refactored `send_audio` to use a new `generate_header` method and updated the nonce handling to align with the `aead_xchacha20_poly1305_rtpsize` mode. Nonces are now truncated to 4 bytes. (`lib/discordrb/voice/network.rb`, [lib/discordrb/voice/network.rbL85-R89](diffhunk://#diff-4a23a5636d10637621b744ed291c33a9520dfbef91bbf23baaf807af2c157057L85-R89))
* Updated `encrypt_audio` to support the new encryption mode, replacing the previous `SecretBox` implementation with a call to the new `XChaCha20AEAD` class. (`lib/discordrb/voice/network.rb`, [lib/discordrb/voice/network.rbR119-R132](diffhunk://#diff-4a23a5636d10637621b744ed291c33a9520dfbef91bbf23baaf807af2c157057R119-R132))

### Cryptographic Implementation Overhaul

* Replaced the old `Sodium` and `SecretBox` implementation (which relied on `xsalsa20_poly1305`) with a new `XChaCha20AEAD` class. This class provides high-level methods for encryption and decryption using the XChaCha20-Poly1305 AEAD algorithm and leverages `libsodium`'s `crypto_aead_xchacha20poly1305_ietf` functions. (`lib/discordrb/voice/sodium.rb`, [lib/discordrb/voice/sodium.rbR4-R152](diffhunk://#diff-510ed97134d78a6739ff3cd1e1ec1fc51a841c4c4f0ec407620d353880f99cc4R4-R152))

### Utility Improvements

* Added a `generate_nonce` method to handle nonce generation for the `aead_xchacha20_poly1305_rtpsize` mode, ensuring compatibility with the new encryption scheme. (`lib/discordrb/voice/network.rb`, [lib/discordrb/voice/network.rbL140-R159](diffhunk://#diff-4a23a5636d10637621b744ed291c33a9520dfbef91bbf23baaf807af2c157057L140-R159))
