### PR TITLE
feat: expose 403 error codes

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -80,8 +80,9 @@ module Discordrb::API
   def raw_request(type, attributes)
     RestClient.send(type, *attributes)
   rescue RestClient::Forbidden => e
+    resp = JSON.parse(e.response.body)
     # HACK: for #request, dynamically inject restclient's response into NoPermission - this allows us to rate limit
-    noprm = Discordrb::Errors::NoPermission.new
+    noprm = Discordrb::Errors::NoPermission.new(resp)
     noprm.define_singleton_method(:_rc_response) { e.response }
     raise noprm, "The bot doesn't have the required permission to do this!"
   rescue RestClient::BadGateway

--- a/lib/discordrb/errors.rb
+++ b/lib/discordrb/errors.rb
@@ -15,7 +15,19 @@ module Discordrb
     class MessageTooLong < RuntimeError; end
 
     # Raised when the bot can't do something because its permissions on the server are insufficient
-    class NoPermission < RuntimeError; end
+    class NoPermission < RuntimeError
+      # @return [Integer, nil] The error code that was encoutered.
+      attr_reader :code
+
+      # @return [String, Hash, nil] The error message(s) that was encountered.
+      attr_reader :message
+
+      # @!visibility private
+      def initialize(data = {})
+        @code = data['code']
+        @message = data['message']
+      end
+    end
 
     # Raised when the bot gets a HTTP 502 error, which is usually caused by Cloudflare.
     class CloudflareError < RuntimeError; end


### PR DESCRIPTION
## Summary

Depending on the action that was taken, 403 error codes can contain additional information about the error that was encountered. E.g. attempting to set a role icon in a server without the boost level returns an error stating that the server's boosts are insufficient. Currently, this information is not exposed, and this PR does just that.

## Added
`Errors::NoPermission#code`
`Errors::NoPermission#message`