### PR TITLE
feat: improve user caching

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1157,7 +1157,7 @@ module Discordrb
       if (member = server.member(data['user']['id'].to_i, false))
         member.update_data(data)
       else
-        ensure_user(data['user'])
+        ensure_user(data['user'], true)
       end
     end
 
@@ -1289,6 +1289,7 @@ module Discordrb
         # replaced.
         init_cache
 
+        data['user']['public_flags'] = data['user']['flags']
         @profile = Profile.new(data['user'], self)
 
         @client_id ||= data['application']['id']&.to_i
@@ -1326,7 +1327,8 @@ module Discordrb
         server = server(id)
         server.process_chunk(data['members'], data['chunk_index'], data['chunk_count'])
       when :USER_UPDATE
-        @profile = Profile.new(data, self)
+        @users[data['id'].to_i]&.update_data(data)
+        @profile ? @profile.update_data(data) : (@profile = Profile.new(data, self))
       when :INVITE_CREATE
         invite = Invite.new(data, self)
         raise_event(InviteCreateEvent.new(data, invite, self))
@@ -1351,13 +1353,32 @@ module Discordrb
         # If create_message is overwritten with a method that returns the parsed message, use that instead, so we don't
         # parse the message twice (which is just thrown away performance)
         message = create_message(data)
-        message = Message.new(data, self) unless message.is_a? Message
+        message = Message.new(data, self) unless message.is_a?(Message)
 
-        # Update the existing member if it exists in the cache.
-        if data['member']
-          member = message.channel.server&.member(data['author']['id'].to_i, false)
-          data['member']['user'] = data['author']
-          member&.update_data(data['member'])
+        if (server = message.server)
+          # Update or create the existing member from the given data hash.
+          if data['member']
+            data['member']['user'] = data['author']
+            cached_member = server.member(data['author']['id'], false)
+
+            if cached_member
+              cached_member&.update_data(data['member'])
+            else
+              server.cache_member(Member.new(data['member'], server, self))
+            end
+          end
+
+          data['mentions']&.each do |mention|
+            next unless (member = mention['member'])
+
+            member['user'] = mention
+
+            if (cached_member = server.member(mention['id'], false))
+              cached_member&.update_data(mention['member'])
+            else
+              server.cache_member(Member.new(mention['member'], server, self))
+            end
+          end
         end
 
         # Dispatch a ChannelCreateEvent for channels we don't have cached
@@ -1406,11 +1427,30 @@ module Discordrb
           return
         end
 
-        # Update the existing member if it exists in the cache.
-        if data['member']
-          member = message.channel.server&.member(data['author']['id'].to_i, false)
-          data['member']['user'] = data['author']
-          member&.update_data(data['member'])
+        if (server = message.server)
+          # Update or create the existing member from the given data hash.
+          if data['member']
+            data['member']['user'] = data['author']
+            cached_member = server.member(data['author']['id'], false)
+
+            if cached_member
+              cached_member&.update_data(data['member'])
+            else
+              server.cache_member(Member.new(data['member'], server, self))
+            end
+          end
+
+          data['mentions']&.each do |mention|
+            next unless (member = mention['member'])
+
+            member['user'] = mention
+
+            if (cached_member = server.member(mention['id'], false))
+              cached_member&.update_data(mention['member'])
+            else
+              server.cache_member(Member.new(mention['member'], server, self))
+            end
+          end
         end
 
         event = MessageEditEvent.new(message, self)
@@ -1438,6 +1478,14 @@ module Discordrb
         end
       when :TYPING_START
         start_typing(data)
+
+        if (member = data['member']) && (server = @servers[data['guild_id']&.to_i])
+          if (found = server.member(member['user']['id'], false))
+            found.update_data(member)
+          else
+            server.cache_member(Member.new(member, server, self))
+          end
+        end
 
         begin
           event = TypingEvent.new(data, self)

--- a/lib/discordrb/cache.rb
+++ b/lib/discordrb/cache.rb
@@ -150,10 +150,13 @@ module Discordrb
 
     # Ensures a given user object is cached and if not, cache it from the given data hash.
     # @param data [Hash] A data hash representing a user.
+    # @param force_cache [true, false] Whether the object in cache should be updated with the given
+    #   data if it already exists.
     # @return [User] the user represented by the data hash.
-    def ensure_user(data)
-      if @users.include?(data['id'].to_i)
-        @users[data['id'].to_i]
+    def ensure_user(data, force_cache = false)
+      if (user = @users[data['id'].to_i])
+        user.update_data(data) if force_cache
+        user
       else
         @users[data['id'].to_i] = User.new(data, self)
       end
@@ -165,8 +168,7 @@ module Discordrb
     #   data if it already exists.
     # @return [Server] the server represented by the data hash.
     def ensure_server(data, force_cache = false)
-      if @servers.include?(data['id'].to_i)
-        server = @servers[data['id'].to_i]
+      if (server = @servers[data['id'].to_i])
         server.update_data(data) if force_cache
         server
       else
@@ -179,8 +181,8 @@ module Discordrb
     # @param server [Server, nil] The server the channel is on, if known.
     # @return [Channel] the channel represented by the data hash.
     def ensure_channel(data, server = nil)
-      if @channels.include?(data['id'].to_i)
-        @channels[data['id'].to_i]
+      if (channel = @channels[data['id'].to_i])
+        channel
       else
         @channels[data['id'].to_i] = Channel.new(data, self, server)
       end

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -113,7 +113,7 @@ module Discordrb
                 data['member']['guild_id'] = @server_id
                 Discordrb::Member.new(data['member'], bot.servers[@server_id], bot)
               else
-                bot.ensure_user(data['user'])
+                bot.ensure_user(data['user'], true)
               end
       @token = data['token']
       @version = data['version']
@@ -1066,8 +1066,8 @@ module Discordrb
         @message = message
         @id = data['id'].to_i
         @type = data['type']
-        @user = bot.ensure_user(data['user']) if data['user']
-        @target_user = bot.ensure_user(data['target_user']) if data['target_user']
+        @user = bot.ensure_user(data['user'], true) if data['user']
+        @target_user = bot.ensure_user(data['target_user'], true) if data['target_user']
         @target_message_id = data['target_message_id']&.to_i
         @triggering_metadata = Metadata.new(data['triggering_interaction_metadata'], @message, @bot) if data['triggering_interaction_metadata']
         @interacted_message_id = data['interacted_message_id']&.to_i

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -118,7 +118,7 @@ module Discordrb
     def initialize(data, server, bot)
       @bot = bot
 
-      @user = bot.ensure_user(data['user'])
+      @user = bot.ensure_user(data['user'], true)
       super(@user) # Initialize the delegate class
 
       @server = server
@@ -469,13 +469,7 @@ module Discordrb
         @boosting_since = data['premium_since'] ? Time.parse(data['premium_since']) : nil
       end
 
-      if (user = data['user'])
-        @user.update_global_name(user['global_name']) if user['global_name']
-        @user.avatar_id = user['avatar'] if user.key('avatar')
-        @user.update_avatar_decoration(user['avatar_decoration_data']) if user.key?('avatar_decoration_data')
-        @user.update_collectibles(user['collectibles']) if user.key?('collectibles')
-        @user.update_primary_server(user['primary_guild']) if user.key?('primary_guild')
-      end
+      @user.update_data(data['user']) if data['user']
 
       @server_collectibles = Collectibles.new(data['collectibles'] || {}, @bot) if data.key?('collectibles')
       @server_avatar_decoration = process_avatar_decoration(data['avatar_decoration_data']) if data.key?('avatar_decoration_data')

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -196,14 +196,18 @@ module Discordrb
 
           # Turn the message user into a recipient - we can't use the channel recipient
           # directly because the bot may also send messages to the channel
-          @author = Recipient.new(@bot.user(data['author']['id'].to_i), @channel, @bot)
+          @author = Recipient.new(@bot.ensure_user(data['author']), @channel, @bot)
         else
+          # Cache the user-data to avoid network requests in {Channel#history} contexts when the
+          # author has left the server. Skip if the message is from a guild sent via MESSAGE_CREATE.
+          @bot.ensure_user(data['author'], true) unless data['member']
+
           @author_id = data['author']['id'].to_i
         end
       end
 
       @reactions = data['reactions']&.map { |reaction| Reaction.new(reaction) } || []
-      @mentions = data['mentions']&.map { |mention| @bot.ensure_user(mention) } || []
+      @mentions = data['mentions']&.map { |mention| @bot.ensure_user(mention, true) } || []
       @mention_roles = data['mention_roles']&.map(&:to_i) || []
       @poll_result = Poll::Result.new(data['embeds'].pop, @message_reference, @bot) if @type == 46
 
@@ -446,7 +450,7 @@ module Discordrb
 
       get_reactions = proc do |fetch_limit, after_id = nil|
         resp = API::Channel.get_reactions(@bot.token, @channel.id, @id, reaction, nil, after_id, fetch_limit, type)
-        JSON.parse(resp).map { |d| User.new(d, @bot) }
+        JSON.parse(resp).map { |user_data| @bot.ensure_user(user_data, true) }
       end
 
       # Can be done without pagination

--- a/lib/discordrb/data/poll.rb
+++ b/lib/discordrb/data/poll.rb
@@ -188,7 +188,7 @@ module Discordrb
 
         get_users = lambda do |limit, after|
           data = API::Channel.get_poll_voters(@bot.token, channel_id, @message_id, @id, after:, limit:)
-          JSON.parse(data)['users'].collect { |poll_voter_data| @bot.ensure_user(poll_voter_data) }
+          JSON.parse(data)['users'].collect { |poll_voter_data| @bot.ensure_user(poll_voter_data, true) }
         end
 
         return get_users.call(limit, after_time) if limit && limit <= 100

--- a/lib/discordrb/data/profile.rb
+++ b/lib/discordrb/data/profile.rb
@@ -52,18 +52,16 @@ module Discordrb
       @bot.application.modify(description: bio)
     end
 
-    # Updates the cached profile data with the new one.
-    # @note For internal use only.
     # @!visibility private
     def update_data(new_data)
-      @username = new_data['username']
-      @avatar_id = new_data['avatar']
+      super
+
       @banner_id = new_data['banner']
     end
 
     # The inspect method is overwritten to give more useful output
     def inspect
-      "<Profile user=#{super}>"
+      "<Profile #{super[6..]}"
     end
 
     private

--- a/lib/discordrb/data/scheduled_event.rb
+++ b/lib/discordrb/data/scheduled_event.rb
@@ -219,7 +219,7 @@ module Discordrb
     def users(limit: 100, member: false)
       get_users = proc do |fetch_limit, after = nil|
         response = JSON.parse(API::Server.get_scheduled_event_users(@bot.token, @server_id, @id, limit: fetch_limit, with_member: member, after: after))
-        response.map { |data| data['member'] ? Member.new(data['member'], server, @bot).tap { |member| server&.cache_member(member) } : User.new(data['user'], @bot) }
+        response.map { |data| data['member'] ? Member.new(data['member'], server, @bot).tap { |member| server&.cache_member(member) } : @bot.ensure_user(data['user'], true) }
       end
 
       # Can be done without pagination.

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -182,8 +182,8 @@ module Discordrb
     # @param request [true, false] Whether the member should be requested from Discord if it's not cached
     def member(id, request = true)
       id = id.resolve_id
-      return @members[id] if member_cached?(id)
-      return nil unless request
+      member = @members[id]
+      return member if member || !request
 
       member = @bot.member(self, id)
       @members[id] = member unless member.nil?

--- a/lib/discordrb/data/snapshot.rb
+++ b/lib/discordrb/data/snapshot.rb
@@ -41,7 +41,7 @@ module Discordrb
       @attachments = data['attachments']&.map { |file| Attachment.new(file, self, @bot) } || []
       @created_at = data['timestamp'] ? Time.parse(data['timestamp']) : nil
       @edited_at = data['edited_timestamp'] ? Time.parse(data['edited_timestamp']) : nil
-      @mentions = data['mentions']&.map { |mention| @bot.ensure_user(mention) } || []
+      @mentions = data['mentions']&.map { |mention| @bot.ensure_user(mention, true) } || []
       @components = data['components']&.map { |component| Components.from_data(component, @bot) } || []
     end
 

--- a/lib/discordrb/data/user.rb
+++ b/lib/discordrb/data/user.rb
@@ -136,10 +136,9 @@ module Discordrb
     # @!visibility private
     def initialize(data, bot)
       @bot = bot
-
+      @id = data['id'].to_i
       @username = data['username']
       @global_name = data['global_name']
-      @id = data['id'].to_i
       @discriminator = data['discriminator']
       @avatar_id = data['avatar']
       @activities = Discordrb::ActivitySet.new
@@ -151,10 +150,9 @@ module Discordrb
       @client_status = process_client_status(data['client_status'])
       @banner_id = data['banner']
       @system_account = data['system'] || false
+      @primary_server = process_primary_server(data['primary_guild'])
+      @collectibles = Collectibles.new(data['collectibles'] || {}, @bot)
       @avatar_decoration = process_avatar_decoration(data['avatar_decoration_data'])
-      @collectibles = Collectibles.new(data['collectibles'] || {}, bot)
-
-      @primary_server = process_primary_server(data['primary_guild'] || {})
     end
 
     # Get a user's PM channel or send them a PM
@@ -210,27 +208,6 @@ module Discordrb
       @global_name = global_name
     end
 
-    # Set the user's avatar_decoration
-    # @note For internal use only.
-    # @!visibility private
-    def update_avatar_decoration(decoration)
-      @avatar_decoration = process_avatar_decoration(decoration)
-    end
-
-    # Set the user's collectibles
-    # @note For internal use only.
-    # @!visibility private
-    def update_collectibles(collectibles)
-      @collectibles = Collectibles.new(collectibles || {}, @bot)
-    end
-
-    # Set the user's primary server
-    # @note For internal use only.
-    # @!visibility private
-    def update_primary_server(server)
-      @primary_server = process_primary_server(server || {})
-    end
-
     # Set the user's presence data
     # @note for internal use only
     # @!visibility private
@@ -276,12 +253,12 @@ module Discordrb
 
     # @!visibility private
     def process_avatar_decoration(decoration)
-      decoration ? AvatarDecoration.new(decoration, @bot) : nil
+      AvatarDecoration.new(decoration, @bot) if decoration
     end
 
     # @!visibility private
     def process_primary_server(server)
-      PrimaryServer.new(server, @bot) if server['identity_enabled']
+      PrimaryServer.new(server, @bot) if server&.[]('identity_enabled')
     end
 
     # @!method offline?
@@ -319,6 +296,18 @@ module Discordrb
     # The inspect method is overwritten to give more useful output
     def inspect
       "<User username=#{@username} id=#{@id} discriminator=#{@discriminator}>"
+    end
+
+    # @!visibility private
+    def update_data(new_data)
+      @username = new_data['username']
+      @global_name = new_data['global_name']
+      @discriminator = new_data['discriminator']
+      @avatar_id = new_data['avatar']
+      @public_flags = new_data['public_flags'] || 0
+      @primary_server = process_primary_server(new_data['primary_guild'])
+      @collectibles = Collectibles.new(new_data['collectibles'] || {}, @bot)
+      @avatar_decoration = process_avatar_decoration(new_data['avatar_decoration_data'])
     end
   end
 end

--- a/lib/discordrb/events/bans.rb
+++ b/lib/discordrb/events/bans.rb
@@ -13,9 +13,9 @@ module Discordrb::Events
 
     # @!visibility private
     def initialize(data, bot)
-      @user = bot.user(data['user']['id'].to_i)
-      @server = bot.server(data['guild_id'].to_i)
       @bot = bot
+      @user = bot.ensure_user(data['user'], true)
+      @server = bot.server(data['guild_id'].to_i)
     end
   end
 

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -110,7 +110,7 @@ module Discordrb::Events
     # @!visibility private
     def process_resolved(resolved_data)
       resolved_data['users']&.each do |id, data|
-        @resolved[:users][id.to_i] = @bot.ensure_user(data)
+        @resolved[:users][id.to_i] = @bot.ensure_user(data, true)
       end
 
       resolved_data['roles']&.each do |id, data|

--- a/lib/discordrb/events/members.rb
+++ b/lib/discordrb/events/members.rb
@@ -98,7 +98,7 @@ module Discordrb::Events
     # @!visibility private
     # @note Override init_user to account for the deleted user on the server
     def init_user(data, bot)
-      @user = Discordrb::User.new(data['user'], bot)
+      @user = bot.ensure_user(data['user'], true)
     end
 
     # @return [User] the user in question.

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -163,6 +163,7 @@ describe Discordrb::Bot do
         allow(bot).to receive(:raise_event)
         allow(Discordrb::Message).to receive(:new).and_return(message)
         allow(channel).to receive(:process_last_message_id)
+        allow(message).to receive(:server)
       end
 
       it 'raises a ChannelCreateEvent if the DM channel is uncached' do

--- a/spec/data/message_spec.rb
+++ b/spec/data/message_spec.rb
@@ -28,7 +28,7 @@ describe Discordrb::Message do
     allow(server).to receive(:member)
     allow(channel).to receive(:private?)
     allow(channel).to receive(:text?)
-    allow(bot).to receive(:ensure_user).with message_author
+    allow(bot).to receive(:ensure_user).with message_author, true
   end
 
   fixture :message_data, %i[message]
@@ -113,6 +113,7 @@ describe Discordrb::Message do
     let(:message) { described_class.new(message_data, bot) }
     let(:emoji) { double('emoji') }
     let(:reaction) { double('reaction') }
+    let(:user1) { double('user') }
 
     fixture :user_data, %i[user]
 
@@ -125,6 +126,10 @@ describe Discordrb::Message do
       allow(Discordrb::API::Channel).to receive(:get_reactions)
         .with(any_args, user_data['id'].to_i, anything, nil, nil, anything, anything)
         .and_return([].to_json)
+
+      allow(bot).to receive(:ensure_user)
+        .with(user_data, true)
+        .and_return(user1)
     end
 
     it 'calls the API method' do


### PR DESCRIPTION
# Summary

Using `Bot#ensure_user` has a small problem. User objects that are cached aren't ever updated sans `GUILD_MEMBER_UPDATE` and `PRESENCE_UPDATE` events. For bots that can't use these events, this isn't good. For example, say someone runs a slash command, changes their nameplate, and then runs the command again. The cache won't be updated the second time the command is run, and we'll have stale data.

I think the most non-intrusive way to solve this is to introduce a `force_cache` argument, like we do with `Bot#ensure_server`. This way, we can update the cached object with new data if it already exists. Any other ideas and ways to solve this are welcome, this is just what I managed to come up with

## Added
`force_cache` parameter to `Bot#ensure_user`