### PR TITLE
feat: delegate more interaction methods

### DIFF
--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -333,7 +333,7 @@ module Discordrb
 
     # @return [true, false] whether the application was installed by the user who initiated this interaction.
     def user_integration?
-      @integration_owners[1] == @user_id
+      @integration_owners[1] == @user.id
     end
 
     # @return [true, false] whether the application was installed by the server where this interaction originates from.

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -33,7 +33,13 @@ module Discordrb::Events
     # @!attribute [r] context
     #   @return [Integer]
     #   @see Interaction#context
-    delegate :type, :server, :server_id, :channel, :channel_id, :user, :user_locale, :context, to: :interaction
+    # @!attribute [r] user_integration?
+    #   @return [true, false]
+    #   @see Interaction#user_integration?
+    # @!attribute [r] server_integration?
+    #   @return [true, false]
+    #   @see Interaction#server_integration?
+    delegate :type, :server, :server_id, :channel, :channel_id, :user, :user_locale, :context, :user_integration?, :server_integration?, to: :interaction
 
     # @!visibility private
     def initialize(data, bot)


### PR DESCRIPTION
## Summary

I understand that we don't need to delegate every method available on the interaction object to `InteractionCreateEvent`, but please make an exception for  `#user_integration?` and `#server_integration?`. Because they're the only reliable way to determine if the bot can access certain bits of data, e.g., in a user-app, something like `event.user.color` would require a `#server_integration?` check because getting the color of the user's role requires resolving the roles the user has, which may not always be possible in contexts where the bot has not been authorized with the bot scope.

