### PR TITLE
feat: gateway timeout

### DIFF
--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -152,6 +152,11 @@ module Discordrb
     # - 4014: Use of disabled privileged intents.
     FATAL_CLOSE_CODES = [4003, 4004, 4011, 4014].freeze
 
+    # The timeout in seconds for responses from Discord when expecting one.
+    # This is used when expecting a hello message after the initial connection
+    # and when expecting a heartbeat ack after sending a heartbeat (if {#check_heartbeat_acks} is true).
+    RESPONSE_TIMEOUT = ENV['DISCORDRB_GATEWAY_TIMEOUT']&.to_f
+
     # Heartbeat ACKs are Discord's way of verifying on the client side whether the connection is still alive. If this is
     # set to true (default value) the gateway client will use that functionality to detect zombie connections and
     # reconnect in such a case; however it may lead to instability if there's some problem with the ACKs. If this occurs
@@ -279,6 +284,9 @@ module Discordrb
         end
 
         @last_heartbeat_acked = false
+
+        # A heartbeat ack should be received quickly after heartbeat
+        socket_timeout(0)
       end
 
       send_heartbeat(@session ? @session.sequence : 0)
@@ -451,9 +459,24 @@ module Discordrb
 
     private
 
+    def socket_timeout(duration)
+      return unless RESPONSE_TIMEOUT
+
+      duration += RESPONSE_TIMEOUT
+      if @socket.respond_to?(:timeout=)
+        @socket.timeout = duration
+        LOGGER.debug("Set socket timeout to #{duration}")
+      else # Ruby version < 3.4
+        LOGGER.debug("Socket timeout unsupported on Ruby < 3.4; skipping timeout configuration (current: #{RUBY_VERSION})")
+      end
+    end
+
     def setup_heartbeats(interval)
       # Make sure to reset ACK handling, so we don't keep reconnecting
       @last_heartbeat_acked = true
+
+      # Socket timeout needs to be larger than heartbeat interval
+      socket_timeout(interval + 1)
 
       # We don't want to have redundant heartbeat threads, so if one already exists, don't start a new one
       return if @heartbeat_thread
@@ -588,6 +611,9 @@ module Discordrb
       @socket = obtain_socket(gateway_uri)
       LOGGER.debug('Obtained socket')
 
+      # A hello message should be received quickly after it is connected
+      socket_timeout(0)
+
       # Initialise some properties
       @handshake = ::WebSocket::Handshake::Client.new(url: url) # Represents the handshake between us and the server
       @handshaked = false # Whether the handshake has finished yet
@@ -622,6 +648,10 @@ module Discordrb
           rescue EOFError
             @pipe_broken = true
             handle_internal_close('Socket EOF in websocket_loop')
+            next
+          rescue IO::TimeoutError
+            @pipe_broken = true
+            handle_internal_close('Socket did not receive a response in time')
             next
           end
 
@@ -804,7 +834,10 @@ module Discordrb
     # Op 11
     def handle_heartbeat_ack(packet)
       LOGGER.debug("Received heartbeat ack for packet: #{packet.inspect}")
-      @last_heartbeat_acked = true if @check_heartbeat_acks
+      return unless @check_heartbeat_acks
+
+      @last_heartbeat_acked = true
+      socket_timeout(@heartbeat_interval + 1)
     end
 
     # Called when the websocket has been disconnected in some way - say due to a pipe error while sending


### PR DESCRIPTION
# Summary

While Discordrb has been working flawlessly on my machine, after I moved to another place, it starts seeing errors like tihs frequently:

```
[WARN : heartbeat @ 2025-10-15 20:45:43.756] Last heartbeat was not acked, so this is a zombie connection! Reconnecting
[ERROR : heartbeat @ 2025-10-15 20:45:43.756] The websocket connection has closed: (no information)
[ERROR : websocket @ 2025-10-15 21:00:53.264] An error occurred in the main websocket loop!
[ERROR : websocket @ 2025-10-15 21:00:53.264] Exception: #<Errno::ETIMEDOUT: Connection timed out>
[ERROR : websocket @ 2025-10-15 21:00:53.264] /usr/local/lib/ruby/3.4.0/openssl/buffering.rb:160:in 'OpenSSL::SSL::SSLSocket#sysread'
[ERROR : websocket @ 2025-10-15 21:00:53.264] /usr/local/lib/ruby/3.4.0/openssl/buffering.rb:160:in 'OpenSSL::Buffering#readpartial'
[ERROR : websocket @ 2025-10-15 21:00:53.264] /usr/local/bundle/gems/discordrb-3.5.0/lib/discordrb/gateway.rb:602:in 'Discordrb::Gateway#websocket_loop'
[ERROR : websocket @ 2025-10-15 21:00:53.264] /usr/local/bundle/gems/discordrb-3.5.0/lib/discordrb/gateway.rb:579:in 'Discordrb::Gateway#connect'
[ERROR : websocket @ 2025-10-15 21:00:53.264] /usr/local/bundle/gems/discordrb-3.5.0/lib/discordrb/gateway.rb:473:in 'block in Discordrb::Gateway#connect_loop'
[ERROR : websocket @ 2025-10-15 21:00:53.264] <internal:kernel>:168:in 'Kernel#loop'
[ERROR : websocket @ 2025-10-15 21:00:53.265] /usr/local/bundle/gems/discordrb-3.5.0/lib/discordrb/gateway.rb:472:in 'Discordrb::Gateway#connect_loop'
[ERROR : websocket @ 2025-10-15 21:00:53.265] /usr/local/bundle/gems/discordrb-3.5.0/lib/discordrb/gateway.rb:168:in 'block in Discordrb::Gateway#run_async'
[INFO : websocket @ 2025-10-15 21:00:53.265] Instant reconnection flag was set - reconnecting right away
[INFO : websocket @ 2025-10-15 21:00:54.008] Discord using gateway protocol version: 9, requested: 9
```

Notice that the time between the two errors is 15min 10s (and it always is whenever this happens), which is a pretty long time for a Discord bot to be down. This timeout threshold is probably set somewhere in `/proc/sys/net/ipv4/tcp_*`(and nowhere else sets a timeout, so it will otherwise just hang indefinitely), but I am not sure. Anyway, the workaround that I have come up with requires some modification to Discordrb which I have done in this PR. It should not affect any existing users, but will help in this particular case where the socket becomes zombie before the first hello message.

I am not sure whether the 2s initial timeout I set here is too short or not, but I think it will not normally be exceeded even in very poor network conditions. If it is too short, I can make it to be configurable by an environment variable so that people can set this according to the network condition.

## Added

Sets a timeout on the socket connected to Discord gateway.

## Changed

## Deprecated

## Removed

## Fixed
