### PR TITLE
feat: fix thread caching

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1472,7 +1472,7 @@ module Discordrb
       when :CHANNEL_PINS_UPDATE
         event = ChannelPinsUpdateEvent.new(data, self)
 
-        event.channel.process_last_pin_timestamp(event.last_pin_timestamp) if event.last_pin_timestamp
+        event.channel.process_last_pin_timestamp(data['last_pin_timestamp']) if data.key?('last_pin_timestamp')
 
         raise_event(event)
       when :GUILD_MEMBER_ADD

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -998,7 +998,7 @@ module Discordrb
     # @note For internal use only
     # @!visibility private
     def process_last_pin_timestamp(time)
-      @last_pin_timestamp = time.is_a?(String) ? Time.parse(time) : time
+      @last_pin_timestamp = time ? Time.parse(time) : time
     end
 
     # Updates the cached data with new data
@@ -1016,7 +1016,6 @@ module Discordrb
       @parent_id = new_data[:parent_id] || new_data['parent_id'] || @parent_id
       process_permission_overwrites(new_data[:permission_overwrites] || new_data['permission_overwrites'])
       @rate_limit_per_user = new_data[:rate_limit_per_user] || new_data['rate_limit_per_user'] || @rate_limit_per_user
-      process_last_pin_timestamp(new_data['last_pin_timestamp']) if new_data['last_pin_timestamp']
     end
 
     # @return [String] a URL that a user can use to navigate to this channel in the client


### PR DESCRIPTION
# Summary

This PR fixes a small issue where thread related fields never ever get updated on `THREAD_UPDATE`. This was because even though we call `Channel#update_from(other)`, there's nothing in the method body which actually updates the thread-related fields.

## Added
`Channel#last_pin_timestamp`
Missing predicate alias for `Channel#archived`
Missing predicate alias for `Channel#invitable`

## Fixed
Thread-specific attributes never getting updated
