### PR TITLE
fix: key -> key?

### DIFF
--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -461,7 +461,7 @@ module Discordrb
         @communication_disabled_until = timeout_until ? Time.parse(timeout_until) : nil
       end
 
-      if data.key('premium_since')
+      if data.key?('premium_since')
         @boosting_since = data['premium_since'] ? Time.parse(data['premium_since']) : nil
       end
 


### PR DESCRIPTION
## Summary

`key` is an actual real method on `Hash`, but it does something very different compared to `key?`
