### PR TITLE
fix: handle pre-existing thread-ids in WH URLs

### DIFF
--- a/lib/discordrb/webhooks/client.rb
+++ b/lib/discordrb/webhooks/client.rb
@@ -124,23 +124,35 @@ module Discordrb::Webhooks
     end
 
     def post_json(builder, components, wait, thread_id)
-      uri = URI.parse(@url)
-      query_data = URI.decode_www_form(uri.query || '').to_h
-      query = URI.encode_www_form({ wait:, thread_id:, **query_data }.compact)
-
       data = builder.to_json_hash.merge({ components: components.to_a })
-      RestClient.post(@url + (query.empty? ? '' : "?#{query}"), data.to_json, content_type: :json)
+      RestClient.post(encode_url(wait, thread_id), data.to_json, content_type: :json)
     end
 
     def post_multipart(builder, components, wait, thread_id)
-      query = URI.encode_www_form({ wait:, thread_id: }.compact)
       data = builder.to_multipart_hash
       data[:components] = components.to_a if components&.to_a&.any?
-      RestClient.post(@url + (query.empty? ? '' : "?#{query}"), data.compact)
+      RestClient.post(encode_url(wait, thread_id), data.compact)
     end
 
     def generate_url(id, token)
       "https://discord.com/api/v9/webhooks/#{id}/#{token}"
+    end
+
+    def encode_url(wait, thread_id)
+      uri = URI.parse(@url)
+
+      # NOTE: We have to use string keys here, since URI#decode_www_form returns
+      # string keys, and keys with different types are treated as array query params
+      # and appended to the query params twice.
+      query = {
+        'wait' => wait,
+        'thread_id' => thread_id,
+        **URI.decode_www_form(uri.query || '').to_h
+      }
+
+      query = URI.encode_www_form(query.compact)
+      uri.query = query unless query.empty?
+      uri.to_s
     end
   end
 end

--- a/spec/webhooks_spec.rb
+++ b/spec/webhooks_spec.rb
@@ -85,7 +85,7 @@ describe Discordrb::Webhooks do
   describe Discordrb::Webhooks::Client do
     let(:id) { SecureRandom.bytes(8) }
     let(:token) { SecureRandom.bytes(24) }
-    let(:provided_url) { instance_double(String) }
+    let(:provided_url) { instance_double(String, to_str: 'https://discord.com/api/v9/webhooks') }
 
     subject { described_class.new(url: provided_url) }
 
@@ -229,13 +229,17 @@ describe Discordrb::Webhooks do
       it 'makes a POST request with JSON data' do
         subject.__send__(:post_json, builder, [], false, nil)
 
-        expect(RestClient).to have_received(:post).with(provided_url, builder.to_json_hash.merge({ components: [] }).to_json, content_type: :json)
+        url = 'https://discord.com/api/v9/webhooks?wait=false'
+
+        expect(RestClient).to have_received(:post).with(url, builder.to_json_hash.merge({ components: [] }).to_json, content_type: :json)
       end
 
       it 'waits when wait=true' do
         subject.__send__(:post_json, builder, [], true, nil)
 
-        expect(provided_url).to have_received(:+).with('?wait=true')
+        url = 'https://discord.com/api/v9/webhooks?wait=true'
+
+        expect(RestClient).to have_received(:post).with(url, builder.to_json_hash.merge({ components: [] }).to_json, content_type: :json)
       end
     end
 
@@ -246,7 +250,6 @@ describe Discordrb::Webhooks do
 
       before do
         allow(RestClient).to receive(:post).with(any_args)
-        allow(provided_url).to receive(:+).with(anything).and_return(provided_url)
         allow(multipart_hash).to receive(:[]=).and_return(instance_of(Array))
         allow(multipart_hash).to receive(:compact).and_return(post_data)
       end
@@ -254,19 +257,25 @@ describe Discordrb::Webhooks do
       it 'makes a POST request with multipart data' do
         subject.__send__(:post_multipart, builder, [], false, nil)
 
-        expect(RestClient).to have_received(:post).with(provided_url, post_data)
+        url = 'https://discord.com/api/v9/webhooks?wait=false'
+
+        expect(RestClient).to have_received(:post).with(url, post_data)
       end
 
       it 'waits for a response when wait=true' do
         subject.__send__(:post_multipart, builder, [], true, nil)
 
-        expect(provided_url).to have_received(:+).with('?wait=true')
+        url = 'https://discord.com/api/v9/webhooks?wait=true'
+
+        expect(RestClient).to have_received(:post).with(url, post_data)
       end
 
       it 'adds a thread_id when it is provided' do
         subject.__send__(:post_multipart, builder, [], false, '123456')
 
-        expect(provided_url).to have_received(:+).with('?wait=false&thread_id=123456')
+        url = 'https://discord.com/api/v9/webhooks?wait=false&thread_id=123456'
+
+        expect(RestClient).to have_received(:post).with(url, post_data)
       end
     end
 


### PR DESCRIPTION
## Summary

Since @swarley is a little busy rn, I copied the commits from #396  fixing this, and applied the review comment and made the compliance tests pass.

## Fixed
Swarley - Gracefully handle pre-existing `thread_id` query string params in webhook URLs.
Me - Spec