### PR TITLE
feat: Member#sort_roles

### DIFF
--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -284,6 +284,12 @@ module Discordrb
 
     alias_method :color, :colour
 
+    # Get the member's roles sorted by their order in the hierarchy.
+    # @return [Array<Role>] the roles the member has, ordered by hierarchy.
+    def sort_roles
+      roles.sort_by { |role| [role.position, role.id] }
+    end
+
     # Server deafens this member.
     # @param reason [String, nil] The reason for defeaning this member.
     def server_deafen(reason: nil)


### PR DESCRIPTION
## Summary

This PR adds a `#sorted_roles` method. Sometimes, you may want to get a list of roles a member has sorted by hierarchical order. Usually in most cases doing something like `event.user.roles.sort_by(&:position)` is fine. But what some folks may not know, is that two roles can sometimes share the same `#position`. Apparently in this case, the `#id` field should be used to check which role is higher

## Added
`Member#sort_roles`