### PR TITLE
feat: embed and media flags

### DIFF
--- a/lib/discordrb/data/attachment.rb
+++ b/lib/discordrb/data/attachment.rb
@@ -5,6 +5,14 @@ module Discordrb
   class Attachment
     include IDObject
 
+    # Mapping of attachment flags.
+    FLAGS = {
+      clip: 1 << 0,
+      thumbnail: 1 << 1,
+      spoiler: 1 << 3,
+      animated: 1 << 5
+    }.freeze
+
     # @return [String] the CDN URL this attachment can be downloaded at.
     attr_reader :url
 
@@ -43,6 +51,21 @@ module Discordrb
     # @return [Integer] the flags set on this attachment combined as a bitfield.
     attr_reader :flags
 
+    # @return [String, nil] the thumbhash of the attachment, if applicable.
+    attr_reader :placeholder
+
+    # @return [Integer, nil] the version of the attachment's thumbhash, if applicable.
+    attr_reader :placeholder_version
+
+    # @return [Application, nil] the application that was recognized in the clipped stream.
+    attr_reader :clip_application
+
+    # @return [Array<User>] the users who were in the clipped stream.
+    attr_reader :clip_participants
+
+    # @return [Time, nil] the time at when the clip was created, if applicable.
+    attr_reader :clip_creation_time
+
     # @!visibility private
     def initialize(data, message, bot)
       @bot = bot
@@ -66,6 +89,13 @@ module Discordrb
       @duration_seconds = data['duration_secs']&.to_f
       @waveform = data['waveform']
       @flags = data['flags'] || 0
+
+      @placeholder = data['placeholder']
+      @placeholder_version = data['placeholder_version']
+
+      @clip_application = Application.new(data['application'], @bot) if data['application']
+      @clip_participants = data['clip_participants']&.map { |user| @bot.ensure_user(user) } || []
+      @clip_creation_time = Time.iso8601(data['clip_created_at']) if data['clip_created_at']
     end
 
     # @return [true, false] whether this file is an image file.
@@ -75,7 +105,7 @@ module Discordrb
 
     # @return [true, false] whether this file is tagged as a spoiler.
     def spoiler?
-      @filename.start_with? 'SPOILER_'
+      @filename.start_with?('SPOILER_') || @flags.anybits?(FLAGS[:spoiler])
     end
 
     # @return [Message, nil] the message this attachment object belongs to.
@@ -86,6 +116,16 @@ module Discordrb
     # @return [Snapshot, nil] the message snapshot this attachment object belongs to.
     def snapshot
       @message unless @message.is_a?(Message)
+    end
+
+    # @!method clip?
+    #   @return [true, false] whether or not the attachment is a clip from a stream.
+    # @!method thumbnail?
+    #   @return [true, false] whether or not the attachment is the thumbnail of a thread in a media channel.
+    # @!method animated?
+    #   @return [true, false] whether or not the attachment is considered to be an animated image.
+    FLAGS.each do |name, value|
+      define_method("#{name}?") { @flags.anybits?(value) } if name != :spoiler
     end
   end
 end

--- a/lib/discordrb/data/component.rb
+++ b/lib/discordrb/data/component.rb
@@ -446,8 +446,16 @@ module Discordrb
 
     # Resolved metadata about a piece of media.
     class MediaItem
+      # Mapping of flags.
+      FLAGS = {
+        animated: 1 << 0
+      }.freeze
+
       # @return [String] the URL to the media item.
       attr_reader :url
+
+      # @return [Integer] the flags of the media item.
+      attr_reader :flags
 
       # @return [Integer, nil] the width of the media item.
       attr_reader :width
@@ -458,6 +466,9 @@ module Discordrb
       # @return [String, nil] the proxied URL to the media item.
       attr_reader :proxy_url
 
+      # @return [String, nil] the placeholder of the media item.
+      attr_reader :placeholder
+
       # @return [String, nil] the content type of the media item.
       attr_reader :content_type
 
@@ -465,15 +476,29 @@ module Discordrb
       #   when the media item was uploaded via an `attachment://<filename>` reference.
       attr_reader :attachment_id
 
+      # @return [Integer, nil] the version of the thumbhash for images and videos, if any.
+      attr_reader :placeholder_version
+
       # @!visibility private
       def initialize(data, bot)
         @bot = bot
         @url = data['url']
         @width = data['width']
+        @flags = data['flags']
         @height = data['height']
         @proxy_url = data['proxy_url']
+        @placeholder = data['placeholder']
         @content_type = data['content_type']
         @attachment_id = data['attachment_id']&.to_i
+        @placeholder_version = data['placeholder_version']
+      end
+
+      # @!method animated?
+      #   @return [true, false] whether or not the media item is animated.
+      FLAGS.each do |name, value|
+        define_method("#{name}?") do
+          @flags.anybits?(value)
+        end
       end
     end
 

--- a/lib/discordrb/data/embed.rb
+++ b/lib/discordrb/data/embed.rb
@@ -11,6 +11,9 @@ module Discordrb
     # @return [String, nil] the title of the embed object. `nil` if there is not a title
     attr_reader :title
 
+    # @return [Integer] the flags of the embed object combined as a bitfield.
+    attr_reader :flags
+
     # @return [String, nil] the description of the embed object. `nil` if there is not a description
     attr_reader :description
 
@@ -55,17 +58,18 @@ module Discordrb
 
       @url = data['url']
       @title = data['title']
+      @flags = data['flags'] || 0
       @type = data['type'].to_sym
       @description = data['description']
-      @timestamp = data['timestamp'].nil? ? nil : Time.parse(data['timestamp'])
+      @timestamp = Time.parse(data['timestamp']) if data['timestamp']
       @color = data['color']
-      @footer = data['footer'].nil? ? nil : EmbedFooter.new(data['footer'], self)
-      @image = data['image'].nil? ? nil : EmbedImage.new(data['image'], self)
-      @video = data['video'].nil? ? nil : EmbedVideo.new(data['video'], self)
-      @provider = data['provider'].nil? ? nil : EmbedProvider.new(data['provider'], self)
-      @thumbnail = data['thumbnail'].nil? ? nil : EmbedThumbnail.new(data['thumbnail'], self)
-      @author = data['author'].nil? ? nil : EmbedAuthor.new(data['author'], self)
-      @fields = data['fields'].nil? ? nil : data['fields'].map { |field| EmbedField.new(field, self) }
+      @footer = EmbedFooter.new(data['footer'], self) if data['footer']
+      @image = EmbedImage.new(data['image'], self) if data['image']
+      @video = EmbedVideo.new(data['video'], self) if data['video']
+      @provider = EmbedProvider.new(data['provider'], self) if data['provider']
+      @thumbnail = EmbedThumbnail.new(data['thumbnail'], self) if data['thumbnail']
+      @author = EmbedAuthor.new(data['author'], self) if data['author']
+      @fields = data['fields']&.map { |field| EmbedField.new(field, self) }
     end
 
     # @return [Message, nil] the message this embed object is contained in.
@@ -120,6 +124,21 @@ module Discordrb
     # @return [Integer] the height of the image, in pixels.
     attr_reader :height
 
+    # @return [Integer] the flags of the image, as a bitfield.
+    attr_reader :flags
+
+    # @return [String, nil] the alt text of the image.
+    attr_reader :description
+
+    # @return [String, nil] the media type of the image.
+    attr_reader :content_type
+
+    # @return [String, nil] the thumbhash of the image.
+    attr_reader :placeholder
+
+    # @return [Integer, nil] the version of the image's thumbhash.
+    attr_reader :placeholder_version
+
     # @!visibility private
     def initialize(data, embed)
       @embed = embed
@@ -128,6 +147,11 @@ module Discordrb
       @proxy_url = data['proxy_url']
       @width = data['width']
       @height = data['height']
+      @flags = data['flags'] || 0
+      @description = data['description']
+      @content_type = data['content_type']
+      @placeholder = data['placeholder']
+      @placeholder_version = data['placeholder_version']
     end
   end
 
@@ -139,19 +163,43 @@ module Discordrb
     # @return [String] the source URL of the video.
     attr_reader :url
 
+    # @return [String] the proxy URL of the video.
+    attr_reader :proxy_url
+
     # @return [Integer] the width of the video, in pixels.
     attr_reader :width
 
     # @return [Integer] the height of the video, in pixels.
     attr_reader :height
 
+    # @return [Integer] the flags of the video, as a bitfield.
+    attr_reader :flags
+
+    # @return [String, nil] the alt text of the video.
+    attr_reader :description
+
+    # @return [String, nil] the media type of the video.
+    attr_reader :content_type
+
+    # @return [String, nil] the thumbhash of the video.
+    attr_reader :placeholder
+
+    # @return [Integer, nil] the version of the video's thumbhash.
+    attr_reader :placeholder_version
+
     # @!visibility private
     def initialize(data, embed)
       @embed = embed
 
       @url = data['url']
+      @proxy_url = data['proxy_url']
       @width = data['width']
       @height = data['height']
+      @flags = data['flags'] || 0
+      @description = data['description']
+      @content_type = data['content_type']
+      @placeholder = data['placeholder']
+      @placeholder_version = data['placeholder_version']
     end
   end
 


### PR DESCRIPTION
## Summary

This PR adds embed flags and a few other new fields that were added for attachments recently

## Added
`Embed#flags`

`EmbedImage#flags`
`EmbedImage#description`
`EmbedImage#placeholder`
`EmbedImage#content_type`
`EmbedImage#placeholder_version`

`EmbedVideo#flags`
`EmbedVideo#proxy_url`
`EmbedVideo#description`
`EmbedVideo#placeholder`
`EmbedVideo#content_type`
`EmbedVideo#placeholder_version`

`MediaItem#flags`
`MediaItem::FLAGS`
`MediaItem#placeholder`
`MediaItem#placeholder_version`

`Attachment::FLAGS`
`Attachment#placeholder`
`Attachment#clip_application`
`Attachment#clip_participants`
`Attachment#clip_creation_time`
`Attachment#placeholder_version`