### PR TITLE
Fix wrong wording in `#voice_state_update` documentation

### DIFF
--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -290,7 +290,7 @@ module Discordrb
     # This **event** is raised when a user's voice state changes. This includes when a user joins, leaves, or
     # moves between voice channels, as well as their mute and deaf status for themselves and on the server.
     # @param attributes [Hash] The event's attributes.
-    # @option attributes [String, Integer, User] :from Matches the user that sent the message.
+    # @option attributes [String, Integer, User] :from Matches the user that raised the event.
     # @option attributes [String, Integer, Channel] :channel Matches the voice channel the user has joined.
     # @option attributes [String, Integer, Channel] :old_channel Matches the voice channel the user was in previously.
     # @option attributes [true, false] :mute Matches whether or not the user is muted server-wide.


### PR DESCRIPTION
# Summary
This updates wrong wording in the `voice_state_update` event documentation. The previous wording suggested that there would be a message related to the event, which is not the case. 

## Changed
- Documentation wording

