### PR TITLE
feat: replied user in allowed mentions

### DIFF
--- a/lib/discordrb/allowed_mentions.rb
+++ b/lib/discordrb/allowed_mentions.rb
@@ -14,14 +14,20 @@ module Discordrb
     # @return [Array<String, Integer>, nil]
     attr_accessor :roles
 
+    # @return [true, false, nil]
+    attr_accessor :replied_user
+    alias_method :replied_user?, :replied_user
+
     # @param parse [Array<"users", "roles", "everyone">] Mention types that can be inferred from the message.
     #   `users` and `roles` allow for all mentions of the respective type to ping. `everyone` allows usage of `@everyone` and `@here`
     # @param users [Array<User, String, Integer>] Users or user IDs that can be pinged. Cannot be used in conjunction with `"users"` in `parse`
     # @param roles [Array<Role, String, Integer>] Roles or role IDs that can be pinged. Cannot be used in conjunction with `"roles"` in `parse`
-    def initialize(parse: nil, users: nil, roles: nil)
+    # @param replied_user [true, false, nil] For replies, whether to mention the author of the message being replied to. Defaults to no mention
+    def initialize(parse: nil, users: nil, roles: nil, replied_user: nil)
       @parse = parse
       @users = users
       @roles = roles
+      @replied_user = replied_user
     end
 
     # @!visibility private
@@ -29,7 +35,8 @@ module Discordrb
       {
         parse: @parse,
         users: @users&.map { |user| user.is_a?(IDObject) ? user.id : user },
-        roles: @roles&.map { |role| role.is_a?(IDObject) ? role.id : role }
+        roles: @roles&.map { |role| role.is_a?(IDObject) ? role.id : role },
+        replied_user: @replied_user
       }.compact
     end
   end


### PR DESCRIPTION
## Summary

I think we already support setting `replied_user` as a top-level argument in `Message#reply!`, but this might be useful for folks using `AllowedMentions` outside of the context of `Message#reply!`, e.g. when using `Channel#send_message!`.

## Added
`replied_user:` to the `AllowedMentions` builder.