### PR TITLE
feat: support strings in app command handlers

### DIFF
--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -561,12 +561,13 @@ module Discordrb
     end
 
     # This **event** is raised whenever an application command (slash command) is executed.
-    # @param name [Symbol] The name of the application command this handler is for.
+    # @param name [Symbol, String] The name of the application command this handler is for.
     # @param attributes [Hash] The event's attributes.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ApplicationCommandEvent] The event that was raised.
     # @return [ApplicationCommandEventHandler] The event handler that was registered.
     def application_command(name, attributes = {}, &block)
+      name = name.to_sym
       @application_commands ||= {}
 
       unless block
@@ -681,7 +682,7 @@ module Discordrb
     # @yieldparam event [AutocompleteEvent] The event that was raised.
     # @return [AutocompleteEventHandler] The event handler that was registered.
     def autocomplete(name = nil, attributes = {}, &block)
-      register_event(AutocompleteEvent, attributes.merge!({ name: name }), block)
+      register_event(AutocompleteEvent, attributes.merge!({ name: name&.to_s }), block)
     end
 
     # This **event** is raised whenever an application command's permissions are updated.

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -489,7 +489,7 @@ module Discordrb::Events
       return false unless event.is_a?(AutocompleteEvent)
 
       [
-        matches_all(@attributes[:name], event.focused) { |a, e| a&.to_s == e },
+        matches_all(@attributes[:name], event.focused) { |a, e| a == e },
         matches_all(@attributes[:command_id], event.command_id) { |a, e| a&.to_i == e },
         matches_all(@attributes[:subcommand], event.subcommand) { |a, e| a&.to_sym == e },
         matches_all(@attributes[:command_name], event.command_name) { |a, e| a&.to_sym == e },


### PR DESCRIPTION
# Summary

Currently, we already support passing in strings to application command subcommands and groups. It's explicitly [documented as such](https://github.com/shardlab/discordrb/blob/fde3e228e96ac893e795db5e10d1280a25a66f86/lib/discordrb/events/interactions.rb#L247). Unfortunately, this isn't supported at the top-level which makes things pretty inconsistent. Rejecting strings in subcommands and groups would be a breaking change so ig we can't do it. I'd personally prefer if strings were allowed at the top-level, since context menu commands can have spaces in them, and you end up having to use quotes anyways (`:"big atom command name"`), or converting a string to a symbol yourself.

## Fixed

Closes #222 
