### PR TITLE
feat: burst reactions

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -212,9 +212,9 @@ module Discordrb::API::Channel
 
   # Get a list of clients who reacted with a specific reaction on a message
   # https://discord.com/developers/docs/resources/channel#get-reactions
-  def get_reactions(token, channel_id, message_id, emoji, before_id, after_id, limit = 100)
+  def get_reactions(token, channel_id, message_id, emoji, before_id, after_id, limit = 100, type = 0)
     emoji = URI.encode_www_form_component(emoji) unless emoji.ascii_only?
-    query_string = URI.encode_www_form({ limit: limit || 100, before: before_id, after: after_id }.compact)
+    query_string = URI.encode_www_form({ limit: limit || 100, before: before_id, after: after_id, type: type }.compact)
     Discordrb::API.request(
       :channels_cid_messages_mid_reactions_emoji,
       channel_id,

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1377,6 +1377,12 @@ module Discordrb
       when :MESSAGE_REACTION_ADD
         add_message_reaction(data)
 
+        if data['member']
+          server = self.server(data['guild_id'].to_i)
+
+          server.cache_member(Member.new(data['member'], server, self))
+        end
+
         return if profile.id == data['user_id'].to_i && !should_parse_self
 
         event = ReactionAddEvent.new(data, self)

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -131,6 +131,7 @@ module Discordrb
     # @option attributes [String, Integer, User] :from Matches the user who added the reaction.
     # @option attributes [String, Integer, Message] :message Matches the message to which the reaction was added.
     # @option attributes [String, Integer, Channel] :in Matches the channel the reaction was added in.
+    # @option attributes [Integer, Symbol] :type Matches the type of reaction (`:normal` or `:burst`) that was added.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ReactionAddEvent] The event that was raised.
     # @return [ReactionAddEventHandler] The event handler that was registered.
@@ -145,6 +146,7 @@ module Discordrb
     # @option attributes [String, Integer, User] :from Matches the user who removed the reaction.
     # @option attributes [String, Integer, Message] :message Matches the message to which the reaction was removed.
     # @option attributes [String, Integer, Channel] :in Matches the channel the reaction was removed in.
+    # @option attributes [Integer, Symbol] :type Matches the type of reaction (`:normal` or `:burst`) that was added.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ReactionRemoveEvent] The event that was raised.
     # @return [ReactionRemoveEventHandler] The event handler that was registered.
@@ -645,7 +647,7 @@ module Discordrb
     def channel_pins_update(attributes = {}, &block)
       register_event(ChannelPinsUpdateEvent, attributes, block)
     end
-    
+
     # This **event** is raised whenever an autocomplete interaction is created.
     # @param name [String, Symbol, nil] An option name to match against.
     # @param attributes [Hash] The event's attributes.

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -325,15 +325,17 @@ module Discordrb
     # Returns the list of users who reacted with a certain reaction.
     # @param reaction [String, #to_reaction] the unicode emoji or {Emoji}
     # @param limit [Integer] the limit of how many users to retrieve. `nil` will return all users
+    # @param type [Integer, Symbol] the type of reaction to get. See {Reaction::TYPES}
     # @example Get all the users that reacted with a thumbs up.
     #   thumbs_up_reactions = message.reacted_with("\u{1F44D}")
     # @return [Array<User>] the users who used this reaction
-    def reacted_with(reaction, limit: 100)
+    def reacted_with(reaction, limit: 100, type: :normal)
       reaction = reaction.to_reaction if reaction.respond_to?(:to_reaction)
       reaction = reaction.to_s if reaction.respond_to?(:to_s)
+      type = Reaction::TYPES[type] || type
 
       get_reactions = proc do |fetch_limit, after_id = nil|
-        resp = API::Channel.get_reactions(@bot.token, @channel.id, @id, reaction, nil, after_id, fetch_limit)
+        resp = API::Channel.get_reactions(@bot.token, @channel.id, @id, reaction, nil, after_id, fetch_limit, type)
         JSON.parse(resp).map { |d| User.new(d, @bot) }
       end
 

--- a/lib/discordrb/data/reaction.rb
+++ b/lib/discordrb/data/reaction.rb
@@ -3,7 +3,13 @@
 module Discordrb
   # A reaction to a message.
   class Reaction
-    # @return [Integer] the amount of users who have reacted with this reaction
+    # Map of reaction types
+    TYPES = {
+      normal: 0,
+      burst: 1
+    }.freeze
+
+    # @return [Integer] the total amount of users who have reacted with this reaction (including burst reactions)
     attr_reader :count
 
     # @return [true, false] whether the current bot or user used this reaction
@@ -16,11 +22,30 @@ module Discordrb
     # @return [String] the name or unicode representation of the emoji
     attr_reader :name
 
+    # @return [true, false] whether the current bot or user used this reaction as a burst reaction
+    attr_reader :me_burst
+    alias_method :me_burst?, :me_burst
+
+    # @return [Array<ColourRGB>] colors used for animations in burst reactions
+    attr_reader :burst_colours
+    alias_method :burst_colors, :burst_colours
+
+    # @return [Integer] the total amount of users who have reacted with this reaction as a burst reaction
+    attr_reader :burst_count
+
+    # @return [Integer] the total amount of users who have reacted with this reaction as a normal reaction
+    attr_reader :normal_count
+
+    # @!visibility private
     def initialize(data)
       @count = data['count']
       @me = data['me']
       @id = data['emoji']['id']&.to_i
       @name = data['emoji']['name']
+      @me_burst = data['me_burst']
+      @burst_colours = data['burst_colors'].map { |b| ColourRGB.new(b.delete('#')) }
+      @burst_count = data['count_details']['burst']
+      @normal_count = data['count_details']['normal']
     end
 
     # Converts this Reaction into a string that can be sent back to Discord in other reaction endpoints.

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -637,7 +637,7 @@ module Discordrb
     # @return [BulkBan]
     def bulk_ban(users:, message_seconds: 0, reason: nil)
       raise ArgumentError, 'Can only ban between 1 and 200 users!' unless users.size.between?(1, 200)
-      
+
       return ban(users.first, 0, message_seconds: message_seconds, reason: reason) if users.size == 1
 
       response = API::Server.bulk_ban(@bot.token, @id, users.map(&:resolve_id), message_seconds, reason)

--- a/lib/discordrb/events/reactions.rb
+++ b/lib/discordrb/events/reactions.rb
@@ -14,6 +14,17 @@ module Discordrb::Events
     # @!visibility private
     attr_reader :message_id
 
+    # @return [true, false] if the reaction is a burst reaction
+    attr_reader :burst
+    alias_method :burst?, :burst
+
+    # @return [Integer] the type of the reaction. 0 for normal, 1 for burst
+    attr_reader :type
+
+    # @return [Array<ColourRGB>] colors used for animations in burst reactions
+    attr_reader :burst_colours
+    alias_method :burst_colors, :burst_colours
+
     def initialize(data, bot)
       @bot = bot
 
@@ -21,6 +32,9 @@ module Discordrb::Events
       @user_id = data['user_id'].to_i
       @message_id = data['message_id'].to_i
       @channel_id = data['channel_id'].to_i
+      @burst = data['burst']
+      @type = data['type']
+      @burst_colours = data['burst_colors']&.map { |b| Discordrb::ColourRGB.new(b.delete('#')) } || []
     end
 
     # @return [User, Member] the user that reacted to this message, or member if a server exists.
@@ -88,6 +102,16 @@ module Discordrb::Events
             e.current_bot?
           else
             a == e
+          end
+        end,
+        matches_all(@attributes[:type], event.type) do |a, e|
+          case a
+          when Integer
+            a == e
+          when :normal
+            e.zero?
+          when :burst
+            e == 1
           end
         end
       ].reduce(true, &:&)

--- a/spec/api/channel_spec.rb
+++ b/spec/api/channel_spec.rb
@@ -10,6 +10,7 @@ describe Discordrb::API::Channel do
     let(:message_id) { double('message_id', to_s: 'message_id') }
     let(:before_id) { double('before_id', to_s: 'before_id') }
     let(:after_id) { double('after_id', to_s: 'after_id') }
+    let(:type) { 0 }
 
     before do
       allow(Discordrb::API).to receive(:request)
@@ -22,10 +23,10 @@ describe Discordrb::API::Channel do
           anything,
           channel_id,
           :get,
-          "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/test?limit=27&before=#{before_id}&after=#{after_id}",
+          "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/test?limit=27&before=#{before_id}&after=#{after_id}&type=#{type}",
           any_args
         )
-      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, 'test', before_id, after_id, 27)
+      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, 'test', before_id, after_id, 27, 0)
     end
 
     it 'percent-encodes emoji' do
@@ -34,10 +35,10 @@ describe Discordrb::API::Channel do
           anything,
           channel_id,
           :get,
-          "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/%F0%9F%91%8D?limit=27&before=#{before_id}&after=#{after_id}",
+          "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/%F0%9F%91%8D?limit=27&before=#{before_id}&after=#{after_id}&type=#{type}",
           any_args
         )
-      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, "\u{1F44D}", before_id, after_id, 27)
+      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, "\u{1F44D}", before_id, after_id, 27, 0)
     end
 
     it 'uses the maximum limit of 100 if nil is provided' do
@@ -46,10 +47,10 @@ describe Discordrb::API::Channel do
           anything,
           channel_id,
           :get,
-          "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/test?limit=100&before=#{before_id}&after=#{after_id}",
+          "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/test?limit=100&before=#{before_id}&after=#{after_id}&type=#{type}",
           any_args
         )
-      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, 'test', before_id, after_id, nil)
+      Discordrb::API::Channel.get_reactions(token, channel_id, message_id, 'test', before_id, after_id, nil, 0)
     end
   end
 

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -119,17 +119,17 @@ describe Discordrb::Message do
     before do
       # Return the appropriate number of users based on after_id
       allow(Discordrb::API::Channel).to receive(:get_reactions)
-        .with(any_args, nil, anything) # ..., after_id, limit
+        .with(anything, anything, anything, anything, nil, nil, anything, anything)
         .and_return([user_data].to_json)
 
       allow(Discordrb::API::Channel).to receive(:get_reactions)
-        .with(any_args, user_data['id'].to_i, anything)
+        .with(any_args, user_data['id'].to_i, anything, nil, nil, anything, anything)
         .and_return([].to_json)
     end
 
     it 'calls the API method' do
       expect(Discordrb::API::Channel).to receive(:get_reactions)
-        .with(any_args, '\u{1F44D}', nil, nil, 27)
+        .with(any_args, '\u{1F44D}', nil, nil, 27, 0)
 
       message.reacted_with('\u{1F44D}', limit: 27)
     end
@@ -144,7 +144,7 @@ describe Discordrb::Message do
       allow(emoji).to receive(:to_reaction).and_return('123')
 
       expect(Discordrb::API::Channel).to receive(:get_reactions)
-        .with(any_args, '123', nil, nil, anything)
+        .with(any_args, '123', nil, nil, anything, 0)
 
       message.reacted_with(emoji)
     end
@@ -153,7 +153,7 @@ describe Discordrb::Message do
       allow(reaction).to receive(:to_s).and_return('123')
 
       expect(Discordrb::API::Channel).to receive(:get_reactions)
-        .with(any_args, '123', nil, nil, anything)
+        .with(any_args, '123', nil, nil, anything, 0)
 
       message.reacted_with(reaction)
     end


### PR DESCRIPTION
# Summary

This PR adds burst reactions aka super reactions

## Added

`Reaction::TYPES`
`Reaction#me_burst?`
`Reaction#burst_colours`
`Reaction#burst_count`
`Reaction#normal_count`


`ReactionEvent#burst?`
`ReactionEvent#type`
`ReactionEvent#burst_colours`

`type:` filter attribute for reaction events
`type:` KWARG for `Message#reacted_with`

## Changed

While I was going through the `:MESSAGE_REACTION_ADD` event [documentation](https://discord.com/developers/docs/events/gateway-events#message-reaction-add-message-reaction-add-event-fields), I noticed that this event includes the full member for the user who reacted to the message. Since this is a full member, I guess it's okay for us to cache the member?