### PR TITLE
feat: new timestamp styles

### DIFF
--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -65,7 +65,9 @@ module Discordrb
     long_date: 'D', # 20 April 2021
     short_datetime: 'f', # 20 April 2021 16:20
     long_datetime: 'F', # Tuesday, 20 April 2021 16:20
-    relative: 'R' # 2 months ago
+    relative: 'R', # 2 months ago
+    simple_datetime: 's', # 20/04/2021, 16:20
+    medium_datetime: 'S' # 20/04/2021, 16:20:30
   }.freeze
 
   # Splits a message into chunks of 2000 characters. Attempts to split by lines if possible.


### PR DESCRIPTION
## Summary

This PR adds the two new `s` and `S` timestamp formatting styles. I tried to come up with appropriate names for these, since I couldn't use what they listed in the table, because the existing names for some of the other timestamp styles was changed.

## Added
`:simple_datetime`
`:medium_datetime`