### PR TITLE
fix: lazily cache un-cached members

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1101,10 +1101,11 @@ module Discordrb
       server_id = data['guild_id'].to_i
       server = self.server(server_id)
 
-      if (member = server.member(data['user']['id'].to_i))
+      # Only attempt to update members that're already cached
+      if (member = server.member(data['user']['id'].to_i, false))
         member.update_data(data)
       else
-        Discordrb::LOGGER.warn("update_guild_member attempted to access a member which doesn't exist! Not sure what happened here, ignoring.")
+        ensure_user(data['user'])
       end
     end
 
@@ -1301,12 +1302,21 @@ module Discordrb
           return
         end
 
+        if !should_parse_self && profile.id == data['author']['id'].to_i
+          debug('Ignored message from the current bot')
+          return
+        end
+
         # If create_message is overwritten with a method that returns the parsed message, use that instead, so we don't
         # parse the message twice (which is just thrown away performance)
         message = create_message(data)
         message = Message.new(data, self) unless message.is_a? Message
 
-        return if message.from_bot? && !should_parse_self
+        # Update the existing member if it exists in the cache.
+        if data['member']
+          member = message.channel.server&.member(data['author']['id'].to_i, false)
+          member&.update_data(data['member'])
+        end
 
         # Dispatch a ChannelCreateEvent for channels we don't have cached
         if message.channel.private? && @pm_channels[message.channel.recipient.id].nil?
@@ -1330,16 +1340,25 @@ module Discordrb
       when :MESSAGE_UPDATE
         update_message(data)
 
+        if !should_parse_self && profile.id == data['author']['id'].to_i
+          debug('Ignored message from the current bot')
+          return
+        end
+
         message = Message.new(data, self)
 
         event = MessageUpdateEvent.new(message, self)
         raise_event(event)
 
-        return if message.from_bot? && !should_parse_self
-
-        unless message.author
+        if data['author'].nil?
           LOGGER.debug("Edited a message with nil author! Content: #{message.content.inspect}, channel: #{message.channel.inspect}")
           return
+        end
+
+        # Update the existing member if it exists in the cache.
+        if data['member']
+          member = message.channel.server&.member(data['author']['id'].to_i, false)
+          member&.update_data(data['member'])
         end
 
         event = MessageEditEvent.new(message, self)
@@ -1378,6 +1397,12 @@ module Discordrb
         add_message_reaction(data)
 
         return if profile.id == data['user_id'].to_i && !should_parse_self
+
+        if data['member']
+          server = self.server(data['guild_id'].to_i)
+
+          server&.cache_member(Member.new(data['member'], server, self))
+        end
 
         event = ReactionAddEvent.new(data, self)
         raise_event(event)

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -645,7 +645,7 @@ module Discordrb
     def channel_pins_update(attributes = {}, &block)
       register_event(ChannelPinsUpdateEvent, attributes, block)
     end
-    
+
     # This **event** is raised whenever an autocomplete interaction is created.
     # @param name [String, Symbol, nil] An option name to match against.
     # @param attributes [Hash] The event's attributes.

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -91,35 +91,21 @@ module Discordrb
 
       @webhook_id = data['webhook_id']&.to_i
 
-      @author = if data['author']
-                  if @webhook_id
-                    # This is a webhook user! It would be pointless to try to resolve a member here, so we just create
-                    # a User and return that instead.
-                    Discordrb::LOGGER.debug("Webhook user: #{data['author']['id']}")
-                    User.new(data['author'].merge({ '_webhook' => true }), @bot)
-                  elsif @channel.private?
-                    # Turn the message user into a recipient - we can't use the channel recipient
-                    # directly because the bot may also send messages to the channel
-                    Recipient.new(bot.user(data['author']['id'].to_i), @channel, bot)
-                  else
-                    member = @channel.server.member(data['author']['id'].to_i)
+      if data['author']
+        if @webhook_id
+          # This is a webhook user! It would be pointless to try to resolve a member here, so we just create
+          # a User and return that instead.
+          Discordrb::LOGGER.debug("Webhook user: #{data['author']['id']}")
+          @author = User.new(data['author'].merge({ '_webhook' => true }), @bot)
+        elsif @channel.private?
 
-                    if member
-                      member.update_data(data['member']) if data['member']
-                      member.update_global_name(data['author']['global_name']) if data['author']['global_name']
-                    else
-                      Discordrb::LOGGER.debug("Member with ID #{data['author']['id']} not cached (possibly left the server).")
-                      member = if data['member']
-                                 member_data = data['author'].merge(data['member'])
-                                 Member.new(member_data, @server, bot)
-                               else
-                                 @bot.ensure_user(data['author'])
-                               end
-                    end
-
-                    member
-                  end
-                end
+          # Turn the message user into a recipient - we can't use the channel recipient
+          # directly because the bot may also send messages to the channel
+          @author = Recipient.new(bot.user(data['author']['id'].to_i), @channel, bot)
+        else
+          @author_id = data['author']['id'].to_i
+        end
+      end
 
       @timestamp = Time.parse(data['timestamp']) if data['timestamp']
       @edited_timestamp = data['edited_timestamp'].nil? ? nil : Time.parse(data['edited_timestamp'])
@@ -167,18 +153,18 @@ module Discordrb
     #   {User} for old messages when the author has left the server since then)
     def author
       return @author if @author
-      
+
       if @channel.server
-        @author = @channel.server.member(@author_id)        
-        Discordrb::LOGGER.debug("Member with ID #{@author_id} not cached (possibly left the server).") unless @author
+        @author = @channel.server.member(@author_id)
+        Discordrb::LOGGER.debug("Member with ID #{@author_id} not cached (possibly left the server).") if @author.nil?
       end
 
-      @author||= @bot.user(@author_id)
+      @author ||= @bot.user(@author_id)
     end
 
     alias_method :user, :author
     alias_method :writer, :author
-    
+
     # Replies to this message with the specified content.
     # @deprecated Please use {#respond}.
     # @param content [String] The content to send. Should not be longer than 2000 characters or it will result in an error.

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -637,7 +637,7 @@ module Discordrb
     # @return [BulkBan]
     def bulk_ban(users:, message_seconds: 0, reason: nil)
       raise ArgumentError, 'Can only ban between 1 and 200 users!' unless users.size.between?(1, 200)
-      
+
       return ban(users.first, 0, message_seconds: message_seconds, reason: reason) if users.size == 1
 
       response = API::Server.bulk_ban(@bot.token, @id, users.map(&:resolve_id), message_seconds, reason)

--- a/lib/discordrb/events/members.rb
+++ b/lib/discordrb/events/members.rb
@@ -71,7 +71,19 @@ module Discordrb::Events
 
   # Member is updated (roles added or deleted)
   # @see Discordrb::EventContainer#member_update
-  class ServerMemberUpdateEvent < ServerMemberEvent; end
+  class ServerMemberUpdateEvent < ServerMemberEvent
+    # Override init_user so we don't make requests all the time on large servers
+    def init_user(data, _)
+      @user_id = data['user']['id']
+    end
+
+    # @return [Member] the member in question.
+    def user
+      @server&.member(@user_id)
+    end
+
+    alias_method :member, :user
+  end
 
   # Event handler for {ServerMemberUpdateEvent}
   class ServerMemberUpdateEventHandler < ServerMemberEventHandler; end

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -229,7 +229,9 @@ module Discordrb::Events
             a == e
           end
         end,
-        matches_all(@attributes[:from], event.author) do |a, e|
+        matches_all(@attributes[:from], event.message) do |a, e|
+          # Resolve the author in the block in order to prevent resolving the author even when the attribute is `nil`
+          e = e.author
           case a
           when String
             a == e.name

--- a/lib/discordrb/events/threads.rb
+++ b/lib/discordrb/events/threads.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Generic subclass for threads
 module Discordrb::Events
   # Raised when a thread is created
   class ThreadCreateEvent < Event
@@ -62,9 +63,6 @@ module Discordrb::Events
     # @return [Channel]
     attr_reader :thread
 
-    # @return [Array<Member, User>]
-    attr_reader :added_members
-
     # @return [Array<Integer>]
     attr_reader :removed_member_ids
 
@@ -75,13 +73,17 @@ module Discordrb::Events
 
     def initialize(data, bot)
       @bot = bot
+      @server = bot.server(data['guild_id'].to_i) if data['guild_id']
       @thread = data.is_a?(Discordrb::Channel) ? data : bot.channel(data['id'].to_i)
-      @added_members = data['added_members']&.map do |member|
-        data['guild_id'] ? bot.member(data['guild_id'], member['user_id']) : bot.user(member['user_id'])
-      end || []
+      @added_member_ids = data['added_members']&.map { |m| m['user_id']&.to_i } || []
       @removed_member_ids = data['removed_member_ids']&.map(&:resolve_id) || []
       @member_count = data['member_count']
     end
+  end
+
+  # @return [Array<Member, User>] the members that were added to the thread
+  def added_members
+    @added_members ||= @added_member_ids&.map { |id| @server&.member(id) || @bot.user(id) }
   end
 
   # Event handler for ThreadMembersUpdateEvent

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -152,8 +152,11 @@ describe Discordrb::Bot do
       let(:author) { instance_double(Discordrb::User, id: user_id) }
       let(:message_fixture) { { 'author' => { 'id' => user_id }, 'channel_id' => channel_id } }
       let(:message) { instance_double(Discordrb::Message, channel: channel, from_bot?: false, mentions: []) }
+      let(:profile) { instance_double(Discordrb::Profile, id: 123_456, current_bot?: false) }
 
       before do
+        allow(user_id).to receive(:to_i).and_return(user_id)
+        allow(bot).to receive(:profile).and_return(profile)
         allow(bot).to receive(:channel).with(channel_id).and_return(channel)
         allow(channel).to receive(:is_a?).with(Discordrb::Channel).and_return(true)
         allow(bot).to receive(:ignored?).with(user_id).and_return(false)

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -43,7 +43,7 @@ describe Discordrb::Message do
       # Bot will receive #ensure_user because the observed message author
       # is not present in the server cache, which is possible
       # (for example) if the author had left the server.
-      expect(bot).to receive(:ensure_user).with message_author
+      # expect(bot).to receive(:ensure_user).with message_author
       described_class.new(message_data, bot)
     end
   end

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -169,14 +169,14 @@ describe Discordrb::Events do
       describe 'end_with attribute' do
         it "matches #{matching}" do
           handler = Discordrb::Events::MessageEventHandler.new({ end_with: expr }, double('proc'))
-          event = double('event', channel: double('channel', private?: false), author: double('author'), timestamp: double('timestamp'), content: matching)
+          event = double('event', channel: double('channel', private?: false), author: double('author'), timestamp: double('timestamp'), content: matching, message: matching)
           allow(event).to receive(:is_a?).with(Discordrb::Events::MessageEvent).and_return(true)
           expect(handler.matches?(event)).to be_truthy
         end
 
         it "doesn't match #{non_matching}" do
           handler = Discordrb::Events::MessageEventHandler.new({ end_with: expr }, double('proc'))
-          event = double('event', channel: double('channel', private?: false), author: double('author'), timestamp: double('timestamp'), content: non_matching)
+          event = double('event', channel: double('channel', private?: false), author: double('author'), timestamp: double('timestamp'), content: non_matching, message: matching)
           allow(event).to receive(:is_a?).with(Discordrb::Events::MessageEvent).and_return(true)
           expect(handler.matches?(event)).to be_falsy
         end


### PR DESCRIPTION
## Summary

Currently, we makes an HTTP request for any server member that isn't cached. The main causes of these network requests are `MESSAGE_CREATE` and `GUILD_MEMBER_UPDATE` events. This PR attempts to make members in many of the more spammy events be lazily cached.

In the future we should probably revisit this and automatically request member chunks on `GUILD_CREATE`

## Changed

- Made `Message#author` be lazily resolved (from Swarley)
- Don't request un-cached members on `GUILD_MEMBER_UPDATE`
- Attempt to update cached members with member objects from `MESSAGE_CREATE` at the dispatch level
- Make server members in `THREAD_MEMBERS_UPDATE` be lazily resolved
- Cache full member objects on `MESSAGE_REACTION_ADD`