### PR TITLE
feat: base64 encoder

### DIFF
--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -120,6 +120,19 @@ module Discordrb
       "<t:#{time.to_i}:#{TIMESTAMP_STYLES[style] || style}>"
     end
   end
+
+  # A utility method to base64 encode a file like object using its mime type.
+  # @param file [File, #read] A file like object that responds to #read.
+  # @return [String] The file object encoded as base64 image data.
+  def self.encode64(file)
+    path_method = %i[original_filename path local_path].find { |method| file.respond_to?(method) }
+
+    raise ArgumentError, 'File object must respond to original_filename, path, or local path.' unless path_method
+    raise ArgumentError, 'File object must respond to read.' unless file.respond_to?(:read)
+
+    mime_type = MIME::Types.type_for(file.__send__(path_method)).first&.to_s || 'image/jpeg'
+    "data:#{mime_type};base64,#{Base64.encode64(file.read).strip}"
+  end
 end
 
 # In discordrb, Integer and {String} are monkey-patched to allow for easy resolution of IDs

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -261,13 +261,7 @@ module Discordrb::API::Server
     data = { color: colour, name: name, hoist: hoist, mentionable: mentionable, permissions: packed_permissions, colors: colours, unicode_emoji: unicode_emoji }
 
     if icon != :undef && icon
-      path_method = %i[original_filename path local_path].find { |meth| icon.respond_to?(meth) }
-
-      raise ArgumentError, 'File object must respond to original_filename, path, or local path.' unless path_method
-      raise ArgumentError, 'File must respond to read' unless icon.respond_to? :read
-
-      mime_type = MIME::Types.type_for(icon.__send__(path_method)).first&.to_s || 'image/jpeg'
-      data[:icon] = "data:#{mime_type};base64,#{Base64.encode64(icon.read).strip}"
+      Discordrb.encode64(icon)
     elsif icon.nil?
       data[:icon] = nil
     end

--- a/lib/discordrb/data/profile.rb
+++ b/lib/discordrb/data/profile.rb
@@ -22,13 +22,8 @@ module Discordrb
     # @param avatar [String, #read] A JPG file to be used as the avatar, either
     #  something readable (e.g. File Object) or as a data URL.
     def avatar=(avatar)
-      if avatar.respond_to? :read
-        # Set the file to binary mode if supported, so we don't get problems with Windows
-        avatar.binmode if avatar.respond_to?(:binmode)
-
-        avatar_string = 'data:image/jpg;base64,'
-        avatar_string += Base64.strict_encode64(avatar.read)
-        update_profile_data(avatar: avatar_string)
+      if avatar.respond_to?(:read)
+        update_profile_data(avatar: Discordrb.encode64(avatar))
       else
         update_profile_data(avatar: avatar)
       end

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -513,7 +513,7 @@ module Discordrb
     # with the regular role defaults the client uses unless specified, i.e. name is "new role",
     # permissions are the default, colour is the default etc.
     # @param name [String] Name of the role to create.
-    # @param colour [Integer, ColourRGB, #combined] The roles  primary colour.
+    # @param colour [Integer, ColourRGB, #combined] The primary colour of the role to create.
     # @param hoist [true, false] whether members of this role should be displayed seperately in the members list.
     # @param mentionable [true, false] whether this role can mentioned by anyone in the server.
     # @param permissions [Integer, Array<Symbol>, Permissions, #bits] The permissions to write to the new role.
@@ -552,13 +552,9 @@ module Discordrb
     # @param reason [String] The reason the for the creation of this emoji.
     # @return [Emoji] The emoji that has been added.
     def add_emoji(name, image, roles = [], reason: nil)
-      image_string = image
-      if image.respond_to? :read
-        image_string = 'data:image/jpg;base64,'
-        image_string += Base64.strict_encode64(image.read)
-      end
+      image = image.respond_to?(:read) ? Discordrb.encode64(image) : image
 
-      data = JSON.parse(API::Server.add_emoji(@bot.token, @id, image_string, name, roles.map(&:resolve_id), reason))
+      data = JSON.parse(API::Server.add_emoji(@bot.token, @id, image, name, roles.map(&:resolve_id), reason))
       new_emoji = Emoji.new(data, @bot, self)
       @emoji[new_emoji.id] = new_emoji
     end
@@ -708,10 +704,8 @@ module Discordrb
     # Sets the server's icon.
     # @param icon [String, #read] The new icon, in base64-encoded JPG format.
     def icon=(icon)
-      if icon.respond_to? :read
-        icon_string = 'data:image/jpg;base64,'
-        icon_string += Base64.strict_encode64(icon.read)
-        update_server_data(icon_id: icon_string)
+      if icon.respond_to?(:read)
+        update_server_data(icon_id: Discordrb.encode64(icon))
       else
         update_server_data(icon_id: icon)
       end

--- a/lib/discordrb/data/webhook.rb
+++ b/lib/discordrb/data/webhook.rb
@@ -212,11 +212,7 @@ module Discordrb
     private
 
     def avatarise(avatar)
-      if avatar.respond_to? :read
-        "data:image/jpg;base64,#{Base64.strict_encode64(avatar.read)}"
-      else
-        avatar
-      end
+      avatar.respond_to?(:read) ? Discordrb.encode64(avatar) : avatar
     end
 
     def update_internal(data)

--- a/spec/data/webhook_spec.rb
+++ b/spec/data/webhook_spec.rb
@@ -166,8 +166,8 @@ describe Discordrb::Webhook do
   describe '#avatarise' do
     context 'avatar responds to read' do
       it 'returns encoded' do
-        avatar = double('avatar', read: 'text')
-        expect(webhook.send(:avatarise, avatar)).to eq "data:image/jpg;base64,#{Base64.strict_encode64('text')}"
+        avatar = double('avatar', read: 'text', path: '/foo')
+        expect(webhook.send(:avatarise, avatar)).to eq 'data:image/jpeg;base64,dGV4dA=='
       end
     end
 


### PR DESCRIPTION
## Summary

A few months ago in November, we [discussed](<https://discord.com/channels/81384788765712384/381891448884428801/1301199422444666922>) adding a Base64 encoding helper. This adds that, since base64 encoding is also required for a bunch of things that we don't support yet

## Added
`Discordrb.encode64`
