### PR TITLE
fix: remove WSCS's monkey patch

### DIFF
--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ffi', '>= 1.9.24'
   spec.add_dependency 'opus-ruby'
   spec.add_dependency 'rest-client', '>= 2.0.0'
-  spec.add_dependency 'websocket-client-simple', '>= 0.3.0'
+  spec.add_dependency 'websocket-client-simple', '>= 0.9.0'
 
   spec.add_dependency 'discordrb-webhooks', '~> 3.5.0'
 

--- a/lib/discordrb/websocket.rb
+++ b/lib/discordrb/websocket.rb
@@ -2,16 +2,6 @@
 
 require 'websocket-client-simple'
 
-# The WSCS module which we're hooking
-# @see Websocket::Client::Simple::Client
-module WebSocket::Client::Simple
-  # Patch to the WSCS class to allow reading the internal thread
-  class Client
-    # @return [Thread] the internal thread this client is using for the event loop.
-    attr_reader :thread
-  end
-end
-
 module Discordrb
   # Utility wrapper class that abstracts an instance of WSCS. Useful should we decide that WSCS isn't good either -
   # in that case we can just switch to something else


### PR DESCRIPTION
# Summary

This PR removes an old monkey patch that exposed websocket-client-simple's internal thread. As of WSCS [version 0.7.0](https://github.com/ruby-jp/websocket-client-simple/releases/tag/v0.7.0), the client exposes the thread. I hope it's alright to bump the minimum required version for WSCS in this PR. Since, most users are probably already using a WSCS version greater than or equal to 0.7.0.

I went and checked out WSCS's commit history since version 0.3.0, and It seems like the changes are far and few, so it should be okay to bump the version ig