### PR TITLE
feat: voice channel status

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -340,6 +340,21 @@ module Discordrb::API::Channel
     )
   end
 
+  # Update the status of a voice channel.
+  # https://discord.com/developers/docs/resources/channel#set-voice-channel-status
+  def set_voice_channel_status(token, channel_id, status, reason: nil)
+    Discordrb::API.request(
+      :channels_cid_voice_status,
+      channel_id,
+      :put,
+      "#{Discordrb::API.api_base}/channels/#{channel_id}/voice-status",
+      { status: }.to_json,
+      content_type: :json,
+      Authorization: token,
+      'X-Audit-Log-Reason': reason
+    )
+  end
+
   # Get a list of pinned messages in a channel
   # https://discord.com/developers/docs/resources/message#get-channel-pins
   def pinned_messages(token, channel_id, limit = 50, before = nil)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1531,6 +1531,24 @@ module Discordrb
         event.channel.process_last_pin_timestamp(data['last_pin_timestamp']) if data.key?('last_pin_timestamp')
 
         raise_event(event)
+      when :VOICE_CHANNEL_STATUS_UPDATE
+        @channels[data['id'].to_i]&.process_voice_status(data['status'])
+
+        event = ChannelStatusUpdateEvent.new(data, self)
+        raise_event(event)
+      when :VOICE_CHANNEL_START_TIME_UPDATE
+        @channels[data['id'].to_i]&.process_start_time(data['voice_start_time'])
+
+        event = ChannelStartTimeUpdateEvent.new(data, self)
+        raise_event(event)
+      when :CHANNEL_INFO
+        data['channels'].each do |inner|
+          next unless (channel = @channels[inner['id'].to_i])
+
+          channel.process_voice_status(inner['status']) if inner.key?('status')
+
+          channel.process_start_time(inner['voice_start_time']) if inner.key?('voice_start_time')
+        end
       when :GUILD_MEMBER_ADD
         add_guild_member(data)
 

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -290,6 +290,36 @@ module Discordrb
       register_event(ChannelRecipientRemoveEvent, attributes, block)
     end
 
+    # This **event** is raised whenever the status for a voice channel is updated.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [String, Regexp] :status Matches the new status of the voice channel.
+    # @option attributes [String, Integer, Server] :server Matches the server where the status was updated.
+    # @option attributes [String, Integer, Channel] :channel Matches the channel where the status was updated.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [ChannelStatusUpdateEvent] The event that was raised.
+    # @return [ChannelStatusUpdateEventHandler] the event handler that was registered.
+    def channel_status_update(attributes = {}, &block)
+      register_event(ChannelStatusUpdateEvent, attributes, block)
+    end
+
+    alias_method :voice_channel_status, :channel_status_update
+
+    # This **event** is raised whenever the start time for a voice channel is updated.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [Time] :start_time Matches the of the start time of the voice channel.
+    # @option attributes [Time] :after Matches a time after the start time of the voice channel.
+    # @option attributes [Time] :before Matches a time before the start time of the voice channel.
+    # @option attributes [String, Integer, Server] :server Matches the server where the start time was updated.
+    # @option attributes [String, Integer, Channel] :channel Matches the channel where the start time was updated.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [ChannelStartTimeUpdateEvent] The event that was raised.
+    # @return [ChannelStartTimeUpdateEventHandler] the event handler that was registered.
+    def channel_start_time_update(attributes = {}, &block)
+      register_event(ChannelStartTimeUpdateEvent, attributes, block)
+    end
+
+    alias_method :voice_channel_start_time, :channel_start_time_update
+
     # This **event** is raised when a user's voice state changes. This includes when a user joins, leaves, or
     # moves between voice channels, as well as their mute and deaf status for themselves and on the server.
     # @param attributes [Hash] The event's attributes.

--- a/lib/discordrb/data/audit_logs.rb
+++ b/lib/discordrb/data/audit_logs.rb
@@ -73,7 +73,9 @@ module Discordrb
       166 => :onboarding_create,
       167 => :onboarding_update,
       190 => :home_settings_create,
-      191 => :home_settings_update
+      191 => :home_settings_update,
+      192 => :voice_channel_status_create,
+      193 => :voice_channel_status_delete
     }.freeze
 
     # @!visibility private
@@ -83,7 +85,7 @@ module Discordrb
       stage_instance_create sticker_create scheduled_event_create thread_create
       soundboard_sound_create auto_moderation_rule_create onboarding_prompt_create
       onboarding_create home_settings_create creator_monetization_request_created
-      message_pin auto_moderation_flag_to_channel
+      message_pin auto_moderation_flag_to_channel voice_channel_status_create
     ].freeze
 
     # @!visibility private
@@ -94,6 +96,7 @@ module Discordrb
       stage_instance_delete sticker_delete scheduled_event_delete
       thread_delete soundboard_sound_delete auto_moderation_rule_delete
       onboarding_prompt_delete message_unpin auto_moderation_block_message
+      voice_channel_status_delete
     ].freeze
 
     # @!visibility private
@@ -175,6 +178,9 @@ module Discordrb
       # @return [Symbol, nil] the type of the permission overwrite.
       attr_reader :overwrite_type
 
+      # @return [String, nil] the new status of the voice channel.
+      attr_reader :status
+
       # @return [String, nil] the reason for this action occurring.
       attr_reader :reason
 
@@ -215,6 +221,7 @@ module Discordrb
         @overwrite_role_name = options['role_name']
         @overwrite_id = options['id']&.to_i
         @overwrite_type = Overwrite::TYPES.key(options['type']) if options['type']
+        @status = options['status'] == '' ? nil : options['status']
       end
 
       # @return [Server, Channel, Member, User, Role, Invite, Webhook, Emoji, nil] the target being performed on.
@@ -418,6 +425,7 @@ module Discordrb
       when 163..165 then :onboarding_prompt
       when 166..167 then :onboarding
       when 190..191 then :home_settings
+      when 192..193 then :voice_channel_status
 
       else :unknown
       end

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -1036,6 +1036,30 @@ module Discordrb
       @bot.ensure_channel(JSON.parse(data))
     end
 
+    # Fetch the status of the voice channel.
+    # @return [String, nil] The status of the voice channel, or `nil`.
+    def status
+      if !instance_variable_defined?(:@status) && voice?
+        @bot.gateway.send_request_channel_info(@server_id, %i[status voice_start_time])
+
+        sleep(0.01) until instance_variable_defined?(:@status)
+      end
+
+      @status
+    end
+
+    # Fetch the start time of the sesison for the voice channel.
+    # @return [Time, nil] The time at when the voice session started, or `nil`.
+    def start_time
+      if !instance_variable_defined?(:@start_time) && voice?
+        @bot.gateway.send_request_channel_info(@server_id, %i[status voice_start_time])
+
+        sleep(0.01) until instance_variable_defined?(:@start_time)
+      end
+
+      @start_time
+    end
+
     # Start a thread in a forum or media channel.
     # @param name [String] The name of the forum post to create.
     # @param auto_archive_duration [Integer, nil] How long before the post is automatically archived.
@@ -1215,6 +1239,7 @@ module Discordrb
     # @param position [Integer, nil] The new sorting position of the channel. Generally, this parameter should not be used. Please use {#sort_after} instead.
     # @param auto_archive_duration [Integer] The amount of minutes after which the thread will stop showing in the channel list.
     # @param default_thread_rate_limit_per_user [Integer] The default slowmode rate to set on threads created in the text or forum channel.
+    # @param status [String, nil] The status to set for the voice channel; between 1-500 characters, or `nil` to clear the existing status.
     # @param reason [String, nil] The reason to show in the server's audit log for modifying the channel.
     # @return [nil]
     def modify(
@@ -1222,7 +1247,7 @@ module Discordrb
       user_limit: :undef, permission_overwrites: :undef, parent: :undef, voice_region: :undef, video_quality_mode: :undef,
       default_auto_archive_duration: :undef, flags: :undef, tags: :undef, default_reaction: :undef, default_sort_order: :undef,
       default_forum_layout: :undef, archived: :undef, locked: :undef, invitable: :undef, add_flags: :undef, remove_flags: :undef,
-      position: :undef, auto_archive_duration: :undef, default_thread_rate_limit_per_user: :undef, reason: nil
+      position: :undef, auto_archive_duration: :undef, default_thread_rate_limit_per_user: :undef, status: :undef, reason: nil
     )
       data = {
         name: name,
@@ -1275,6 +1300,12 @@ module Discordrb
         data[:flags] = ((@flags & ~to_flags.call(remove_flags)) | to_flags.call(add_flags))
       end
 
+      if status != :undef && voice?
+        API::Channel.set_voice_channel_status(@bot.token, @id, status.to_s, reason: reason)
+
+        return unless data.any? { |_, value| value != :undef }
+      end
+
       update_data(JSON.parse(API::Channel.update!(@bot.token, @id, **data, reason: reason)))
       nil
     end
@@ -1285,7 +1316,7 @@ module Discordrb
     end
 
     # Set the last pin timestamp of a channel.
-    # @param time [String, nil] the time of the last pinned message in the channel
+    # @param time [String, nil] The time of the last pinned message in the channel.
     # @note For internal use only
     # @!visibility private
     def process_last_pin_timestamp(time)
@@ -1293,16 +1324,32 @@ module Discordrb
     end
 
     # Set the last message ID of a channel.
-    # @param id [Integer, nil] the ID of the last message in a channel
+    # @param id [Integer, nil] The ID of the last message in a channel.
     # @note For internal use only
     # @!visibility private
     def process_last_message_id(id)
       @last_message_id = id
     end
 
+    # Set the voice channel status of a channel.
+    # @param status [String, nil] The status of the voice channel.
+    # @note For internal use only
+    # @!visibility private
+    def process_voice_status(status)
+      @status = status&.empty? ? nil : status
+    end
+
+    # Set the start time of a voice channel.
+    # @param time [Integer, nil] The start time of the voice channel.
+    # @note For internal use only
+    # @!visibility private
+    def process_start_time(time)
+      @start_time = time ? Time.at(time) : time
+    end
+
     # Set the available tags of a channel.
-    # @param tag [Hash] the data for the tag to create
-    # @param reason [String, nil] the reason to show in the audit log
+    # @param tag [Hash] The data for the tag to create.
+    # @param reason [String, nil] The reason to show in the audit log.
     # @note For internal use only
     # @!visibility private
     def update_tags(tag, reason)

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -1506,11 +1506,18 @@ module Discordrb
     end
 
     def process_incident_actions(incidents)
-      incidents ||= {}
-      @raid_detected_at = incidents['raid_detected_at'] ? Time.parse(incidents['raid_detected_at']) : nil
-      @dms_disabled_until = incidents['dms_disabled_until'] ? Time.parse(incidents['dms_disabled_until']) : nil
-      @dm_spam_detected_at = incidents['dm_spam_detected_at'] ? Time.parse(incidents['dm_spam_detected_at']) : nil
-      @invites_disabled_until = incidents['invites_disabled_until'] ? Time.parse(incidents['invites_disabled_until']) : nil
+      incidents&.each do |key, value|
+        case key
+        when 'raid_detected_at'
+          @raid_detected_at = value ? Time.parse(value) : nil
+        when 'dms_disabled_until'
+          @dms_disabled_until = value ? Time.parse(value) : nil
+        when 'dm_spam_detected_at'
+          @dm_spam_detected_at = value ? Time.parse(value) : nil
+        when 'invites_disabled_until'
+          @invites_disabled_until = value ? Time.parse(value) : nil
+        end
+      end
     end
 
     def process_scheduled_events(events)

--- a/lib/discordrb/events/channels.rb
+++ b/lib/discordrb/events/channels.rb
@@ -185,9 +185,8 @@ module Discordrb::Events
     # @!visibility private
     def initialize(data, bot)
       @bot = bot
-
-      @server = bot.server(data['guild_id']) if data['guild_id']
       @channel = bot.channel(data['channel_id'])
+      @server = @channel.server
       @last_pin_timestamp = Time.iso8601(data['last_pin_timestamp']) if data['last_pin_timestamp']
     end
   end
@@ -201,6 +200,105 @@ module Discordrb::Events
       [
         matches_all(@attributes[:server], event.server) { |a, e| a.resolve_id == e&.id },
         matches_all(@attributes[:channel], event.channel) { |a, e| a.resolve_id == e.id }
+      ].reduce(true, &:&)
+    end
+  end
+
+  # Raised whenever the status of a voice channel is updated.
+  class ChannelStatusUpdateEvent < Event
+    # @return [String, nil] the new status of the voice channel.
+    attr_reader :status
+
+    # @return [Server] the server that the voice channel is from.
+    attr_reader :server
+
+    # @return [Channel] the channel whose voice status was updated.
+    attr_reader :channel
+
+    # @!visibility private
+    def initialize(data, bot)
+      @bot = bot
+      @channel = bot.channel(data['id'])
+      @server = @channel.server
+      @status = data['status'] == '' ? nil : data['status']
+    end
+  end
+
+  # Event handler for ChannelStatusUpdateEvent.
+  class ChannelStatusUpdateEventHandler < EventHandler
+    # @!visibility private
+    def matches?(event)
+      # Check for the proper event type.
+      return false unless event.is_a?(ChannelStatusUpdateEvent)
+
+      [
+        matches_all(@attributes[:status], event.status) do |a, e|
+          case a
+          when Regexp
+            a.match?(e) if e
+          else
+            a == e
+          end
+        end,
+
+        matches_all(@attributes[:server], event.server) do |a, e|
+          a&.resolve_id == e&.resolve_id
+        end,
+
+        matches_all(@attributes[:channel], event.channel) do |a, e|
+          a&.resolve_id == e&.resolve_id
+        end
+      ].reduce(true, &:&)
+    end
+  end
+
+  # Raised whenever the start time of a voice channel is updated.
+  class ChannelStartTimeUpdateEvent < Event
+    # @return [Server] the server associated with the event.
+    attr_reader :server
+
+    # @return [Channel] the channel associated with the event.
+    attr_reader :channel
+
+    # @return [Time, nil] the new start time of the voice channel.
+    attr_reader :start_time
+
+    # @!visibility private
+    def initialize(data, bot)
+      @bot = bot
+      @channel = bot.channel(data['id'])
+      @server = @channel.server
+      @start_time = Time.at(data['voice_start_time']) if data['voice_start_time']
+    end
+  end
+
+  # Event handler for ChannelStartTimeUpdateEvent.
+  class ChannelStartTimeUpdateEventHandler < EventHandler
+    # @!visibility private
+    def matches?(event)
+      # Check for the proper event type.
+      return false unless event.is_a?(ChannelStartTimeUpdateEvent)
+
+      [
+        matches_all(@attributes[:server], event.server) do |a, e|
+          a&.resolve_id == e&.resolve_id
+        end,
+
+        matches_all(@attributes[:channel], event.channel) do |a, e|
+          a&.resolve_id == e&.resolve_id
+        end,
+
+        matches_all(@attributes[:after], event.start_time) do |a, e|
+          (e > a) if e
+        end,
+
+        matches_all(@attributes[:before], event.start_time) do |a, e|
+          (e < a) if e
+        end,
+
+        matches_all(@attributes[:start_time], event.start_time) do |a, e|
+          a.is_a?(Integer) ? (a == e&.to_i) : (a == e)
+        end
       ].reduce(true, &:&)
     end
   end

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -85,6 +85,11 @@ module Discordrb
     # **Received**: Returned after a heartbeat was sent to the server. This allows clients to identify and deal with
     # zombie connections that don't dispatch any events anymore.
     HEARTBEAT_ACK = 11
+
+    # **Sent**: This opcode identifies packets used to retrieve ephemeral channel data for channels in a server.
+    # This opcode is required to fetch the start time and status of a voice channel if the client does not already
+    # have them cached. (Sending this is never necessary for a gateway client to behave correctly)
+    REQUEST_CHANNEL_INFO = 43
   end
 
   # This class stores the data of an active gateway session. Note that this is different from a websocket connection -
@@ -424,6 +429,17 @@ module Discordrb
       }
 
       send_packet(Opcodes::REQUEST_MEMBERS, data)
+    end
+
+    # Sends a request channel info (op 43). This will order Discord to send ephemeral channel data such as the status
+    # and voice start time of the channels in the server as dispatch events with type `CHANNEL_INFO`. It is necessary to
+    # use this method to get the start time of a voice channel's session, if the client has not already recieved it.
+    # @param fields [Array<String, Symbol>] The fields to include in the dispatch event.
+    # @param server_id [Integer] The ID of the server to fetch ephemeral channel data for.
+    def send_request_channel_info(server_id, fields)
+      data = { guild_id: server_id, fields: fields }
+
+      send_packet(Opcodes::REQUEST_CHANNEL_INFO, data)
     end
 
     # Sends a custom packet over the connection. This can be useful to implement future yet unimplemented functionality

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -53,6 +53,7 @@ module Discordrb
       44 => :create_scheduled_events,     # 17592186044416
       45 => :use_external_sounds,         # 35184372088832
       46 => :send_voice_messages,         # 70368744177664
+      48 => :set_voice_channel_status,    # 281474976710656
       49 => :send_polls,                  # 562949953421312
       50 => :use_external_apps,           # 1125899906842624
       51 => :pin_messages,                # 2251799813685248


### PR DESCRIPTION
## Summary

Adds the "new" voice channel status feature.

## Added
`Channel#status`
`Channel#start_time`

`Opcodes::REQUEST_CHANNEL_INFO`
`Gateway#send_request_channel_info`
`API::Channel#set_voice_channel_status`

`EventContainer#channel_status_update`
`EventContainer#channel_start_time_update`

`Permissions::FLAGS[:set_voice_channel_status]`

`AuditLogs::Entry#status`
`AuditLogs::ACTIONS[:voice_channel_status_delete]`
`AuditLogs::ACTIONS[:voice_channel_status_update]`