### PR TITLE
feat: Channel#send_message!

### DIFF
--- a/examples/awaits.rb
+++ b/examples/awaits.rb
@@ -35,17 +35,17 @@ bot.message(start_with: '!game') do |event|
     # event handler will persist and continue to handle messages.
     if guess == magic
       # This returns `true`, which will destroy the await so we don't reply anymore
-      guess_event.respond 'you win!'
+      guess_event.respond!(content: 'you win!')
       true
     else
       # Let the user know if they guessed too high or low.
-      guess_event.respond(guess > magic ? 'too high' : 'too low')
+      guess_event.respond!(content: guess > magic ? 'too high' : 'too low')
 
       # Return false so the await is not destroyed, and we continue to listen
       false
     end
   end
-  event.respond "My number was: `#{magic}`."
+  event.respond!(content: "My number was: `#{magic}`.")
 end
 
 # Above we used the provided User#await! method to easily set up
@@ -61,7 +61,7 @@ CROSS_MARK = "\u274c"
 
 bot.message(content: '!time') do |event|
   # Send a message, and store a reference to it that we can add the reaction.
-  message = event.respond "The current time is: #{Time.now.strftime('%F %T %Z')}"
+  message = event.respond!(content: "The current time is: #{Time.now.strftime('%F %T %Z')}")
 
   # React to the message to give a user an easy "button" to press
   message.react CROSS_MARK

--- a/examples/ping.rb
+++ b/examples/ping.rb
@@ -23,7 +23,7 @@ puts 'Click on it to invite it to your server.'
 # This method call adds an event handler that will be called on any message that exactly contains the string "Ping!".
 # The code inside it will be executed, and a "Pong!" response will be sent to the channel.
 bot.message(content: 'Ping!') do |event|
-  event.respond 'Pong!'
+  event.respond!(content: 'Pong!')
 end
 
 # This method call has to be put at the end of your script, it is what makes the bot actually connect to Discord. If you

--- a/examples/ping_with_respond_time.rb
+++ b/examples/ping_with_respond_time.rb
@@ -10,8 +10,8 @@ bot = Discordrb::Bot.new token: 'B0T.T0KEN.here'
 bot.message(content: 'Ping!') do |event|
   # The `respond` method returns a `Message` object, which is stored in a variable `m`. The `edit` method is then called
   # to edit the message with the time difference between when the event was received and after the message was sent.
-  m = event.respond('Pong!')
-  m.edit "Pong! Time taken: #{Time.now - event.timestamp} seconds."
+  message = event.respond!(content: 'Pong!')
+  message.edit "Pong! Time taken: #{Time.now - event.timestamp} seconds."
 end
 
 bot.run

--- a/examples/select_menus.rb
+++ b/examples/select_menus.rb
@@ -5,73 +5,53 @@ require 'securerandom'
 
 bot = Discordrb::Bot.new(token: ENV.fetch('DISCORDRB_TOKEN'))
 
-bot.message do |event|
-  if event.message.content == 'TEST'
-    event.channel.send_message('Examples of different select menus')
+bot.message(content: 'TEST') do |event|
+  event.channel.send_message!(content: 'Examples of different select menus')
 
-    event.channel.send_message(
-      'string_select (old select_menu, but alias define to keep legacy)', false, nil, nil, nil, nil,
-      Discordrb::Components::View.new do |builder|
-        builder.row do |r|
-          r.string_select(custom_id: 'string_select', placeholder: 'Test of StringSelect', max_values: 3) do |ss|
-            ss.option(label: 'Value 1', value: '1', description: 'First value', emoji: { name: '1️⃣' })
-            ss.option(label: 'Value 2', value: '2', description: 'Second value', emoji: { name: '2️⃣' })
-            ss.option(label: 'Value 3', value: '3', description: 'Third value', emoji: { name: '3️⃣' })
-          end
-          # Same as above with the alias to keep the compatibility with the old method
-          # r.select_menu(custom_id: 'string_select', placeholder: 'Test of StringSelect', max_values: 3) do |ss|
-          #   ss.option(label: 'Value 1', value: '1', description: 'First value', emoji: { name: '1️⃣' })
-          #   ss.option(label: 'Value 2', value: '2', description: 'Second value', emoji: { name: '2️⃣' })
-          #   ss.option(label: 'Value 3', value: '3', description: 'Third value', emoji: { name: '3️⃣' })
-          # end
-        end
+  event.channel.send_message!(content: 'string_select (old select_menu, but alias define to keep legacy)') do |_, view|
+    view.row do |row|
+      row.string_select(custom_id: 'string_select', placeholder: 'Test of StringSelect', max_values: 3) do |menu|
+        menu.option(label: 'Value 1', value: '1', description: 'First value', emoji: { name: '1️⃣' })
+        menu.option(label: 'Value 2', value: '2', description: 'Second value', emoji: { name: '2️⃣' })
+        menu.option(label: 'Value 3', value: '3', description: 'Third value', emoji: { name: '3️⃣' })
       end
-    )
+      # Same as above with the alias to keep the compatibility with the old method
+      # r.select_menu(custom_id: 'string_select', placeholder: 'Test of StringSelect', max_values: 3) do |ss|
+      #   ss.option(label: 'Value 1', value: '1', description: 'First value', emoji: { name: '1️⃣' })
+      #   ss.option(label: 'Value 2', value: '2', description: 'Second value', emoji: { name: '2️⃣' })
+      #   ss.option(label: 'Value 3', value: '3', description: 'Third value', emoji: { name: '3️⃣' })
+      # end
+    end
+  end
 
-    event.channel.send_message(
-      'user_select', false, nil, nil, nil, nil,
-      Discordrb::Components::View.new do |builder|
-        builder.row do |r|
-          r.user_select(custom_id: 'user_select', placeholder: 'Test of UserSelect', max_values: 3, disabled: true)
-        end
-      end
-    )
+  event.channel.send_message!(content: 'user_select') do |_, view|
+    view.row do |row|
+      row.user_select(custom_id: 'user_select', placeholder: 'Test of UserSelect', max_values: 3, disabled: true)
+    end
+  end
 
-    event.channel.send_message(
-      'user_select', false, nil, nil, nil, nil,
-      Discordrb::Components::View.new do |builder|
-        builder.row do |r|
-          r.user_select(custom_id: 'user_select', placeholder: 'Test of UserSelect', max_values: 3)
-        end
-      end
-    )
+  event.channel.send_message!(content: 'user_select') do |_, view|
+    view.row do |row|
+      row.user_select(custom_id: 'user_select', placeholder: 'Test of UserSelect', max_values: 3)
+    end
+  end
 
-    event.channel.send_message(
-      'role_select', false, nil, nil, nil, nil,
-      Discordrb::Components::View.new do |builder|
-        builder.row do |r|
-          r.role_select(custom_id: 'role_select', placeholder: 'Test of RoleSelect', max_values: 3)
-        end
-      end
-    )
+  event.channel.send_message!(content: 'role_select') do |_, view|
+    view.row do |row|
+      row.role_select(custom_id: 'role_select', placeholder: 'Test of RoleSelect', max_values: 3)
+    end
+  end
 
-    event.channel.send_message(
-      'mentionable_select', false, nil, nil, nil, nil,
-      Discordrb::Components::View.new do |builder|
-        builder.row do |r|
-          r.mentionable_select(custom_id: 'mentionable_select', placeholder: 'Test of MentionableSelect', max_values: 3)
-        end
-      end
-    )
+  event.channel.send_message!(content: 'mentionable_select') do |_, view|
+    view.row do |row|
+      row.mentionable_select(custom_id: 'mentionable_select', placeholder: 'Test of MentionableSelect', max_values: 3)
+    end
+  end
 
-    event.channel.send_message(
-      'channel_select', false, nil, nil, nil, nil,
-      Discordrb::Components::View.new do |builder|
-        builder.row do |r|
-          r.channel_select(custom_id: 'channel_select', placeholder: 'Test of ChannelSelect', max_values: 3)
-        end
-      end
-    )
+  event.channel.send_message!(content: 'channel_select') do |_, view|
+    view.row do |row|
+      row.channel_select(custom_id: 'channel_select', placeholder: 'Test of ChannelSelect', max_values: 3)
+    end
   end
 end
 

--- a/examples/shutdown.rb
+++ b/examples/shutdown.rb
@@ -14,7 +14,7 @@ bot.command(:exit, help_available: false) do |event|
   # able to shut your bot down whenever they wanted.
   break unless event.user.id == 66237334693085184 # Replace number with your ID
 
-  bot.send_message(event.channel.id, 'Bot is shutting down')
+  event.channel.send_message!(content: 'Bot is shutting down')
   exit
 end
 

--- a/examples/webhooks.rb
+++ b/examples/webhooks.rb
@@ -10,7 +10,7 @@ bot = Discordrb::Bot.new(token: ENV.fetch('DISCORDRB_TOKEN'))
 
 bot.message do |event|
   if event.message.content == 'CREATE'
-    event.channel.send_message('Create webhook in this channel')
+    event.channel.send_message!(content: 'Create webhook in this channel')
 
     wh = event.channel.create_webhook('Test', nil, 'Creation webhook')
     wh.execute(content: '[CREATE]')

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -75,8 +75,8 @@ module Discordrb::API::Channel
   # https://discord.com/developers/docs/resources/channel#create-message
   # @param attachments [Array<File>, nil] Attachments to use with `attachment://` in embeds. See
   #   https://discord.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds
-  def create_message(token, channel_id, message, tts = false, embeds = nil, nonce = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = nil)
-    body = { content: message, tts: tts, embeds: embeds, nonce: nonce, allowed_mentions: allowed_mentions, message_reference: message_reference, components: components&.to_a, flags: flags }
+  def create_message(token, channel_id, message, tts = false, embeds = nil, nonce = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = nil, enforce_nonce = false)
+    body = { content: message, tts: tts, embeds: embeds, nonce: nonce, allowed_mentions: allowed_mentions, message_reference: message_reference, components: components&.to_a, flags: flags, enforce_nonce: enforce_nonce }
     body = if attachments
              files = [*0...attachments.size].zip(attachments).to_h
              { **files, payload_json: body.to_json }

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -400,18 +400,20 @@ module Discordrb
     # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
     # @param embeds [Hash, Discordrb::Webhooks::Embed, Array<Hash>, Array<Discordrb::Webhooks::Embed> nil] The rich embed(s) to append to this message.
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
-    # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
+    # @param message_reference [Message, String, Integer, Hash, nil] The message, or message ID, to reply to if any.
     # @param components [View, Array<Hash>] Interaction components to associate with this message.
-    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) and SUPPRESS_NOTIFICATIONS (1 << 12) can be set.
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2), SUPPRESS_NOTIFICATIONS (1 << 12), and IS_COMPONENTS_V2 (1 << 15) can be set.
+    # @param nonce [String, nil] A optional nonce in order to verify that a message was sent. Maximum of twenty-five characters.
+    # @param enforce_nonce [true, false] whether the nonce should be enforced and used for message de-duplication.
     # @return [Message] The message that was sent.
-    def send_message(channel, content, tts = false, embeds = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = 0)
+    def send_message(channel, content, tts = false, embeds = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = 0, nonce = nil, enforce_nonce = false)
       channel = channel.resolve_id
       debug("Sending message to #{channel} with content '#{content}'")
       allowed_mentions = { parse: [] } if allowed_mentions == false
-      message_reference = { message_id: message_reference.id } if message_reference.respond_to?(:id)
+      message_reference = { message_id: message_reference.resolve_id } if message_reference.respond_to?(:resolve_id)
       embeds = (embeds.instance_of?(Array) ? embeds.map(&:to_hash) : [embeds&.to_hash]).compact
 
-      response = API::Channel.create_message(token, channel, content, tts, embeds, nil, attachments, allowed_mentions&.to_hash, message_reference, components, flags)
+      response = API::Channel.create_message(token, channel, content, tts, embeds, nonce, attachments, allowed_mentions&.to_hash, message_reference, components, flags, enforce_nonce)
       Message.new(JSON.parse(response), self)
     end
 
@@ -426,12 +428,14 @@ module Discordrb
     # @param allowed_mentions [Hash, Discordrb::AllowedMentions, false, nil] Mentions that are allowed to ping on this message. `false` disables all pings
     # @param message_reference [Message, String, Integer, nil] The message, or message ID, to reply to if any.
     # @param components [View, Array<Hash>] Interaction components to associate with this message.
-    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2) and SUPPRESS_NOTIFICATIONS (1 << 12) can be set.
-    def send_temporary_message(channel, content, timeout, tts = false, embeds = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = 0)
+    # @param flags [Integer] Flags for this message. Currently only SUPPRESS_EMBEDS (1 << 2), SUPPRESS_NOTIFICATIONS (1 << 12), and IS_COMPONENTS_V2 (1 << 15) can be set.
+    # @param nonce [String, nil] A optional nonce in order to verify that a message was sent. Maximum of twenty-five characters.
+    # @param enforce_nonce [true, false] whether the nonce should be enforced and used for message de-duplication.
+    def send_temporary_message(channel, content, timeout, tts = false, embeds = nil, attachments = nil, allowed_mentions = nil, message_reference = nil, components = nil, flags = 0, nonce = nil, enforce_nonce = false)
       Thread.new do
         Thread.current[:discordrb_name] = "#{@current_thread}-temp-msg"
 
-        message = send_message(channel, content, tts, embeds, attachments, allowed_mentions, message_reference, components, flags)
+        message = send_message(channel, content, tts, embeds, attachments, allowed_mentions, message_reference, components, flags, nonce, enforce_nonce)
         sleep(timeout)
         message.delete
       end

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -5,6 +5,23 @@ module Discordrb
   class Message
     include IDObject
 
+    # Map of message flags.
+    FLAGS = {
+      crossposted: 1 << 0,
+      crosspost: 1 << 1,
+      suppress_embeds: 1 << 2,
+      source_message_deleted: 1 << 3,
+      urgent: 1 << 4,
+      thread: 1 << 5,
+      ephemeral: 1 << 6,
+      loading: 1 << 7,
+      failed_to_mention_roles: 1 << 8,
+      suppress_notifications: 1 << 12,
+      voice_message: 1 << 13,
+      snapshot: 1 << 14,
+      uikit_components: 1 << 15
+    }.freeze
+
     # @return [String] the content of this message.
     attr_reader :content
     alias_method :text, :content
@@ -437,5 +454,11 @@ module Discordrb
     end
 
     alias_method :message, :to_message
+
+    FLAGS.each do |name, value|
+      define_method("#{name}?") do
+        @flags.anybits?(value)
+      end
+    end
   end
 end

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -54,6 +54,14 @@ module Discordrb::Events
       channel.send_temporary_message(content, timeout, tts, embed, attachments, allowed_mentions, components, flags)
     end
 
+    # # Sends a message to the channel this message was sent in, right now.
+    # @see Channel#send_message!
+    def send_message!(**parameters)
+      # HACK: We can accept any arguments with `**`, and then validate the arguments when actually
+      #   unpacking them into `Channel#send_message!`
+      channel.send_message!(**parameters)
+    end
+
     # Adds a string to be sent after the event has finished execution. Avoids problems with rate limiting because only
     # one message is ever sent. If it is used multiple times, the strings will bunch up into one message (separated by
     # newlines)
@@ -87,6 +95,9 @@ module Discordrb::Events
     alias_method :send, :send_message
     alias_method :respond, :send_message
     alias_method :send_temp, :send_temporary_message
+
+    alias_method :send!, :send_message!
+    alias_method :respond!, :send_message!
   end
 
   # Event raised when a text message is sent to a channel


### PR DESCRIPTION
## Summary

This PR adds in a KWARG version of `Channel#send_message`. I went and updated all the examples as well, since it might be a good idea to point people to the new version of the method

## Added
`Channel#send_message!`
`enforce_nonce` parameter
`Respondable#send_message!`

## Fixed

Previously, there was a bug where directly creating a reply with a message ID would error out. The fix was to change the line below to use `#resolve_id` instead

**Broken**
```ruby
message_reference = { message_id: message_reference.id } if message_reference.respond_to?(:id)
```

**Fixed**
```ruby
message_reference = { message_id: message_reference.resolve_id } if message_reference.respond_to?(:resolve_id)
```
