### PR TITLE
fix: server boost caching

### DIFF
--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -64,25 +64,20 @@ module Discordrb
     # @!visibility private
     def initialize(data, bot)
       @bot = bot
-      @owner_id = data['owner_id'].to_i
       @id = data['id'].to_i
       @members = {}
       @voice_states = {}
       @emoji = {}
 
-      process_channels(data['channels'])
       update_data(data)
 
       # Whether this server's members have been chunked (resolved using op 8 and GUILD_MEMBERS_CHUNK) yet
       @chunked = false
-
-      @booster_count = data['premium_subscription_count'] || 0
-      @boost_level = data['premium_tier']
     end
 
     # @return [Member] The server owner.
     def owner
-      @owner ||= member(@owner_id)
+      member(@owner_id)
     end
 
     # The default channel is the text channel on this server with the highest position
@@ -876,6 +871,9 @@ module Discordrb
       @splash_id = new_data['splash'] || @splash_id
       @banner_id = new_data['banner'] || @banner_id
       @features = new_data['features'] ? new_data['features'].map { |element| element.downcase.to_sym } : @features || []
+      @booster_count = new_data['premium_subscription_count'] || @booster_count || 0
+      @boost_level = new_data['premium_tier'] || @boost_level
+      @owner_id = new_data['owner_id'].to_i
 
       process_channels(new_data['channels']) if new_data['channels']
       process_roles(new_data['roles']) if new_data['roles']


### PR DESCRIPTION
## Summary

I think `GUILD_UPDATE` is fired whenever someone boosts a server, or it loses a boost. Unfortunately, I don't think we have anything that updates this in the cache, which is what's probably causing the cache to become stale.

- So while I was going through the initializer, I saw that we actually double cache channels on `:GUILD_CREATE`. This is because the initializer called `#process_channels` and then `#update_data` would also call that method again. I think it's safe to say that we probably only should call this once.

- Another thing is that the server's owner can change, and bots will get a `:GUILD_UPDATE` when that happens. Unfortunately, this means we can't memoize the owner, since there's a possibility that the memoized owner isn't the same as the `@owner_id` variable. I learned this the hard way when someone transferred ownership of a server my bot was in and permissions were getting incorrectly calculated, since [`PermissionCalculator#permission?`](https://github.com/shardlab/discordrb/blob/0752e573194cd038346fbf6ec237b316f7c9ac8d/lib/discordrb/permissions.rb#L165) checks for ownership.