### PR TITLE
feat: handle USER_UPDATE events

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1276,6 +1276,8 @@ module Discordrb
         id = data['guild_id'].to_i
         server = server(id)
         server.process_chunk(data['members'], data['chunk_index'], data['chunk_count'])
+      when :USER_UPDATE
+        @profile = Profile.new(data, self)
       when :INVITE_CREATE
         invite = Invite.new(data, self)
         raise_event(InviteCreateEvent.new(data, invite, self))


### PR DESCRIPTION
## Summary

Discord has a [USER_UPDATE](https://discord.com/developers/docs/events/gateway-events#user-update) event which is fired whenever info about the bot's current user changes. You'd think that we'd already be covered by the `:GUILD_MEMBER_UPDATE` event for this case, but I've noticed that `:GUILD_MEMBER_UPDATE` doesn't fire whenever properties about the current bot change without the `:server_members` intent.

## Added
```ruby
when :USER_UPDATE
  @profile = Profile.new(data, self)
```