### PR TITLE
removal: undocumented gateway properties

### DIFF
--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -298,9 +298,7 @@ module Discordrb
       send_identify(@token, {
                       os: RUBY_PLATFORM,
                       browser: 'discordrb',
-                      device: 'discordrb',
-                      referrer: '',
-                      referring_domain: ''
+                      device: 'discordrb'
                     }, compress, LARGE_THRESHOLD, @shard_key, @intents)
     end
 


### PR DESCRIPTION
## Summary

This PR removes the `referrer` and `referring_domain` properties from the identify packet. Since these fields aren't documented, and we already send them as an empty string, ig it's okay to just remove them entirely
