### PR TITLE
feat: Message#modify

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -144,6 +144,31 @@ module Discordrb::API::Channel
     )
   end
 
+  # Update the properties of a message.
+  # https://discord.com/developers/docs/resources/message#edit-message
+  def update_message(token, channel_id, message_id, content: :undef, embeds: :undef, flags: :undef, components: :undef, attachments: :undef, files: :undef, poll: :undef)
+    body = { content:, embeds:, flags:, components:, attachments:, poll: }.reject { |_, value| value == :undef }
+
+    body = if files == :undef
+             body.to_json
+           else
+             indices = files.each_index.map { |id| "files[#{id}]" }
+             { **indices.zip(files).to_h, payload_json: body.to_json }
+           end
+
+    headers = { Authorization: token }
+    headers[:content_type] = :json if files == :undef
+
+    Discordrb::API.request(
+      :channels_cid_messages_mid,
+      channel_id,
+      :patch,
+      "https://discord.com/api/v10/channels/#{channel_id}/messages/#{message_id}",
+      body,
+      headers
+    )
+  end
+
   # Delete a message
   # https://discord.com/developers/docs/resources/channel#delete-message
   def delete_message(token, channel_id, message_id, reason = nil)

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -627,7 +627,7 @@ module Discordrb
       yield(builder, view) if block_given?
 
       flags = Array(flags).map { |flag| Discordrb::Message::FLAGS[flag] || flag }.reduce(0, &:|)
-      flags |= (1 << 15) if has_components
+      flags |= Discordrb::Message::FLAGS[:uikit_components] if has_components
       builder = builder.to_json_hash
 
       if timeout

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -402,12 +402,10 @@ module Discordrb
       @reactions.select(&:me)
     end
 
-    # Removes embeds from the message
+    # Removes embeds from the message.
     # @return [Message] the resulting message.
     def suppress_embeds
-      flags = @flags | (1 << 2)
-      response = API::Channel.edit_message(@bot.token, @channel.id, @id, :undef, :undef, :undef, :undef, flags)
-      Message.new(JSON.parse(response), @bot)
+      modify(flags: @flags | FLAGS[:suppress_embeds])
     end
 
     # Check if this message mentions a specific user or role.
@@ -502,7 +500,7 @@ module Discordrb
 
     # The inspect method is overwritten to give more useful output
     def inspect
-      "<Message content=\"#{@content}\" id=#{@id} timestamp=#{@timestamp} author=#{@author} channel=#{@channel}>"
+      "<Message id=#{@id} channel_id=#{@channel.id} content=\"#{@content}\" creation_time=#{creation_time}>"
     end
 
     # @return [String] a URL that a user can use to navigate to this message in the client
@@ -602,6 +600,75 @@ module Discordrb
       end
 
       @timestamps
+    end
+
+    # Edit the properties of the message.
+    # @param content [String] The new content of the message. Should not be longer than 2000 characters.
+    # @param embeds [Array<Hash, Webhooks::Embed>] The new embeds that should be attached to the message.
+    # @param flags [Integer, Symbol, Array<Symbol, Integer>] The new message flags that should be applied.
+    # @param components [View, Array<#to_h>] The new message components that should be set for the message.
+    # @param has_components [true, false] Whether to set the `:uikit_components` flag when updating the message.
+    # @param attachments [Array<File, Hash, Integer, String, Attachment>] The new attachments to set for the message.
+    # @param retain_attachments [true, false] Whether or not to retain the exisiting attachments present on the message.
+    # @yieldparam builder [Webhooks::Builder] An optional message builder. Overwrites arguments passed to the method.
+    # @yieldparam view [Webhooks::View] An optional component builder. Overwrites arguments passed to the method.
+    # @note Any arguments that you pass will completely overwrite the old value. For example, passing `flags` will completely
+    #   replace the `flags` field, passing `embeds` will completely replace all the `embeds`, etc.
+    # @return [Message] the updated message.
+    def modify(
+      content: :undef, embeds: :undef, flags: :undef, components: :undef, attachments: :undef,
+      retain_attachments: false, has_components: :undef
+    )
+      builder = Discordrb::Webhooks::Builder.new
+      view = Discordrb::Webhooks::View.new
+
+      builder.content = content
+      embeds&.each { |embed| builder << embed } unless embeds == :undef
+      yield(builder, view) if block_given?
+
+      flags = Array(flags).map { |flag| FLAGS[flag] || flag }.reduce(0, &:|) if flags != :undef
+      components = components&.to_a unless components == :undef
+      builder = builder.to_json_hash
+
+      if has_components == true
+        flags == :undef ? (flags = (@flags | FLAGS[:uikit_components])) : flags |= FLAGS[:uikit_components]
+      end
+
+      builder = {
+        flags: flags,
+        content: builder[:content],
+        components: block_given? && view.to_a.any? ? view.to_a : components,
+        embeds: block_given? && builder[:embeds]&.any? ? builder[:embeds] : embeds
+      }
+
+      if flags != :undef && !uikit_components? && flags.anybits?(FLAGS[:uikit_components])
+        builder[:poll] = nil
+        builder[:embeds] = []
+        builder[:content] = nil
+      end
+
+      if attachments.is_a?(Array) && attachments.any?
+        attachments.each do |attachment|
+          case attachment
+          when String, Integer, Attachment
+            (builder[:attachments] ||= []) << { id: attachment.resolve_id }
+          when Hash
+            (builder[:attachments] ||= []) << attachment
+          else
+            (builder[:files] ||= []) << attachment
+          end
+        end
+      elsif attachments != :undef
+        builder[:attachments] = attachments
+      end
+
+      # rubocop:disable Style/IfUnlessModifier
+      if builder[:files] && retain_attachments == true && @attachments.any?
+        (builder[:attachments] ||= []).push(*@attachments.map { |attachment| { id: attachment.id } })
+      end
+
+      # rubocop:enable Style/IfUnlessModifier
+      Message.new(JSON.parse(API::Channel.update_message(@bot.token, @channel.id, @id, **builder)), @bot)
     end
   end
 end

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -598,7 +598,7 @@ module Discordrb
           if (count = (paginator.amount_fetched + options[:offset])) > 9975
             []
           else
-            get_messages.call(offset: count + options[:offset])
+            get_messages.call(offset: count)
           end
         elsif sort_order == :desc
           get_messages.call(max_id: page&.last&.id, offset: page ? 0 : nil)


### PR DESCRIPTION
## Summary

Currently, support for editing messages isn't very good. If you want to edit just one field, you need to provide values for all of the other values unless you want to obliterate the existing values. We also currently don't support editing files. The code for this is a little messy, even though I tried to keep it fairly neat. Closes #223. Closes #419.

## Added
`Message#edit!`
`API::Channel#update_message`
