### PR TITLE
feat: integration events

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -20,6 +20,7 @@ require 'discordrb/events/webhooks'
 require 'discordrb/events/invites'
 require 'discordrb/events/interactions'
 require 'discordrb/events/threads'
+require 'discordrb/events/integrations'
 
 require 'discordrb/api'
 require 'discordrb/api/channel'
@@ -1578,6 +1579,15 @@ module Discordrb
         delete_guild_role(data)
 
         event = ServerRoleDeleteEvent.new(data, self)
+        raise_event(event)
+      when :INTEGRATION_CREATE
+        event = IntegrationCreateEvent.new(data, self)
+        raise_event(event)
+      when :INTEGRATION_UPDATE
+        event = IntegrationUpdateEvent.new(data, self)
+        raise_event(event)
+      when :INTEGRATION_DELETE
+        event = IntegrationDeleteEvent.new(data, self)
         raise_event(event)
       when :GUILD_CREATE
         create_guild(data)

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -14,6 +14,7 @@ require 'discordrb/events/await'
 require 'discordrb/events/bans'
 require 'discordrb/events/reactions'
 require 'discordrb/events/interactions'
+require 'discordrb/events/integrations'
 
 require 'discordrb/await'
 
@@ -694,6 +695,42 @@ module Discordrb
     # @return [ApplicationCommandPermissionsUpdateEventHandler] The event handler that was registered.
     def application_command_permissions_update(attributes = {}, &block)
       register_event(ApplicationCommandPermissionsUpdateEvent, attributes, block)
+    end
+
+    # This **event** is raised whenever an integration is added to a server.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Integer, Integration] :id An integration to match against.
+    # @option attributes [String, Integer, Server] :server A server to match against.
+    # @option attributes [String, Integer, Application] :application An application to match against.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [IntegrationCreateEvent] The event that was raised.
+    # @return [IntegrationCreateEventHandler] The event handler that was registered.
+    def integration_create(attributes = {}, &block)
+      register_event(IntegrationCreateEvent, attributes, block)
+    end
+
+    # This **event** is raised whenever an integration is updated in a server.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Integer, Integration] :id An integration to match against.
+    # @option attributes [String, Integer, Server] :server A server to match against.
+    # @option attributes [String, Integer, Application] :application An application to match against.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [IntegrationUpdateEvent] The event that was raised.
+    # @return [IntegrationUpdateEventHandler] The event handler that was registered.
+    def integration_update(attributes = {}, &block)
+      register_event(IntegrationUpdateEvent, attributes, block)
+    end
+
+    # This **event** is raised whenever an integration is removed from a server.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Integer, Integration] :id An integration to match against.
+    # @option attributes [String, Integer, Server] :server A server to match against.
+    # @option attributes [String, Integer, Application] :application An application to match against.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [IntegrationDeleteEvent] The event that was raised.
+    # @return [IntegrationDeleteEventHandler] The event handler that was registered.
+    def integration_delete(attributes = {}, &block)
+      register_event(IntegrationDeleteEvent, attributes, block)
     end
 
     # This **event** is raised for every dispatch received over the gateway, whether supported by discordrb or not.

--- a/lib/discordrb/data/integration.rb
+++ b/lib/discordrb/data/integration.rb
@@ -3,23 +3,21 @@
 module Discordrb
   # Integration Account
   class IntegrationAccount
+    include IDObject
+
     # @return [String] this account's name.
     attr_reader :name
 
-    # @return [Integer] this account's ID.
-    attr_reader :id
-
     # @!visibility private
     def initialize(data)
-      @name = data['name']
       @id = data['id'].to_i
+      @name = data['name']
     end
   end
 
   # Bot/OAuth2 application for discord integrations
   class IntegrationApplication
-    # @return [Integer] the ID of the application.
-    attr_reader :id
+    include IDObject
 
     # @return [String] the name of the application.
     attr_reader :name
@@ -30,9 +28,6 @@ module Discordrb
     # @return [String] the description of the application.
     attr_reader :description
 
-    # @return [String] the summary of the application.
-    attr_reader :summary
-
     # @return [User, nil] the bot associated with this application.
     attr_reader :bot
 
@@ -42,8 +37,7 @@ module Discordrb
       @name = data['name']
       @icon = data['icon']
       @description = data['description']
-      @summary = data['summary']
-      @bot = Discordrb::User.new(data['user'], bot) if data['user']
+      @bot = bot.ensure_user(data['bot']) if data['bot']
     end
   end
 
@@ -51,38 +45,50 @@ module Discordrb
   class Integration
     include IDObject
 
+    # Map of expire behaviors.
+    EXPIRE_BEHAVIORS = {
+      remove: 0,
+      kick: 1
+    }.freeze
+
     # @return [String] the integration name
     attr_reader :name
 
     # @return [Server] the server the integration is linked to
     attr_reader :server
 
-    # @return [User] the user the integration is linked to
+    # @return [User, nil] the user who added the integration to the server. This will be `nil`
+    #  for very old integrations, or if the integration was sent via a Gateway event.
     attr_reader :user
 
-    # @return [Integer, nil] the role that this integration uses for "subscribers"
+    # @return [Integer, nil] the ID of the role that this integration uses for "subscribers"
     attr_reader :role_id
 
-    # @return [true, false] whether emoticons are enabled
+    # @return [true, false] whether or not emoticons are enabled
     attr_reader :emoticon
     alias_method :emoticon?, :emoticon
+    alias_method :emoticons?, :emoticon
 
-    # @return [String] the integration type (YouTube, Twitch, etc.)
+    # @return [String] the integration type (YouTube, Twitch, Discord, etc.)
     attr_reader :type
 
     # @return [true, false] whether the integration is enabled
     attr_reader :enabled
+    alias_method :enabled?, :enabled
 
-    # @return [true, false] whether the integration is syncing
+    # @return [true, false] whether or not the integration is syncing
     attr_reader :syncing
+    alias_method :syncing?, :syncing
 
     # @return [IntegrationAccount] the integration account information
     attr_reader :account
 
-    # @return [Time] the time the integration was synced at
+    # @return [Time, nil] the time the integration was last synced at
     attr_reader :synced_at
 
-    # @return [Symbol] the behaviour of expiring subscribers (:remove = Remove User from role; :kick = Kick User from server)
+    # @return [Symbol, nil] the behaviour of expiring subscribers. When this is `:remove`, the
+    #  associated role will be removed from the user. When this is `:kick`, the user will be
+    #  kicked out of the server
     attr_reader :expire_behaviour
     alias_method :expire_behavior, :expire_behaviour
 
@@ -92,34 +98,47 @@ module Discordrb
     # @return [Integer, nil] how many subscribers this integration has.
     attr_reader :subscriber_count
 
-    # @return [true, false] has this integration been revoked.
+    # @return [true, false] whether or not this integration been revoked.
     attr_reader :revoked
+    alias_method :revoked?, :revoked
+
+    # @return [IntegrationApplication, nil] the application for the integration.
+    attr_reader :application
+
+    # @return [Array<String>] the oauth2 scopes the application has been authorized for
+    attr_reader :scopes
 
     # @!visibility private
     def initialize(data, bot, server)
       @bot = bot
-
-      @name = data['name']
       @server = server
       @id = data['id'].to_i
+      @name = data['name']
       @enabled = data['enabled']
-      @syncing = data['syncing']
+      @syncing = data['syncing'] || false
       @type = data['type']
       @account = IntegrationAccount.new(data['account'])
-      @synced_at = Time.parse(data['synced_at'])
-      @expire_behaviour = %i[remove kick][data['expire_behavior']]
-      @expire_grace_period = data['expire_grace_period']
-      @user = @bot.ensure_user(data['user'])
+      @synced_at = Time.parse(data['synced_at']) if data['synced_at']
+      @expire_behaviour = EXPIRE_BEHAVIORS.key(data['expire_behavior']) if data['expire_behavior']
+      @expire_grace_period = data['expire_grace_period'] || 0
+      @user = @bot.ensure_user(data['user']) if data['user']
       @role_id = data['role_id']&.to_i
-      @emoticon = data['enable_emoticons']
+      @emoticon = data['enable_emoticons'] || false
       @subscriber_count = data['subscriber_count']&.to_i
-      @revoked = data['revoked']
+      @revoked = data['revoked'] || false
       @application = IntegrationApplication.new(data['application'], bot) if data['application']
+      @scopes = data['scopes'] || []
     end
 
-    # The inspect method is overwritten to give more useful output
+    # Get the role that this integration uses for subscribers.
+    # @return [Role, nil] The role that this integration uses for subscribers.
+    def subscriber_role
+      @server.role(@role_id) if @role_id
+    end
+
+    # The inspect method is overwritten to give more useful output.
     def inspect
-      "<Integration name=#{@name} id=#{@id} type=#{@type} enabled=#{@enabled}>"
+      "<Integration name=\"#{@name}\" id=#{@id} type=\"#{@type}\" enabled=#{@enabled}>"
     end
   end
 end

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -158,7 +158,8 @@ module Discordrb
       member(@bot.profile)
     end
 
-    # @return [Array<Integration>] an array of all the integrations connected to this server.
+    # @return [Array<Integration>] an array of the integrations in this server.
+    # @note If the server has more than 50 integrations, they cannot be accessed.
     def integrations
       integration = JSON.parse(API::Server.integrations(@bot.token, @id))
       integration.map { |element| Integration.new(element, @bot, self) }

--- a/lib/discordrb/events/integrations.rb
+++ b/lib/discordrb/events/integrations.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'discordrb/data'
+require 'discordrb/events/generic'
+
+module Discordrb::Events
+  # Generic superclass for integration events.
+  class IntegrationEvent < Event
+    # @return [Server] the server associated with the event.
+    attr_reader :server
+
+    # @return [Integration] the integration associated with the event.
+    attr_reader :integration
+
+    # @!visibility private
+    def initialize(data, bot)
+      @bot = bot
+      @server = bot.server(data['guild_id'].to_i)
+      @integration = Discordrb::Integration.new(data, @bot, @server)
+    end
+  end
+
+  # Raised whenever an integration is created.
+  class IntegrationCreateEvent < IntegrationEvent; end
+
+  # Raised whenever an integration is updated.
+  class IntegrationUpdateEvent < IntegrationEvent; end
+
+  # Raised whenever an integration is deleted.
+  class IntegrationDeleteEvent < Event
+    # @return [Server] the server associated with the event.
+    attr_reader :server
+
+    # @return [Integer] the ID of the integration that was removed.
+    attr_reader :integration_id
+
+    # @return [Integer, nil] the ID of the application that was removed.
+    attr_reader :application_id
+
+    # @!visibility private
+    def initialize(data, bot)
+      @bot = bot
+      @server = bot.server(data['guild_id'].to_i)
+      @integration_id = data['id'].to_i
+      @application_id = data['application_id']&.to_i
+    end
+  end
+
+  # Generic event handler for integration events.
+  class IntegrationEventHandler < EventHandler
+    # @!visibility private
+    def matches?(event)
+      # Check for the proper event type.
+      return false unless event.is_a?(IntegrationEvent)
+
+      [
+        matches_all(@attributes[:server], event.server) do |a, e|
+          a&.resolve_id == e&.resolve_id
+        end,
+
+        matches_all(@attributes[:id], event.integration) do |a, e|
+          a&.resolve_id == e&.resolve_id
+        end,
+
+        matches_all(@attributes[:application], event.integration) do |a, e|
+          a&.resolve_id == e.application&.resolve_id
+        end
+      ].reduce(true, &:&)
+    end
+  end
+
+  # Event handler for INTEGRATION_CREATE events.
+  class IntegrationCreateEventHandler < IntegrationEventHandler; end
+
+  # Event handler for INTEGRATION_UPDATE events.
+  class IntegrationUpdateEventHandler < IntegrationEventHandler; end
+
+  # Event handler for INTEGRATION_DELETE events.
+  class IntegrationDeleteEventHandler < EventHandler
+    # @!visibility private
+    def matches?(event)
+      # Check for the proper event type.
+      return false unless event.is_a?(IntegrationDeleteEvent)
+
+      [
+        matches_all(@attributes[:server], event.server) do |a, e|
+          a&.resolve_id == e&.resolve_id
+        end,
+
+        matches_all(@attributes[:id], event.integration_id) do |a, e|
+          a&.resolve_id == e&.resolve_id
+        end,
+
+        matches_all(@attributes[:application], event.application_id) do |a, e|
+          a&.resolve_id == e&.resolve_id
+        end
+      ].reduce(true, &:&)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Currently, fetching integrations is broken because the code always assumed that `synced_at` field is always provided. This isn't real because the docs say that the field is optional. Additionally, integration stuff is pretty rough right now, so I took the chance to improve a few things. There are also Gateway events for integrations `CREATE/UPDATE/DELETE` that were not previously handled

## Added
`Integration#scopes`
`Integration#application`

`EventContainer#integration_create`
`EventContainer#integration_update`
`EventContainer#integration_delete`

## Changed
Discord bot integrations don't provide certain non-bot fields. For some of these fields, we can provide sane defaults where they are marked as non-nullable. In cases were we cannot provide defaults, we have to mark them as being nullable in accordance with the docs.

Instead of defining `attr_reader :id` in a bunch of integration classes, we can simply `include IDObject` to DRY up the code a little bit.

## Removed
Since `IntegrationApplication` wasn't previously exposed anywhere, I removed the `summary` field since it's always an empty string and not even listed in the API docs.