### PR TITLE
fix: broken guard clauses

### DIFF
--- a/lib/discordrb/data/overwrite.rb
+++ b/lib/discordrb/data/overwrite.rb
@@ -65,9 +65,8 @@ module Discordrb
 
     # Comparison by attributes [:id, :type, :allow, :deny]
     def ==(other)
-      # rubocop:disable Lint/Void
-      false unless other.is_a? Discordrb::Overwrite
-      # rubocop:enable Lint/Void
+      return false unless other.is_a?(Discordrb::Overwrite)
+
       id == other.id &&
         type == other.type &&
         allow == other.allow &&

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -136,9 +136,8 @@ module Discordrb
 
     # Comparison based on permission bits
     def ==(other)
-      # rubocop:disable Lint/Void
-      false unless other.is_a? Discordrb::Permissions
-      # rubocop:enable Lint/Void
+      return false unless other.is_a?(Discordrb::Permissions)
+
       bits == other.bits
     end
   end


### PR DESCRIPTION
## Summary

This fixes the broken guard clauses mentioned in #246

## Fixed
Broken guard clauses where equality comparison operands don't actually return if the object isn't of the same type.
