### PR TITLE
feat: missing interaction attributes

### DIFF
--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -27,7 +27,13 @@ module Discordrb::Events
     # @!attribute [r] user
     #   @return [User]
     #   @see Interaction#user
-    delegate :type, :server, :server_id, :channel, :channel_id, :user, to: :interaction
+    # @!attribute [r] user_locale
+    #   @return [String]
+    #   @see Interaction#user_locale
+    # @!attribute [r] context
+    #   @return [Integer]
+    #   @see Interaction#context
+    delegate :type, :server, :server_id, :channel, :channel_id, :user, :user_locale, :context, to: :interaction
 
     def initialize(data, bot)
       @interaction = Discordrb::Interaction.new(data, bot)


### PR DESCRIPTION
## Summary

This PR adds in a couple of missing attributes for Interactions. I wasn't sure on how to expose some of these such as `authorizing_integration_owners` in a way that would be super useful

## Added
`Interaction#context`
`Interaction#user_locale`
`Interaction#server_locale`
`Interaction#user_integration?`
`Interaction#server_integration?`
`Interaction#max_attachment_size`
`Interaction#application_permissions`