### PR TITLE
fix: multipart webhooks

### DIFF
--- a/lib/discordrb/webhooks/client.rb
+++ b/lib/discordrb/webhooks/client.rb
@@ -131,8 +131,9 @@ module Discordrb::Webhooks
 
     def post_multipart(builder, components, wait, thread_id)
       query = URI.encode_www_form({ wait:, thread_id: }.compact)
-      data = builder.to_multipart_hash.merge({ components: components.to_a })
-      RestClient.post(@url + (query.empty? ? '' : "?#{query}"), data)
+      data = builder.to_multipart_hash
+      data[:components] = components.to_a if components&.any?
+      RestClient.post(@url + (query.empty? ? '' : "?#{query}"), data.compact)
     end
 
     def generate_url(id, token)

--- a/spec/webhooks_spec.rb
+++ b/spec/webhooks_spec.rb
@@ -247,7 +247,8 @@ describe Discordrb::Webhooks do
       before do
         allow(RestClient).to receive(:post).with(any_args)
         allow(provided_url).to receive(:+).with(anything).and_return(provided_url)
-        allow(multipart_hash).to receive(:merge).with(instance_of(Hash)).and_return(post_data)
+        allow(multipart_hash).to receive(:[]=).and_return(instance_of(Array))
+        allow(multipart_hash).to receive(:compact).and_return(post_data)
       end
 
       it 'makes a POST request with multipart data' do


### PR DESCRIPTION
## Summary

Discord doesn't like `empty` or `nil` data for fields that aren't marked as such when adding a file using the webhooks client.


```ruby
{"message": "Invalid Form Body", "code": 50035, "errors": {"allowed_mentions": {"_errors": [{"code": "MODEL_TYPE_CONVERT", "message": "Expected an object/dictionary."}]}, "components": {"_errors": [{"code": "LIST_TYPE_CONVERT", "message": "Only iterables may be used in a ListType"}]}}}
```