### PR TITLE
fix: prevent #channels from being nil

### DIFF
--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -68,6 +68,8 @@ module Discordrb
       @members = {}
       @voice_states = {}
       @emoji = {}
+      @channels = []
+      @channels_by_id = {}
 
       update_data(data)
 


### PR DESCRIPTION
# Summary

This only occurs for servers fetched via the REST API. There's also the problem of `#channels` always being empty when fetched via REST, since channel data is only provided on `:GUILD_CREATE` events, but that should probably be tackled separately.