### PR TITLE
style: use (...) syntax to forward arguments

### DIFF
--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -35,67 +35,59 @@ module Discordrb::Events
       @bot = bot
     end
 
-    # (see Interaction#respond)
-    def respond(content: nil, tts: nil, embeds: nil, allowed_mentions: nil, flags: 0, ephemeral: nil, wait: false, components: nil, attachments: nil, &block)
-      @interaction.respond(
-        content: content, tts: tts, embeds: embeds, allowed_mentions: allowed_mentions,
-        flags: flags, ephemeral: ephemeral, wait: wait, components: components, attachments: attachments,
-        &block
-      )
+    # @see Interaction#respond
+    def respond(...)
+      @interaction.respond(...)
     end
 
-    # (see Interaction#defer)
-    def defer(flags: 0, ephemeral: true)
-      @interaction.defer(flags: flags, ephemeral: ephemeral)
+    # @see Interaction#defer
+    def defer(...)
+      @interaction.defer(...)
     end
 
-    # (see Interaction#update_message)
-    def update_message(content: nil, tts: nil, embeds: nil, allowed_mentions: nil, flags: 0, ephemeral: nil, wait: false, components: nil, attachments: nil, &block)
-      @interaction.update_message(
-        content: content, tts: tts, embeds: embeds, allowed_mentions: allowed_mentions,
-        flags: flags, ephemeral: ephemeral, wait: wait, components: components, attachments: attachments,
-        &block
-      )
+    # @see Interaction#update_message
+    def update_message(...)
+      @interaction.update_message(...)
     end
 
-    # (see Interaction#show_modal)
-    def show_modal(title:, custom_id:, components: nil, &block)
-      @interaction.show_modal(title: title, custom_id: custom_id, components: components, &block)
+    # @see Interaction#show_modal
+    def show_modal(...)
+      @interaction.show_modal(...)
     end
 
-    # (see Interaction#edit_response)
-    def edit_response(content: nil, embeds: nil, allowed_mentions: nil, components: nil, attachments: nil, &block)
-      @interaction.edit_response(content: content, embeds: embeds, allowed_mentions: allowed_mentions, components: components, attachments: attachments, &block)
+    # @see Interaction#edit_response
+    def edit_response(...)
+      @interaction.edit_response(...)
     end
 
-    # (see Interaction#delete_response)
+    # @see Interaction#delete_response
     def delete_response
       @interaction.delete_response
     end
 
-    # (see Interaction#send_message)
-    def send_message(content: nil, embeds: nil, tts: false, allowed_mentions: nil, flags: 0, ephemeral: nil, components: nil, attachments: nil, &block)
-      @interaction.send_message(content: content, embeds: embeds, tts: tts, allowed_mentions: allowed_mentions, flags: flags, ephemeral: ephemeral, components: components, attachments: attachments, &block)
+    # @see Interaction#send_message
+    def send_message(...)
+      @interaction.send_message(...)
     end
 
-    # (see Interaction#edit_message)
-    def edit_message(message, content: nil, embeds: nil, allowed_mentions: nil, attachments: nil, &block)
-      @interaction.edit_message(message, content: content, embeds: embeds, allowed_mentions: allowed_mentions, attachments: attachments, &block)
+    # @see Interaction#edit_message
+    def edit_message(...)
+      @interaction.edit_message(...)
     end
 
-    # (see Interaction#delete_message)
-    def delete_message(message)
-      @interaction.delete_message(message)
+    # @see Interaction#delete_message
+    def delete_message(...)
+      @interaction.delete_message(...)
     end
 
-    # (see Interaction#defer_update)
+    # @see Interaction#defer_update
     def defer_update
       @interaction.defer_update
     end
 
-    # (see Interaction#get_component)
-    def get_component(custom_id)
-      @interaction.get_component(custom_id)
+    # @see Interaction#get_component
+    def get_component(...)
+      @interaction.get_component(...)
     end
   end
 

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -56,10 +56,8 @@ module Discordrb::Events
 
     # # Sends a message to the channel this message was sent in, right now.
     # @see Channel#send_message!
-    def send_message!(**parameters)
-      # HACK: We can accept any arguments with `**`, and then validate the arguments when actually
-      #   unpacking them into `Channel#send_message!`
-      channel.send_message!(**parameters)
+    def send_message!(...)
+      channel.send_message!(...)
     end
 
     # Adds a string to be sent after the event has finished execution. Avoids problems with rate limiting because only


### PR DESCRIPTION
## Summary

Currently, for interaction events, we use a pattern where the same method is defined on both the event class and the `@interaction` object, with identical arguments. The event method simply forwards all arguments to the method defined on `@interaction`:

```ruby
# (see Interaction#respond)
def respond(content: nil, tts: nil, embeds: nil, allowed_mentions: nil, flags: 0, ephemeral: nil, &block)
  @interaction.respond(content: content, tts: tts, embeds: embeds, allowed_mentions: allowed_mentions, &block)
end
```

While this approach works fine, it makes it a bit more complex to add new parameters, since both methods need to be updated.

A simpler solution is to use Ruby’s `...` (triple-dot) syntax to forward all arguments. This is equivalent to:

```ruby
def my_method(*params, **kwargs, &block)
  @some_ivar.write(*params, **kwargs, &block)
end
```

However, the triple-dot syntax is only for forwarding, meaning you can't access or modify any of the arguments within the method body. There's a minor performance benefit which is that it avoids creating an intermediate array or hashe for the arguments.