### PR TITLE
fix: lazily resolve resolved message channels

### DIFF
--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -70,6 +70,7 @@ module Discordrb
       @data = data['data']
       @server_id = data['guild_id']&.to_i
       @channel_id = data['channel_id']&.to_i
+      bot.ensure_channel(data['channel']) if data['channel']
       @user = if data['member']
                 data['member']['guild_id'] = @server_id
                 Discordrb::Member.new(data['member'], bot.servers[@server_id], bot)

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -147,18 +147,13 @@ module Discordrb
       @bot = bot
       @id = data['id'].to_i
       @content = data['content']
+      @channel = bot.channel(data['channel_id'].to_i)
       @pinned = data['pinned']
       @type = data['type']
       @tts = data['tts']
       @nonce = data['nonce']
       @mention_everyone = data['mention_everyone']
       @webhook_id = data['webhook_id']&.to_i
-
-      @channel = if data['_channel_data']
-                   @bot.ensure_channel(data['_channel_data'])
-                 else
-                   bot.channel(data['channel_id'].to_i)
-                 end
 
       @referenced_message = Message.new(data['referenced_message'], bot) if data['referenced_message']
       @message_reference = data['message_reference']

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -157,7 +157,6 @@ module Discordrb::Events
       @command_id = command_data['id']
       @command_name = command_data['name'].to_sym
 
-      @channel_data = data['channel']
       @target_id = command_data['target_id']&.to_i
       @resolved = Resolved.new({}, {}, {}, {}, {}, {})
       process_resolved(command_data['resolved']) if command_data['resolved']
@@ -214,7 +213,6 @@ module Discordrb::Events
       end
 
       resolved_data['messages']&.each do |id, data|
-        data['_channel_data'] = @channel_data
         @resolved[:messages][id.to_i] = Discordrb::Message.new(data, @bot)
       end
 


### PR DESCRIPTION
## Summary

Currently, if you run a message context command where the bot is not authorized with the `bot` scope, an error occurs because the bot can't access the channel for the message. Luckily, Discord provides a decent amount of data for a partial channel which we can use instead

## Changed
`Message#server` is now lazily resolved
`Message#role_mentions` is now lazily resolved
