### PR TITLE
feat: static nameplate URLs

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -241,6 +241,11 @@ module Discordrb::API
     "#{cdn_url}/avatar-decoration-presets/#{avatar_decoration_id}.#{format}"
   end
 
+  # make a static nameplate URL from the nameplate asset.
+  def static_nameplate_url(nameplate_asset, format = 'png')
+    "#{cdn_url}/assets/collectibles/#{nameplate_asset.delete_suffix('/')}/static.#{format}"
+  end
+
   # make a nameplate URL from the nameplate asset.
   def nameplate_url(nameplate_asset, format = 'webm')
     "#{cdn_url}/assets/collectibles/#{nameplate_asset.delete_suffix('/')}/asset.#{format}"

--- a/lib/discordrb/data/collectibles.rb
+++ b/lib/discordrb/data/collectibles.rb
@@ -36,9 +36,11 @@ module Discordrb
       end
 
       # Utility method to get the URL of this nameplate.
-      # @return [String] CDN url of this nameplate.
-      def url
-        API.nameplate_url(@asset)
+      # @param static [true, false] Whether to return the static URL of this
+      #   nameplate instead of the animated URL.
+      # @return [String] The CDN url of this nameplate.
+      def url(static: false)
+        static ? API.static_nameplate_url(@asset) : API.nameplate_url(@asset)
       end
     end
   end


### PR DESCRIPTION
# Summary

Nameplates have another path, where they render a single static frame, instead of an animated `webm` video. `/asset.webm` vs. `/static.png`
