### PR TITLE
feat: increased pinned message limits

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -319,25 +319,26 @@ module Discordrb::API::Channel
   end
 
   # Get a list of pinned messages in a channel
-  # https://discord.com/developers/docs/resources/channel#get-pinned-messages
-  def pinned_messages(token, channel_id)
+  # https://discord.com/developers/docs/resources/message#get-channel-pins
+  def pinned_messages(token, channel_id, limit = 50, before = nil)
+    query = URI.encode_www_form({ limit: limit, before: before }.compact)
     Discordrb::API.request(
       :channels_cid_pins,
       channel_id,
       :get,
-      "#{Discordrb::API.api_base}/channels/#{channel_id}/pins",
+      "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/pins?#{query}",
       Authorization: token
     )
   end
 
   # Pin a message
-  # https://discord.com/developers/docs/resources/channel#add-pinned-channel-message
+  # https://discord.com/developers/docs/resources/message#pin-message
   def pin_message(token, channel_id, message_id, reason = nil)
     Discordrb::API.request(
       :channels_cid_pins_mid,
       channel_id,
       :put,
-      "#{Discordrb::API.api_base}/channels/#{channel_id}/pins/#{message_id}",
+      "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/pins/#{message_id}",
       nil,
       Authorization: token,
       'X-Audit-Log-Reason': reason
@@ -345,13 +346,13 @@ module Discordrb::API::Channel
   end
 
   # Unpin a message
-  # https://discord.com/developers/docs/resources/channel#delete-pinned-channel-message
+  # https://discord.com/developers/docs/resources/message#unpin-message
   def unpin_message(token, channel_id, message_id, reason = nil)
     Discordrb::API.request(
       :channels_cid_pins_mid,
       channel_id,
       :delete,
-      "#{Discordrb::API.api_base}/channels/#{channel_id}/pins/#{message_id}",
+      "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/pins/#{message_id}",
       Authorization: token,
       'X-Audit-Log-Reason': reason
     )

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -645,7 +645,7 @@ module Discordrb
     def channel_pins_update(attributes = {}, &block)
       register_event(ChannelPinsUpdateEvent, attributes, block)
     end
-    
+
     # This **event** is raised whenever an autocomplete interaction is created.
     # @param name [String, Symbol, nil] An option name to match against.
     # @param attributes [Hash] The event's attributes.

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -79,6 +79,9 @@ module Discordrb
     # @return [Channel, nil] The thread that was started from this message, or nil.
     attr_reader :thread
 
+    # @return [Time, nil] the time at when this message was pinned. Only present on messages fetched via {Channel#pins}.
+    attr_reader :pinned_at
+
     # @!visibility private
     def initialize(data, bot)
       @bot = bot
@@ -167,6 +170,8 @@ module Discordrb
       @flags = data['flags'] || 0
 
       @thread = data['thread'] ? @bot.ensure_channel(data['thread'], @server) : nil
+
+      @pinned_at = data['pinned_at'] ? Time.parse(data['pinned_at']) : nil
     end
 
     # Replies to this message with the specified content.

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -637,7 +637,7 @@ module Discordrb
     # @return [BulkBan]
     def bulk_ban(users:, message_seconds: 0, reason: nil)
       raise ArgumentError, 'Can only ban between 1 and 200 users!' unless users.size.between?(1, 200)
-      
+
       return ban(users.first, 0, message_seconds: message_seconds, reason: reason) if users.size == 1
 
       response = API::Server.bulk_ban(@bot.token, @id, users.map(&:resolve_id), message_seconds, reason)


### PR DESCRIPTION
## Summary

This PR adds support for paginating past 50 pinned messages

## Added

`Message#pinned_at`
`limit` KWARG to `Channel#pins`
`before` and `limit` arguments for `API::Channel#pinned_messages`