### PR TITLE
feat: message search

### DIFF
--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -221,6 +221,20 @@ module Discordrb::API::Server
     )
   end
 
+  # Query and filter the messages that have been sent in a server.
+  # https://discord.com/developers/docs/resources/message#search-guild-messages
+  def search_messages(token, server_id, limit: 25, offset: nil, max_id: nil, min_id: nil, slop: nil, content: nil, channel_id: nil, author_type: nil, author_id: nil, mentions: nil, mentions_role_id: nil, mention_everyone: nil, replied_to_user_id: nil, replied_to_message_id: nil, pinned: nil, has: nil, embed_type: nil, embed_provider: nil, link_hostname: nil, attachment_filename: nil, attachment_extension: nil, sort_by: nil, sort_order: nil, include_nsfw: nil)
+    query = URI.encode_www_form({ limit:, offset:, max_id:, min_id:, slop:, content:, channel_id:, author_type:, author_id:, mentions:, mentions_role_id:, mention_everyone:, replied_to_user_id:, replied_to_message_id:, pinned:, has:, embed_type:, embed_provider:, link_hostname:, attachment_filename:, attachment_extension:, sort_by:, sort_order:, include_nsfw: }.compact)
+
+    Discordrb::API.request(
+      :guilds_gid_messages_search,
+      server_id,
+      :get,
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/messages/search?#{query}",
+      Authorization: token
+    )
+  end
+
   # Get server roles
   # https://discord.com/developers/docs/resources/guild#get-guild-roles
   def roles(token, server_id)

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -387,6 +387,164 @@ module Discordrb
 
     alias_method :jump_link, :link
 
+    # Search the messages that have been sent in this server.
+    # @example Search for 200 messages from a user that contain an attachment.
+    #  options = {
+    #    limit: 200,
+    #    contains: :file,
+    #    authors: 171764626755813376
+    #  }
+    #
+    #  results = server.search_messages(**options)
+    # @example Search for all of the messages in a channel that mentions someone.
+    #  options = {
+    #    limit: nil,
+    #    mentions: 171764626755813376,
+    #    channels: 381891448884428801
+    #  }
+    #
+    #  results = server.search_messages(**options)
+    # @example Search for 105 messages that contain specific embed types, sorted by oldest to newest.
+    #  options = {
+    #    limit: 105,
+    #    embed_types: %i[article image],
+    #    sort_order: :ascending
+    #  }
+    #
+    #  results = server.search_messages(**options)
+    # @example Search for 30 messages sent between two dates that contain the word “time” and an @everyone ping.
+    #  options = {
+    #    limit: 30,
+    #    content: 'time',
+    #    mentions_everyone: true,
+    #    after: Time.parse("December 16th, 2020"),
+    #    before: Time.parse("December 25th, 2020")
+    #  }
+    #
+    #  results = server.search_messages(**options)
+    # @example Search for 500 messages that reply to a specific message, contain a Ruby file, and were sent by a bot account.
+    #  options = {
+    #    limit: 500,
+    #    author_types: :bot,
+    #    file_extensions: '.rb',
+    #    reply_messages: 1454184993923268660
+    #  }
+    #
+    #  results = server.search_messages(**options)
+    # @param limit [Integer, nil] The maximum number of messages to return, or `nil` to fetch all of the messages that match the search query.
+    # @param offset [Integer, nil] The number of messages between 0-9975 to offset the search query by.
+    # @param before [Time, #resolve_id, nil] Get messages sent before this timestamp.
+    # @param after [Time, #resolve_id, nil] Get messages sent after this timestamp.
+    # @param content [String, #to_s, nil] Get messages with matching message content.
+    # @param slop [Integer, nil] The amount of variation allowed between the placement of words when matching against message content; between 0-100.
+    # @param channels [Array<Channel, Integer, String>, Channel, Integer, String, nil] Get messages that were sent in these channels.
+    # @param authors [Array<#resolve_id>, #resolve_id, nil] Get messages that were created by these authors.
+    # @param author_types [Array<String, Symbol>, String, Symbol, nil] Get messages that were created by these author types: `user`, `bot`, or `webhook`.
+    # @param mentions [Array<#resolve_id>, #resolve_id, nil] Get messages that mention these users or members.
+    # @param role_mentions [Array<Role, Integer, String>, Role, Integer, String, nil] Get messages that mention these roles.
+    # @param mentions_everyone [true, false, nil] Get messages that mention the @everyone role.
+    # @param reply_users [Array<#resolve_id>, #resolve_id, nil] Get messages that replied to these users or members.
+    # @param reply_messages [Array<Message, Integer, String>, Message, Integer, String, nil] Get messages that replied to these messages.
+    # @param pinned [true, false, nil] Get messages that are pinned.
+    # @param contains [Array<String, Symbol>, String, Symbol, nil] Get messages that contain specific fields, e.g. `file`, `poll`, `sound`, etc.
+    # @param embed_types [Array<String, Symbol>, String, Symbol, nil] Get messages that contain matching embed types.
+    # @param embed_providers [Array<String, Symbol>, String, Symbol, nil] Get messages that contain embeds from specific providers.
+    # @param link_hosts [Array<String, Symbol>, String, Symbol, nil] Get messages that contain matching link hostnames, e.g. `discord.com`.
+    # @param file_names [Array<String, Symbol, Attachment>, String, Symbol, Attachment, nil] Get messages that contain matching attachment filenames.
+    # @param file_extensions [Array<String, Symbol>, String, Symbol, nil] Get messages that contain matching attachment file extensions, e.g. `.rb`, `.mp3`, etc.
+    # @param include_nsfw [true, false, nil] Whether or not to include messages that have been sent in NSFW channels.
+    # @param sort_by [Symbol, String, nil] Whether to sort the returned messages by their `:creation_time`, or `:relevance` to the search query.
+    # @param sort_order [Symbol, string, nil] Whether to order the returned messages in `:descending`, or `:ascending` order. Not respected when sorting by `:relevance`.
+    # @raise [Discordrb::Errors::NoPermission] This may occur when the application has not enabled the `MESSAGE_CONTENT` privileged intent on the Discord Developer Portal.
+    # @note Messages with GIFs sent before February 24th, 2026 may not be returned under the `gif` embed type when using the `embed_types:` parameter.
+    # @note Messages fetched via this method will not contain reactions. This means that {Message#reactions} will **always** return an empty array, even if the message has reactions.
+    # @return [SearchedMessages] the results of the search query.
+    def search_messages(
+      limit: 25, offset: nil, before: nil, after: nil, content: nil, slop: 2, channels: nil, authors: nil, author_types: nil,
+      mentions: nil, role_mentions: nil, mentions_everyone: nil, reply_users: nil, reply_messages: nil, pinned: nil, contains: nil,
+      embed_types: nil, embed_providers: nil, link_hosts: nil, file_names: nil, file_extensions: nil, include_nsfw: true, sort_by: nil,
+      sort_order: :descending
+    )
+      sort_order = case sort_order&.to_sym
+                   when nil, :desc, :descending, :newest_first
+                     :desc
+                   when :asc, :ascending, :oldest_first
+                     :asc
+                   else
+                     raise ArgumentError, "Invalid value for the 'sort_order' parameter"
+                   end
+
+      sort_by = case sort_by&.to_sym
+                when nil, :timestamp, :creation_time
+                  :timestamp
+                when :relevance, :match_score
+                  :relevance
+                else
+                  raise ArgumentError, "Invalid value for the 'sort_by' parameter"
+                end
+
+      options = {
+        limit: limit && limit <= 25 ? limit : 25,
+        max_id: before.is_a?(Time) ? IDObject.synthesise(before) : before&.resolve_id,
+        min_id: after.is_a?(Time) ? IDObject.synthesise(after) : after&.resolve_id,
+        offset: offset || 0,
+        slop: slop,
+        content: content&.to_s,
+        channel_id: channels ? Array(channels).map(&:resolve_id) : channels,
+        author_type: author_types ? Array(author_types) : author_types,
+        author_id: authors ? Array(authors).map(&:resolve_id) : authors,
+        mentions: mentions ? Array(mentions).map(&:resolve_id) : mentions,
+        mentions_role_id: role_mentions ? Array(role_mentions).map(&:resolve_id) : role_mentions,
+        mention_everyone: mentions_everyone,
+        replied_to_user_id: reply_users ? Array(reply_users).map(&:resolve_id) : reply_users,
+        replied_to_message_id: reply_messages ? Array(reply_messages).map(&:resolve_id) : reply_messages,
+        pinned: pinned,
+        has: contains ? Array(contains) : contains,
+        embed_type: embed_types ? Array(embed_types) : embed_types,
+        embed_provider: embed_providers ? Array(embed_providers) : embed_providers,
+        link_hostname: link_hosts ? Array(link_hosts) : link_hosts,
+        attachment_filename: (Array(file_names).map { |file| file.is_a?(Attachment) ? file.filename : file } if file_names),
+        attachment_extension: file_extensions ? Array(file_extensions).map { |type| type.to_s.delete_prefix('.') } : file_extensions,
+        sort_by: sort_by,
+        sort_order: sort_order,
+        include_nsfw: include_nsfw
+      }.compact
+
+      raise ArgumentError, "The 'role_mentions' parameter cannot contain the everyone role" if options[:mentions_role_id]&.any?(@id)
+
+      # Only store the total message count from the first request.
+      total = nil
+
+      get_messages = lambda do |query|
+        data = JSON.parse(API::Server.search_messages(@bot.token, @id, **options, **query.compact))
+        total ||= data['total_results']
+
+        data['threads']&.each do |thread|
+          thread['member'] = data['members']&.find { |member| thread['id'] == member['id'] }
+
+          @bot.ensure_channel(thread, self)
+        end
+
+        data['messages'].collect { |nested_messages| Message.new(nested_messages[0], @bot) }
+      end
+
+      paginator = Paginator.new(limit, :down) do |page|
+        if sort_by == :relevance
+          if (paginator.amount_fetched + options[:offset]) > 9975
+            []
+          else
+            get_messages.call(offset: paginator.count + options[:offset])
+          end
+        elsif sort_order == :desc
+          get_messages.call(max_id: page&.last&.id, offset: page ? 0 : nil)
+        else
+          get_messages.call(min_id: page&.last&.id, offset: page ? 0 : nil)
+        end
+      end
+
+      SearchedMessages.new(paginator.to_a, total, @bot)
+    end
+
     # Adds a role to the role cache
     # @note For internal use only
     # @!visibility private
@@ -1075,6 +1233,42 @@ module Discordrb
       @reason = reason
       @banned_users = data['banned_users']&.map(&:resolve_id) || []
       @failed_users = data['failed_users']&.map(&:resolve_id) || []
+    end
+  end
+
+  # A set of messages collected from a search query.
+  class SearchedMessages
+    include Enumerable
+
+    # @return [Array<Message>] the messages that matched the search query.
+    attr_reader :messages
+
+    # @return [Integer] the total number of messages that matched the search query.
+    attr_reader :total_results
+
+    # @!visibility private
+    def initialize(messages, total, bot)
+      @bot = bot
+      @messages = messages
+      @total_results = total
+    end
+
+    # Get a single message that matched the search query by its index.
+    # @param index [Integer] The index of the message to get from the array.
+    # @return [Message] the message that was found at the specified index.
+    def [](index)
+      @messages[index]
+    end
+
+    # Iterate over each message that matched the search query.
+    # @return [Array<Message>, Enumerable] The array that was iterated over.
+    def each(...)
+      @messages.each(...)
+    end
+
+    # @!visibility private
+    def inspect
+      "<SearchedMessages messages=[#{'...' if @messages.any?}] total_results=#{@total_results}>"
     end
   end
 end

--- a/lib/discordrb/paginator.rb
+++ b/lib/discordrb/paginator.rb
@@ -7,6 +7,9 @@ module Discordrb
   class Paginator
     include Enumerable
 
+    # @return [Integer] the total amount of elements that have been fetched so far.
+    attr_reader :amount_fetched
+
     # Creates a new {Paginator}
     # @param limit [Integer] the maximum number of items to request before stopping
     # @param direction [:up, :down] the order in which results are returned in
@@ -14,7 +17,7 @@ module Discordrb
     #   This should be used to request the next page of results.
     # @yieldreturn [Array] the next page of results
     def initialize(limit, direction, &block)
-      @count = 0
+      @amount_fetched = 0
       @limit = limit
       @direction = direction
       @block = block
@@ -37,7 +40,7 @@ module Discordrb
 
         enumerator.each do |item|
           yield item
-          @count += 1
+          @amount_fetched += 1
           break if limit_exceeded?
         end
 
@@ -51,7 +54,7 @@ module Discordrb
     def limit_exceeded?
       return false if @limit.nil?
 
-      @count >= @limit
+      @amount_fetched >= @limit
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR adds support for message search. 

## Added
`Server#search_messages`
`API::Server#search_messages`
`Discordrb::SearchedMessages`

## Changed
I had to expose `Paginator#count` since in certain cases, paginating by offset is required.