### PR TITLE
fix: editing application command permissions

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -887,12 +887,16 @@ module Discordrb
     # @param command_id [Integer, String]
     # @param server_id [Integer, String]
     # @param permissions [Array<Hash>] An array of objects formatted as `{ id: ENTITY_ID, type: 1 or 2, permission: true or false }`
-    def edit_application_command_permissions(command_id, server_id, permissions = [])
+    # @param bearer_token [String] A valid bearer token that has permission to manage the server and its roles.
+    def edit_application_command_permissions(command_id, server_id, permissions = [], bearer_token = nil)
       builder = Interactions::PermissionBuilder.new
       yield builder if block_given?
 
+      raise ArgumentError, 'This method requires a valid bearer token to be provided' unless bearer_token
+
       permissions += builder.to_a
-      API::Application.edit_guild_command_permissions(@token, profile.id, server_id, command_id, permissions)
+      bearer_token = "Bearer #{bearer_token.delete_prefix('Bearer ')}"
+      API::Application.edit_guild_command_permissions(bearer_token, profile.id, server_id, command_id, permissions)
     end
 
     # Fetches all the application emojis that the bot can use.


### PR DESCRIPTION
# Summary

This was apparently a breaking change from Discord, as using this endpoint now requires a bearer token. https://discord.com/developers/docs/change-log#updated-command-permissions

> This endpoint requires authentication with a Bearer token that has permission to manage the guild and its roles

> Command permissions can only be updated using a [Bearer token](https://discord.com/developers/docs/topics/oauth2#client-credentials-grant). Authenticating with a bot token will result in an error.