### PR TITLE
fix: condition to check components presence

### DIFF
--- a/lib/discordrb/webhooks/client.rb
+++ b/lib/discordrb/webhooks/client.rb
@@ -132,7 +132,7 @@ module Discordrb::Webhooks
     def post_multipart(builder, components, wait, thread_id)
       query = URI.encode_www_form({ wait:, thread_id: }.compact)
       data = builder.to_multipart_hash
-      data[:components] = components.to_a if components&.any?
+      data[:components] = components.to_a if components&.to_a&.any?
       RestClient.post(@url + (query.empty? ? '' : "?#{query}"), data.compact)
     end
 


### PR DESCRIPTION
# Summary

The old guard clause is still ineffective, because when a component view is passed directly, it attempts to call `#any` on the view, which isn't defined.
