### PR TITLE
fix: update rubygems release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       packages: write
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
 
     steps:
       - uses: actions/checkout@v4
@@ -26,8 +27,6 @@ jobs:
           done
 
       - uses: rubygems/release-gem@v1
-        with:
-          api_key: ${{ secrets.RUBYGEMS_API_KEY }}
 
       - name: Publish to GitHub Packages
         env:


### PR DESCRIPTION
Add missing job permissions and remove unnecessary keys to use secure deployments from rubygems