### PR TITLE
fix: include names on server previews

### DIFF
--- a/lib/discordrb/data/server_preview.rb
+++ b/lib/discordrb/data/server_preview.rb
@@ -33,6 +33,7 @@ module Discordrb
     def initialize(data, bot)
       @bot = bot
       @id = data['id'].to_i
+      @name = data['name']
       @icon_id = data['icon']
       @splash_id = data['splash']
       @description = data['description']


### PR DESCRIPTION
## Summary

Apparently this field is included as well, but I somehow ended up removing it right before making the PR.

## Added
`ServerPreview#name`