### PR TITLE
feat: Message#mentions?

### DIFF
--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -387,6 +387,17 @@ module Discordrb
       Message.new(JSON.parse(response), @bot)
     end
 
+    # Check if this message mentions a specific user or role.
+    # @param target [Role, User, Member, Integer, String] The mention to match against.
+    # @return [true, false] whether or not this message mentions the target.
+    def mentions?(target)
+      mentions = (@mentions + role_mentions)
+
+      mentions << server if @mention_everyone
+
+      mentions.any?(target.resolve_id)
+    end
+
     # Reacts to a message.
     # @param reaction [String, #to_reaction] the unicode emoji or {Emoji}
     def create_reaction(reaction)


### PR DESCRIPTION
## Summary

This PR adds the `Message#mentions?` method that can be used to check if a role or user was mentioned in a message. Additionally, I discovered one bug while adding this method:

```ruby
# Role mentions can only happen on public servers so make sure we only parse them there
if @channel.text?
  data['mention_roles']&.each do |element|
    @role_mentions << @channel.server.role(element.to_i)
  end
end
 ``` 
 This is actually incorrect because role mentions can happen in places like threads, news channels, stage channels, etc. I didn't bother fixing the bug in this PR because there's already another PR which fixes it: https://github.com/shardlab/discordrb/pull/352

## Added
`Message#mentions?`