### PR TITLE
bump: minimum ruby version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           restore-keys: |
             bundle-${{ matrix.ruby }}
       - name: Install dependencies
-        run: bundle install --path vendor/bundle
+        run: bundle config set path vendor/bundle && bundle install
       - name: Run RSpec
         run: |
           mkdir -p rspec
@@ -52,7 +52,7 @@ jobs:
           path: vendor/bundle
           key: bundle-${{ hashFiles('Gemfile', 'discordrb.gemspec') }}-rubocop
       - name: Install dependencies
-        run: bundle install --path vendor/bundle
+        run: bundle config set path vendor/bundle && bundle install
       - name: Run Rubocop
         run: bundle exec rubocop
 
@@ -71,7 +71,7 @@ jobs:
           path: vendor/bundle
           key: bundle-${{ hashFiles('Gemfile', 'discordrb.gemspec') }}-yard
       - name: Install dependencies
-        run: bundle install --path vendor/bundle
+        run: bundle config set path vendor/bundle && bundle install
       - name: Run YARD
         run: |
           mkdir -p docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [3.2, 3.3, 3.4]
+        ruby: [3.3, 3.4, 4.0]
     container:
       image: ruby:${{ matrix.ruby }}-alpine
     steps:

--- a/discordrb-webhooks.gemspec
+++ b/discordrb-webhooks.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client', '>= 2.0.0'
 
-  spec.required_ruby_version = '>= 3.2'
+  spec.required_ruby_version = '>= 3.3'
   spec.metadata = {
     'rubygems_mfa_required' => 'true'
   }

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'discordrb-webhooks', "~> #{Discordrb::Webhooks::VERSION}"
 
-  spec.required_ruby_version = '>= 3.2'
+  spec.required_ruby_version = '>= 3.3'
 
   spec.add_development_dependency 'bundler', '>= 1.10', '< 5'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
## Summary

Ruby 3.2 has reached the [end-of-life](https://www.ruby-lang.org/en/downloads/branches/.) "EOL: 2026-03-31 (expected)".

## Changed
I bumped the min ruby version to 3.3, and added Ruby 4.0 to the test matrix (because it's the next version).