### PR TITLE
Support base64 versions "0.x"

### DIFF
--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'base64', '~> 0.2.0'
+  spec.add_dependency 'base64', '~> 0.2'
   spec.add_dependency 'ffi', '>= 1.9.24'
   spec.add_dependency 'opus-ruby'
   spec.add_dependency 'rest-client', '>= 2.0.0'


### PR DESCRIPTION
# Summary

Support dependency to base64 0.3.0.

Chagelog: https://github.com/ruby/base64/releases/tag/v0.3.0
