### PR TITLE
feat: comparison operators for roles

### DIFF
--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -257,42 +257,39 @@ module Discordrb
       end
     end
 
-    # @return [Role] the highest role this member has.
+    # Get the highest role this member has.
+    # @return [Role] The highest role this member has.
     def highest_role
-      roles.max_by(&:position)
+      roles.max
     end
 
-    # @return [Role, nil] the role this member is being hoisted with.
+    # Get the role that determines where the member is shown in
+    #   the Discord client's member list.
+    # @return [Role, nil] The role this member is being hoisted with.
     def hoist_role
-      hoisted_roles = roles.select(&:hoist)
-      return nil if hoisted_roles.empty?
-
-      hoisted_roles.max_by(&:position)
+      roles.select(&:hoist).max
     end
 
-    # @return [Role, nil] the role this member is basing their colour on.
+    # Get the role that determines the primary colour of the member.
+    # @return [Role, nil] The role this member is basing their colour on.
     def colour_role
-      coloured_roles = roles.select { |v| v.colour.combined.nonzero? }
-      return nil if coloured_roles.empty?
-
-      coloured_roles.max_by(&:position)
+      roles.select { |role| role.colour.combined.nonzero? }.max
     end
 
     alias_method :color_role, :colour_role
 
-    # @return [ColourRGB, nil] the colour this member has.
+    # Get the primary colour of the member.
+    # @return [ColourRGB, nil] The colour this member has.
     def colour
-      return nil unless colour_role
-
-      colour_role.color
+      colour_role&.colour
     end
 
     alias_method :color, :colour
 
     # Get the member's roles sorted by their order in the hierarchy.
-    # @return [Array<Role>] the roles the member has, ordered by hierarchy.
+    # @return [Array<Role>] The roles the member has, ordered by hierarchy.
     def sort_roles
-      roles.sort_by { |role| [role.position, role.id] }
+      roles.sort
     end
 
     # Server deafens this member.

--- a/lib/discordrb/data/role.rb
+++ b/lib/discordrb/data/role.rb
@@ -320,7 +320,7 @@ module Discordrb
         raise ArgumentError, 'The target role that was provded is not valid'
       end
 
-      roles = @server.roles.sort_by { |role| [role.position, role.id] }
+      roles = @server.roles.sort
 
       # Make sure we remove the current role.
       myself = roles.rindex(@id).tap { |index| roles.delete_at(index) }
@@ -372,6 +372,52 @@ module Discordrb
     end
 
     alias_method :update_colors, :update_colours
+
+    # Check if this role is less than another role in the hierarchy.
+    # @param other [Role] The other role that you want to compare to this one.
+    # @return [true, false] Whether or not this role is less than the other role in the hierarchy.
+    def <(other)
+      # rubocop:disable Style/NumericPredicate
+      self.<=>(other) < 0
+    end
+
+    # Check if this role is greater than another role in the hierarchy.
+    # @param other [Role] The other role that you want to compare to this one.
+    # @return [true, false] Whether or not this role is greater than the other role in the hierarchy.
+    def >(other)
+      self.<=>(other) > 0
+      # rubocop:enable Style/NumericPredicate
+    end
+
+    # Check if this role is less than or equal to another role in the hierarchy.
+    # @param other [Role] The other role that you want to against to this one.
+    # @return [true, false] Whether or not this role is less than or equal to the other role in the hierarchy.
+    def <=(other)
+      self.<=>(other) <= 0
+    end
+
+    # Check if this role is greater than or equal to another role in the hierarchy.
+    # @param other [Role] The other role that you want to compare against this one.
+    # @return [true, false] Whether or not this role is greater than or equal to the other role in the hierarchy.
+    def >=(other)
+      self.<=>(other) >= 0
+    end
+
+    # Compare the role against another role based on its position.
+    # @param other [Role] The role to compare the current role against.
+    # @return [0, -1, 1, nil] An integer representing the ordering of the
+    #   roles, or `nil` if the other entity is not able to be compared to the role.
+    def <=>(other)
+      return unless other.is_a?(Role) && @server == other.server
+
+      if @id == other.id
+        0
+      elsif @position == other.position
+        other.id <=> @id
+      else
+        @position <=> other.position
+      end
+    end
 
     # Modify the properties of the role.
     # @param name [String, nil] The new 1-100 character name of the role.
@@ -441,7 +487,7 @@ module Discordrb
       nil
     end
 
-    # The inspect method is overwritten to give more useful output
+    # The inspect method is overwritten to give more useful output.
     def inspect
       "<Role name=#{@name} permissions=#{@permissions.inspect} hoist=#{@hoist} colour=#{@colour.inspect} server=#{@server.inspect} position=#{@position} mentionable=#{@mentionable} unicode_emoji=#{@unicode_emoji} flags=#{@flags}>"
     end


### PR DESCRIPTION
## Summary

This PR adds the `>`, `<`, `<=`,`>=`, and `<=>` operators for comparing roles via their position in the hierarchy. I understand this may be an unwanted change, but it makes comparing roles by their position a lot easier. Other libraries implement [similar interfaces](https://github.com/Rapptz/discord.py/blob/master/discord/role.py#L241) too. Additionally, by implementing the Darth Vader ship operator `<=>`, calling `#sort` on an `Array<Role>` now behaves correctly.

## Added
`Role#>`
`Role#<`
`Role#<=`
`Role#>=`
`Role#between?`