### PR TITLE
feat: emoji serialization helper

### DIFF
--- a/lib/discordrb/data/emoji.rb
+++ b/lib/discordrb/data/emoji.rb
@@ -99,7 +99,7 @@ module Discordrb
     end
 
     # @!visibility private
-    def self.to_h(emoji, prefix: true)
+    def self.build_emoji_hash(emoji, prefix: true)
       data = { id: nil, name: nil }
 
       case emoji


### PR DESCRIPTION
## Summary

Currently, when working on the library there are multiple places in the API that take an `emoji_id` and `emoji_name` field. This serialization means I need to frequently copy and paste the snippet below, when expressing emojis as a single field in data models to be consistent with the rest of API. I'm not too sure about the name of the helper, and the fact that it's a class method on `Emoji` so any alternative ideas are welcome
