### PR TITLE
docs: hide all initializers

### DIFF
--- a/lib/discordrb/data/application.rb
+++ b/lib/discordrb/data/application.rb
@@ -22,6 +22,7 @@ module Discordrb
     # @return [User] the user object of the owner
     attr_reader :owner
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 

--- a/lib/discordrb/data/integration.rb
+++ b/lib/discordrb/data/integration.rb
@@ -9,6 +9,7 @@ module Discordrb
     # @return [Integer] this account's ID.
     attr_reader :id
 
+    # @!visibility private
     def initialize(data)
       @name = data['name']
       @id = data['id'].to_i
@@ -35,6 +36,7 @@ module Discordrb
     # @return [User, nil] the bot associated with this application.
     attr_reader :bot
 
+    # @!visibility private
     def initialize(data, bot)
       @id = data['id'].to_i
       @name = data['name']
@@ -93,6 +95,7 @@ module Discordrb
     # @return [true, false] has this integration been revoked.
     attr_reader :revoked
 
+    # @!visibility private
     def initialize(data, bot, server)
       @bot = bot
 

--- a/lib/discordrb/data/reaction.rb
+++ b/lib/discordrb/data/reaction.rb
@@ -16,6 +16,7 @@ module Discordrb
     # @return [String] the name or unicode representation of the emoji
     attr_reader :name
 
+    # @!visibility private
     def initialize(data)
       @count = data['count']
       @me = data['me']

--- a/lib/discordrb/data/voice_region.rb
+++ b/lib/discordrb/data/voice_region.rb
@@ -28,6 +28,7 @@ module Discordrb
     # @return [true, false] whether this is a custom voice region (used for events/etc)
     attr_reader :custom
 
+    # @!visibility private
     def initialize(data)
       @id = data['id']
 

--- a/lib/discordrb/data/webhook.rb
+++ b/lib/discordrb/data/webhook.rb
@@ -31,6 +31,7 @@ module Discordrb
     # @return [Member, User, nil] the user object of the owner or nil if the webhook was requested using the token.
     attr_reader :owner
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 

--- a/lib/discordrb/events/await.rb
+++ b/lib/discordrb/events/await.rb
@@ -25,7 +25,7 @@ module Discordrb::Events
     #   @see Await#attributes
     delegate :key, :type, :attributes, to: :await
 
-    # For internal use only
+    # @!visibility private
     def initialize(await, event, bot)
       @await = await
       @event = event

--- a/lib/discordrb/events/channels.rb
+++ b/lib/discordrb/events/channels.rb
@@ -29,6 +29,7 @@ module Discordrb::Events
     #   @see Channel#server
     delegate :name, :server, :type, :owner_id, :recipients, :topic, :user_limit, :position, :permission_overwrites, to: :channel
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
       @channel = data.is_a?(Discordrb::Channel) ? data : bot.channel(data['id'].to_i)
@@ -83,6 +84,7 @@ module Discordrb::Events
     # @return [Integer, nil] the channel's owner ID if this is a group channel
     attr_reader :owner_id
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 
@@ -134,6 +136,7 @@ module Discordrb::Events
 
     delegate :id, to: :recipient
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 
@@ -179,6 +182,7 @@ module Discordrb::Events
     # @return [Server, nil] The server this event originates from.
     attr_reader :server
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 

--- a/lib/discordrb/events/generic.rb
+++ b/lib/discordrb/events/generic.rb
@@ -7,6 +7,7 @@ module Discordrb::Events
   class Negated
     attr_reader :object
 
+    # @!visibility private
     def initialize(object)
       @object = object
     end
@@ -75,6 +76,7 @@ module Discordrb::Events
 
   # Generic event handler that can be extended
   class EventHandler
+    # @!visibility private
     def initialize(attributes, block)
       @attributes = attributes
       @block = block

--- a/lib/discordrb/events/guilds.rb
+++ b/lib/discordrb/events/guilds.rb
@@ -9,6 +9,7 @@ module Discordrb::Events
     # @return [Server] the server in question.
     attr_reader :server
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 
@@ -64,7 +65,8 @@ module Discordrb::Events
     # @return [Integer] The ID of the server that was left.
     attr_reader :server
 
-    # Override init_server to account for the deleted server
+    # @!visibility private
+    # @note Override init_server to account for the deleted server
     def init_server(data, _bot)
       @server = data['id'].to_i
     end
@@ -81,6 +83,7 @@ module Discordrb::Events
     # @return [Array<Emoji>] array of emojis.
     attr_reader :emoji
 
+    # @!visibility private
     def initialize(server, data, bot)
       @bot = bot
       @server = server
@@ -103,6 +106,7 @@ module Discordrb::Events
     # @return [Emoji] the emoji data.
     attr_reader :emoji
 
+    # @!visibility private
     def initialize(server, emoji, bot)
       @bot = bot
       @emoji = emoji
@@ -127,6 +131,7 @@ module Discordrb::Events
     # @return [Emoji, nil] the updated emoji data.
     attr_reader :emoji
 
+    # @!visibility private
     def initialize(server, old_emoji, emoji, bot)
       @bot = bot
       @old_emoji = old_emoji

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -29,6 +29,7 @@ module Discordrb::Events
     #   @see Interaction#user
     delegate :type, :server, :server_id, :channel, :channel_id, :user, to: :interaction
 
+    # @!visibility private
     def initialize(data, bot)
       @interaction = Discordrb::Interaction.new(data, bot)
       @bot = bot
@@ -155,6 +156,7 @@ module Discordrb::Events
     # @return [Integer, nil] The target of this command when it is a context command.
     attr_reader :target_id
 
+    # @!visibility private
     def initialize(data, bot)
       super
 

--- a/lib/discordrb/events/invites.rb
+++ b/lib/discordrb/events/invites.rb
@@ -34,6 +34,7 @@ module Discordrb::Events
 
     alias temporary? temporary
 
+    # @!visibility private
     def initialize(data, invite, bot)
       @bot = bot
       @invite = invite
@@ -53,6 +54,7 @@ module Discordrb::Events
     # @return [String] The code of the deleted invite.
     attr_reader :code
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
       @channel = bot.channel(data['channel_id'])

--- a/lib/discordrb/events/members.rb
+++ b/lib/discordrb/events/members.rb
@@ -16,6 +16,7 @@ module Discordrb::Events
     # @return [Server] the server on which the event happened.
     attr_reader :server
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 
@@ -28,11 +29,13 @@ module Discordrb::Events
 
     private
 
+    # @!visibility private
     def init_user(data, _)
       user_id = data['user']['id'].to_i
       @user = @server.member(user_id)
     end
 
+    # @!visibility private
     def init_roles(data, _)
       @roles = [@server.role(@server.id)]
       return unless data['roles']
@@ -72,7 +75,8 @@ module Discordrb::Events
   # Member is updated (roles added or deleted)
   # @see Discordrb::EventContainer#member_update
   class ServerMemberUpdateEvent < ServerMemberEvent
-    # Override init_user so we don't make requests all the time on large servers
+    # @!visibility private
+    # @note Override init_user so we don't make requests all the time on large servers
     def init_user(data, _)
       @user_id = data['user']['id']
     end
@@ -91,7 +95,8 @@ module Discordrb::Events
   # Member leaves
   # @see Discordrb::EventContainer#member_leave
   class ServerMemberDeleteEvent < ServerMemberEvent
-    # Override init_user to account for the deleted user on the server
+    # @!visibility private
+    # @note Override init_user to account for the deleted user on the server
     def init_user(data, bot)
       @user = Discordrb::User.new(data['user'], bot)
     end

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -138,6 +138,7 @@ module Discordrb::Events
     #   @see Channel#server
     delegate :server, to: :channel
 
+    # @!visibility private
     def initialize(message, bot)
       @bot = bot
       @message = message

--- a/lib/discordrb/events/presence.rb
+++ b/lib/discordrb/events/presence.rb
@@ -19,6 +19,7 @@ module Discordrb::Events
     #   on various device types (`:desktop`, `:mobile`, or `:web`). The value will be `nil` if the user is offline or invisible.
     attr_reader :client_status
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 
@@ -82,6 +83,7 @@ module Discordrb::Events
     #   on various device types (`:desktop`, `:mobile`, or `:web`). The value will be `nil` if the user is offline or invisible.
     attr_reader :client_status
 
+    # @!visibility private
     def initialize(data, activity, bot)
       @bot = bot
       @activity = activity

--- a/lib/discordrb/events/raw.rb
+++ b/lib/discordrb/events/raw.rb
@@ -14,6 +14,7 @@ module Discordrb::Events
     attr_reader :data
     alias_method :d, :data
 
+    # @!visibility private
     def initialize(type, data, bot)
       @type = type
       @data = data

--- a/lib/discordrb/events/reactions.rb
+++ b/lib/discordrb/events/reactions.rb
@@ -14,6 +14,7 @@ module Discordrb::Events
     # @!visibility private
     attr_reader :message_id
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 
@@ -113,6 +114,7 @@ module Discordrb::Events
     # @!visibility private
     attr_reader :message_id
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 

--- a/lib/discordrb/events/roles.rb
+++ b/lib/discordrb/events/roles.rb
@@ -17,6 +17,7 @@ module Discordrb::Events
     #   @see Role#name
     delegate :name, to: :role
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 
@@ -54,6 +55,7 @@ module Discordrb::Events
     # @return [Server] the server on which a role got deleted.
     attr_reader :server
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 

--- a/lib/discordrb/events/threads.rb
+++ b/lib/discordrb/events/threads.rb
@@ -9,6 +9,7 @@ module Discordrb::Events
 
     delegate :name, :server, :owner, :parent_channel, :thread_metadata, to: :thread
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
       @thread = data.is_a?(Discordrb::Channel) ? data : bot.channel(data['id'].to_i)
@@ -71,6 +72,7 @@ module Discordrb::Events
 
     delegate :name, :server, :owner, :parent_channel, :thread_metadata, to: :thread
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
       @server = bot.server(data['guild_id'].to_i) if data['guild_id']

--- a/lib/discordrb/events/typing.rb
+++ b/lib/discordrb/events/typing.rb
@@ -17,6 +17,7 @@ module Discordrb::Events
     # @return [Time] when the typing happened.
     attr_reader :timestamp
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 

--- a/lib/discordrb/events/voice_server_update.rb
+++ b/lib/discordrb/events/voice_server_update.rb
@@ -19,6 +19,7 @@ module Discordrb::Events
     # @return [String] The voice server host.
     attr_reader :endpoint
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 

--- a/lib/discordrb/events/voice_state_update.rb
+++ b/lib/discordrb/events/voice_state_update.rb
@@ -11,6 +11,7 @@ module Discordrb::Events
     # @return [Channel, nil] the old channel this user was on, or nil if the user is newly joining voice.
     attr_reader :old_channel
 
+    # @!visibility private
     def initialize(data, old_channel_id, bot)
       @bot = bot
 

--- a/lib/discordrb/events/webhooks.rb
+++ b/lib/discordrb/events/webhooks.rb
@@ -12,6 +12,7 @@ module Discordrb::Events
     # @return [Channel] the channel the webhook is associated to
     attr_reader :channel
 
+    # @!visibility private
     def initialize(data, bot)
       @bot = bot
 


### PR DESCRIPTION
## Summary

This hides all the initializers from the docs. We already do this for most classes, but there were a few that were missing the `# @!visibility private` tag (mostly events), so I added them.
