### PR TITLE
fix: release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: ruby
+          ruby-version: '3.4.7'
 
       - name: Validate tag matches gemspecs
         run: |


### PR DESCRIPTION
## Summary

This locks the release workflow to run on Ruby 3.4, since previously the workflow defaulted to Ruby 4 and ended up [breaking](https://discord.com/channels/81384788765712384/381891448884428801/1468641322335473778)