### PR TITLE
feat: add server attribute to MESSAGE_DELETE

### DIFF
--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -33,6 +33,7 @@ module Discordrb
     # @option attributes [Time] :before Matches a time before the time the message was sent at.
     # @option attributes [Boolean] :private Matches whether or not the channel is private.
     # @option attributes [Integer, String, Symbol] :type Matches the type of the message that was sent.
+    # @option attributes [Server, Integer, String] :server Matches the server the message was sent in.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [MessageEvent] The event that was raised.
     # @return [MessageEventHandler] the event handler that was registered.
@@ -95,6 +96,7 @@ module Discordrb
     # @option attributes [String, Integer] :id Matches the ID of the message that was edited.
     # @option attributes [String, Integer, Channel] :in Matches the channel the message was edited in.
     # @option attributes [Integer, String, Symbol] :type Matches the type of the message that was edited.
+    # @option attributes [Server, Integer, String] :server Matches the server the message was edited in.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [MessageEditEvent] The event that was raised.
     # @return [MessageEditEventHandler] the event handler that was registered.
@@ -106,6 +108,7 @@ module Discordrb
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String, Integer] :id Matches the ID of the message that was deleted.
     # @option attributes [String, Integer, Channel] :in Matches the channel the message was deleted in.
+    # @option attributes [Server, Integer, String] :server Matches the server the message was deleted in.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [MessageDeleteEvent] The event that was raised.
     # @return [MessageDeleteEventHandler] the event handler that was registered.
@@ -121,6 +124,7 @@ module Discordrb
     # @option attributes [String, Integer] :id Matches the ID of the message that was updated.
     # @option attributes [String, Integer, Channel] :in Matches the channel the message was updated in.
     # @option attributes [Integer, String, Symbol] :type Matches the type of the message that was updated.
+    # @option attributes [Server, Integer, String] :server Matches the server the message was updated in.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [MessageUpdateEvent] The event that was raised.
     # @return [MessageUpdateEventHandler] the event handler that was registered.

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -54,7 +54,7 @@ module Discordrb::Events
       channel.send_temporary_message(content, timeout, tts, embed, attachments, allowed_mentions, components, flags)
     end
 
-    # # Sends a message to the channel this message was sent in, right now.
+    # Sends a message to the channel this message was sent in, right now.
     # @see Channel#send_message!
     def send_message!(...)
       channel.send_message!(...)
@@ -272,7 +272,8 @@ module Discordrb::Events
         end,
         matches_all(@attributes[:after], event.timestamp) { |a, e| a > e },
         matches_all(@attributes[:before], event.timestamp) { |a, e| a < e },
-        matches_all(@attributes[:private], event.channel.private?) { |a, e| !e == !a }
+        matches_all(@attributes[:private], event.channel.private?) { |a, e| !e == !a },
+        matches_all(@attributes[:server], event.server) { |a, e| a&.resolve_id == e&.resolve_id }
       ].reduce(true, &:&)
     end
 
@@ -305,10 +306,14 @@ module Discordrb::Events
     # @return [Integer] the ID associated with this event
     attr_reader :id
 
+    # @return [Server, nil] the server associated with this event
+    attr_reader :server
+
     # @!visibility private
     def initialize(data, bot)
       @id = data['id'].to_i
       @channel = bot.channel(data['channel_id'].to_i)
+      @server = @channel.server
       @saved_message = ''
       @bot = bot
     end
@@ -334,6 +339,9 @@ module Discordrb::Events
           else
             a == e
           end
+        end,
+        matches_all(@attributes[:server], event.server) do |a, e|
+          a&.resolve_id == e&.resolve_id
         end
       ].reduce(true, &:&)
     end

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -169,14 +169,14 @@ describe Discordrb::Events do
       describe 'end_with attribute' do
         it "matches #{matching}" do
           handler = Discordrb::Events::MessageEventHandler.new({ end_with: expr }, double('proc'))
-          event = double('event', channel: double('channel', private?: false), author: double('author'), timestamp: double('timestamp'), content: matching, message: double('message', type: 0))
+          event = double('event', channel: double('channel', private?: false), author: double('author'), timestamp: double('timestamp'), content: matching, message: double('message', type: 0), server: true)
           allow(event).to receive(:is_a?).with(Discordrb::Events::MessageEvent).and_return(true)
           expect(handler.matches?(event)).to be_truthy
         end
 
         it "doesn't match #{non_matching}" do
           handler = Discordrb::Events::MessageEventHandler.new({ end_with: expr }, double('proc'))
-          event = double('event', channel: double('channel', private?: false), author: double('author'), timestamp: double('timestamp'), content: non_matching, message: double('message', type: 0))
+          event = double('event', channel: double('channel', private?: false), author: double('author'), timestamp: double('timestamp'), content: non_matching, message: double('message', type: 0), server: true)
           allow(event).to receive(:is_a?).with(Discordrb::Events::MessageEvent).and_return(true)
           expect(handler.matches?(event)).to be_falsy
         end


### PR DESCRIPTION
## Summary

All of our message events except `message_delete` support accessing `#server` directly. I went and added `#server` on `MessageIDEvent` since it might be good to have consistent attributes on similar events, but it's understandable if this is not something that should be done.
