### PR TITLE
feat: add widget properties to Server#modify

### DIFF
--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -61,6 +61,21 @@ module Discordrb::API::Server
     )
   end
 
+  # Modify the properties of a widget for a server.
+  # https://docs.discord.com/developers/resources/guild#modify-guild-widget
+  def update_widget(token, server_id, enabled: :undef, channel_id: :undef, reason: nil)
+    Discordrb::API.request(
+      :guilds_sid_widget,
+      server_id,
+      :patch,
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/widget",
+      { enabled:, channel_id: }.reject { |_, value| value == :undef }.to_json,
+      content_type: :json,
+      Authorization: token,
+      'X-Audit-Log-Reason': reason
+    )
+  end
+
   # Get a server's channels list
   # https://discord.com/developers/docs/resources/guild#get-guild-channels
   def channels(token, server_id)

--- a/lib/discordrb/data/application.rb
+++ b/lib/discordrb/data/application.rb
@@ -143,6 +143,7 @@ module Discordrb
 
     # Delete an integration types config for the application.
     # @param type [Integer, String] The type of the integration type to remove.
+    # @return [nil]
     def delete_integration_type(type)
       new_data = @integration_types.dup.tap { |i| i.delete(type.to_i) }
       modify(integration_types: collect_integration_types(new_data))
@@ -152,6 +153,7 @@ module Discordrb
     # @param type [Integer, String] The type of the integration type.
     # @param scopes [Array<String, Symbol>, nil] The default Oauth scopes for the config.
     # @param permissions [Permissions, String, Integer, nil] The default permissions for the config.
+    # @return [nil]
     def add_integration_type(type:, scopes: nil, permissions: nil)
       permissions = permisisons.bits if permissions.respond_to?(:bits)
       new_data = @integration_types.dup
@@ -167,7 +169,7 @@ module Discordrb
     # Get the integration types config for when the application has been installed to a user.
     # @return [InstallParams, nil] The default install params for when the application's is installed to a user.
     def user_integration_type
-      @integration_type[1]
+      @integration_types[1]
     end
 
     # Get the integration types config for when the application has been installed in a server.
@@ -317,7 +319,7 @@ module Discordrb
       @interactions_endpoint_url = new_data['interactions_endpoint_url']
       @role_connections_verification_url = new_data['role_connections_verification_url']
       @webhook_events_url = new_data['event_webhooks_url']
-      @webhook_events_status = new_data['event_webhooks_status']
+      @webhook_events_status = new_data['event_webhooks_status'] || 1
 
       @webhook_event_types = new_data['event_webhooks_types'] || []
       @tags = new_data['tags'] || []

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -244,11 +244,15 @@ module Discordrb
       AuditLogs.new(self, @bot, JSON.parse(API::Server.audit_logs(@bot.token, @id, limit, user, action, before)))
     end
 
-    # Cache @widget
     # @note For internal use only
     # @!visibility private
-    def cache_widget_data
-      data = JSON.parse(API::Server.widget(@bot.token, @id))
+    def cache_widget_data(data = nil)
+      data ||= if bot.permission?(:manage_server)
+                 JSON.parse(API::Server.widget(@bot.token, @id))
+               else
+                 return update_data(nil)
+               end
+
       @widget_enabled = data['enabled']
       @widget_channel_id = data['channel_id']
     end
@@ -271,6 +275,7 @@ module Discordrb
 
     # Sets whether this server's widget is enabled
     # @param value [true, false]
+    # @deprecated Please migrate to using {#modify} with the `widget_enabled:` parameter.
     def widget_enabled=(value)
       modify_widget(value, widget_channel)
     end
@@ -279,6 +284,7 @@ module Discordrb
     # Sets whether this server's widget is enabled
     # @param value [true, false]
     # @param reason [String, nil] the reason to be shown in the audit log for this action
+    # @deprecated Please migrate to using {#modify} with the `widget_enabled:` parameter.
     def set_widget_enabled(value, reason = nil)
       modify_widget(value, widget_channel, reason)
     end
@@ -286,6 +292,7 @@ module Discordrb
 
     # Changes the channel on the server's widget
     # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the widget
+    # @deprecated Please migrate to using {#modify} with the `widget_channel:` parameter.
     def widget_channel=(channel)
       modify_widget(widget?, channel)
     end
@@ -294,6 +301,7 @@ module Discordrb
     # Changes the channel on the server's widget
     # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the widget
     # @param reason [String, nil] the reason to be shown in the audit log for this action
+    # @deprecated Please migrate to using {#modify} with the `widget_channel:` parameter.
     def set_widget_channel(channel, reason = nil)
       modify_widget(widget?, channel, reason)
     end
@@ -303,12 +311,11 @@ module Discordrb
     # @param enabled [true, false] whether the widget is enabled
     # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the widget
     # @param reason [String, nil] the reason to be shown in the audit log for this action
+    # @deprecated Please migrate to using {#modify} with the `widget_enabled:` and `widget_channel:` parameters.
     def modify_widget(enabled, channel, reason = nil)
       cache_widget_data if @widget_enabled.nil?
       channel_id = channel ? channel.resolve_id : @widget_channel_id
-      response = JSON.parse(API::Server.modify_widget(@bot.token, @id, enabled, channel_id, reason))
-      @widget_enabled = response['enabled']
-      @widget_channel_id = response['channel_id']
+      cache_widget_data(JSON.parse(API::Server.modify_widget(@bot.token, @id, enabled, channel_id, reason)))
     end
     alias_method :modify_embed, :modify_widget
 
@@ -1096,6 +1103,8 @@ module Discordrb
     # @param description [String, nil] The new description of the server.
     # @param boost_progress_bar [true, false] Whether or not the server boosting progress bar should be visible.
     # @param safety_alerts_channel [Channel, Integer, String, nil] The new channel where safety alerts should be sent.
+    # @param widget_enabled [true, false, nil] Whether or not the server's widget should be enabled.
+    # @param widget_channel [Channel, Integer, String, nil] The new invite channel for the server's widget.
     # @param dms_disabled_until [Time, nil] The time at when non-friend direct messages will be enabled again.
     # @param invites_disabled_until [Time, nil] The time at when invites will no longer be disabled.
     # @param reason [String, nil] The reason to show in the server's audit log for modifying the server.
@@ -1105,7 +1114,8 @@ module Discordrb
       afk_channel: :undef, afk_timeout: :undef, icon: :undef, splash: :undef, discovery_splash: :undef, banner: :undef,
       system_channel: :undef, system_channel_flags: :undef, rules_channel: :undef, public_updates_channel: :undef,
       locale: :undef, features: :undef, description: :undef, boost_progress_bar: :undef, safety_alerts_channel: :undef,
-      dms_disabled_until: :undef, invites_disabled_until: :undef, reason: nil
+      widget_enabled: :undef, widget_channel: :undef, dms_disabled_until: :undef, invites_disabled_until: :undef,
+      reason: nil
     )
       data = {
         name: name,
@@ -1129,6 +1139,15 @@ module Discordrb
         safety_alerts_channel_id: safety_alerts_channel == :undef ? safety_alerts_channel : safety_alerts_channel&.resolve_id
       }
 
+      if widget_enabled != :undef || widget_channel != :undef
+        widget_data = {
+          enabled: widget_enabled,
+          channel_id: widget_channel == :undef ? widget_channel : widget_channel&.resolve_id
+        }
+
+        cache_widget_data(JSON.parse(API::Server.update_widget(@bot.token, @id, **widget_data, reason: reason)))
+      end
+
       if invites_disabled_until != :undef || dms_disabled_until != :undef
         incidents_data = {
           dms_disabled_until: dms_disabled_until == :undef ? @dms_disabled_until&.iso8601 : dms_disabled_until&.iso8601,
@@ -1136,8 +1155,9 @@ module Discordrb
         }
 
         process_incident_actions(JSON.parse(API::Server.update_incident_actions(@bot.token, @id, **incidents_data, reason: reason)))
-        return unless data.any? { |_, value| value != :undef }
       end
+
+      return unless data.any? { |_, value| value != :undef }
 
       update_data(JSON.parse(API::Server.update!(@bot.token, @id, **data, reason: reason)))
       nil


### PR DESCRIPTION
## Summary

Adds the `widget_enabled` and `widget_channel` keywords to `Server#modify`.

## Added
`widget_enabled` and `widget_channel` keywords to `Server#modify`.

## Fixed
403 errors when fetching the server's widget without the `manage_server` permission.