### PR TITLE
fix: broken select menus

### DIFF
--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -1210,7 +1210,7 @@ module Discordrb
 
     # The default `inspect` method is overwritten to give more useful output.
     def inspect
-      "<Channel name=#{@name} id=#{@id} topic=\"#{@topic}\" type=#{@type} position=#{@position} server=#{@server || @server_id}>"
+      "<Channel name=#{@name} id=#{@id} topic=\"#{@topic}\" type=#{@type} position=#{@position} server_id=#{@server_id}>"
     end
 
     # Set the last pin timestamp of a channel.

--- a/lib/discordrb/data/role.rb
+++ b/lib/discordrb/data/role.rb
@@ -11,9 +11,6 @@ module Discordrb
     # @return [String] this role's name ("new role" if it hasn't been changed)
     attr_reader :name
 
-    # @return [Server] the server this role belongs to
-    attr_reader :server
-
     # @return [true, false] whether or not this role should be displayed separately from other users
     attr_reader :hoist
     alias_method :hoist?, :hoist
@@ -115,6 +112,7 @@ module Discordrb
       @permissions = Permissions.new(data['permissions'].to_i, RoleWriter.new(self, @bot.token))
       @name = data['name']
       @id = data['id'].to_i
+      @server_id = @server&.id || data['guild_id']&.to_i
 
       @position = data['position']
 
@@ -145,29 +143,16 @@ module Discordrb
     # @return [Array<Member>] an array of members who have this role.
     # @note This requests a member chunk if it hasn't for the server before, which may be slow initially
     def members
-      @server.members.select { |m| m.role? self }
+      server.members.select { |m| m.role?(self) }
     end
 
     alias_method :users, :members
 
-    # Updates the data cache from a hash containing data
-    # @note For internal use only
-    # @!visibility private
-    def update_data(new_data)
-      @name = new_data['name']
-      @hoist = new_data['hoist']
-      @icon = new_data['icon']
-      @unicode_emoji = new_data['unicode_emoji']
-      @position = new_data['position']
-      @mentionable = new_data['mentionable']
-      @flags = new_data['flags']
-      colours = new_data['colors']
-      @managed = new_data['managed']
-      @permissions.bits = new_data['permissions'].to_i
-      @colour = ColourRGB.new(colours['primary_color'])
-      @tags = Tags.new(new_data['tags']) if new_data['tags']
-      @tertiary_colour = colours['tertiary_color'] ? ColourRGB.new(colours['tertiary_color']) : nil
-      @secondary_colour = colours['secondary_color'] ? ColourRGB.new(colours['secondary_color']) : nil
+    # @return [Server] The server the role belongs to.
+    # @return [Discordrb::Errors::UnknownServer] This can happen if the role is from an interaction for a
+    #   server the bot is not a member of.
+    def server
+      @server ||= (@bot.server(@server_id) if @server_id)
     end
 
     # Sets the role name to something new
@@ -288,8 +273,8 @@ module Discordrb
     # Deletes this role. This cannot be undone without recreating the role!
     # @param reason [String] the reason for this role's deletion
     def delete(reason = nil)
-      API::Server.delete_role(@bot.token, @server.id, @id, reason)
-      @server.delete_role(@id)
+      API::Server.delete_role(@bot.token, @server_id, @id, reason)
+      @server&.delete_role(@id)
     end
 
     # Move the position of this role in the roles list.
@@ -312,15 +297,15 @@ module Discordrb
         raise ArgumentError, "'bottom', 'above', and 'below' are mutually exclusive"
       end
 
-      if (above || below) && !(target = @server.role(above || below))
+      if (above || below) && !(target = server.role(above || below))
         raise ArgumentError, "The given 'above' or 'below' options are not valid"
       end
 
-      if (below && target&.id == @server.id) || (@id == target&.id)
+      if (below && target&.id == @server_id) || (@id == target&.id)
         raise ArgumentError, 'The target role that was provded is not valid'
       end
 
-      roles = @server.roles.sort_by { |role| [role.position, role.id] }
+      roles = server.roles.sort_by { |role| [role.position, role.id] }
 
       # Make sure we remove the current role.
       myself = roles.rindex(@id).tap { |index| roles.delete_at(index) }
@@ -341,7 +326,7 @@ module Discordrb
         { id: role.resolve_id, position: new_position }
       end
 
-      @server.update_role_positions(roles, reason: reason)
+      server.update_role_positions(roles, reason: reason)
       @position
     end
 
@@ -437,13 +422,33 @@ module Discordrb
         }
       end
 
-      update_data(JSON.parse(API::Server.update_role!(@bot.token, @server.id, @id, **data)))
+      update_data(JSON.parse(API::Server.update_role!(@bot.token, @server_id, @id, **data)))
       nil
     end
 
-    # The inspect method is overwritten to give more useful output
+    # The inspect method is overwritten to give more useful output.
     def inspect
-      "<Role name=#{@name} permissions=#{@permissions.inspect} hoist=#{@hoist} colour=#{@colour.inspect} server=#{@server.inspect} position=#{@position} mentionable=#{@mentionable} unicode_emoji=#{@unicode_emoji} flags=#{@flags}>"
+      "<Role name=\"#{@name}\" permissions=#{@permissions.bits} hoist=#{@hoist} position=#{@position} mentionable=#{@mentionable} flags=#{@flags}>"
+    end
+
+    # Updates the data cache from a hash containing data
+    # @note For internal use only
+    # @!visibility private
+    def update_data(new_data)
+      @name = new_data['name']
+      @hoist = new_data['hoist']
+      @icon = new_data['icon']
+      @unicode_emoji = new_data['unicode_emoji']
+      @position = new_data['position']
+      @mentionable = new_data['mentionable']
+      @flags = new_data['flags']
+      colours = new_data['colors']
+      @managed = new_data['managed']
+      @permissions.bits = new_data['permissions'].to_i
+      @colour = ColourRGB.new(colours['primary_color'])
+      @tags = Tags.new(new_data['tags']) if new_data['tags']
+      @tertiary_colour = colours['tertiary_color'] ? ColourRGB.new(colours['tertiary_color']) : nil
+      @secondary_colour = colours['secondary_color'] ? ColourRGB.new(colours['secondary_color']) : nil
     end
   end
 end

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -114,12 +114,13 @@ module Discordrb::Events
       end
 
       resolved_data['roles']&.each do |id, data|
+        data['guild_id'] = @interaction.server_id
         @resolved[:roles][id.to_i] = Discordrb::Role.new(data, @bot)
       end
 
       resolved_data['channels']&.each do |id, data|
         data['guild_id'] = @interaction.server_id
-        @resolved[:channels][id.to_i] = Discordrb::Channel.new(data, @bot)
+        @resolved[:channels][id.to_i] = @bot.ensure_channel(data)
       end
 
       resolved_data['members']&.each do |id, data|
@@ -344,11 +345,14 @@ module Discordrb::Events
 
   # An event for when a user interacts with a component.
   class ComponentEvent < InteractionCreateEvent
-    # @return [String] User provided data for this button.
+    # @return [String] user-defined identifier for the component.
     attr_reader :custom_id
 
-    # @return [Interactions::Message, nil] The message the button originates from.
+    # @return [Interactions::Message, nil] the message the component originates from.
     attr_reader :message
+
+    # @return [Resolved] the resolved channels, roles, users, members, and attachments.
+    attr_reader :resolved
 
     # @!visibility private
     def initialize(data, bot)
@@ -356,6 +360,8 @@ module Discordrb::Events
 
       @message = @interaction.message
       @custom_id = data['data']['custom_id']
+      @resolved = Resolved.new({}, {}, {}, {}, {}, {})
+      process_resolved(data['data']['resolved']) if data['data']['resolved']
     end
   end
 
@@ -417,16 +423,11 @@ module Discordrb::Events
     # @return [Array<Component>] an array of partial component objects that were in the modal.
     attr_reader :components
 
-    # @return [Resolved] The resolved channels, roles, users, members, and attachments for the modal.
-    attr_reader :resolved
-
     # @!visibility private
     def initialize(data, bot)
       super
 
       @components = @interaction.components
-      @resolved = Resolved.new({}, {}, {}, {}, {}, {})
-      process_resolved(data['data']['resolved']) if data['data']['resolved']
     end
 
     # Get the value of an input passed to the modal.
@@ -447,7 +448,7 @@ module Discordrb::Events
     # @param custom_id [String] The custom ID of the file upload component to get attachments for.
     # @return [Array<Attachment>] the attachments that were uploaded to the file upload component.
     def attachments(custom_id)
-      values(custom_id)&.map { |id| @resolved[:attachments][id.to_i] } || []
+      values(custom_id)&.map { |id| @resolved.attachments[id.to_i] } || []
     end
   end
 
@@ -457,14 +458,14 @@ module Discordrb::Events
 
   # Event for when a user interacts with a select user component.
   class UserSelectEvent < ComponentEvent
-    # @return [Array<User>] Selected values.
+    # @return [Array<User>] the users that were selected.
     attr_reader :values
 
     # @!visibility private
     def initialize(data, bot)
       super
 
-      @values = data['data']['values'].map { |e| bot.user(e) }
+      @values = data['data']['values'].map { |id| bot.user(id) }
     end
   end
 
@@ -474,14 +475,15 @@ module Discordrb::Events
 
   # Event for when a user interacts with a select role component.
   class RoleSelectEvent < ComponentEvent
-    # @return [Array<Role>] Selected values.
+    # @return [Array<Role>] the roles that were selected.
     attr_reader :values
 
     # @!visibility private
     def initialize(data, bot)
       super
 
-      @values = data['data']['values'].map { |e| bot.server(data['guild_id']).role(e) }
+      server = @bot.servers[@interaction.server_id]
+      @values = data['data']['values'].map { |id| server&.role(id) || @resolved.roles[id.to_i] }
     end
   end
 
@@ -491,16 +493,16 @@ module Discordrb::Events
 
   # Event for when a user interacts with a select mentionable component.
   class MentionableSelectEvent < ComponentEvent
-    # @return [Hash<Symbol => Array<User>, Symbol => Array<Role>>] Selected values.
+    # @return [Hash<Symbol => Array<User>, Symbol => Array<Role>>] the selected roles and users.
     attr_reader :values
 
     # @!visibility private
     def initialize(data, bot)
       super
 
-      users = data['data']['resolved']['users'].map { |_, user| @bot.ensure_user(user) }
-      roles = data['data']['resolved']['roles'] ? data['data']['resolved']['roles'].keys.map { |e| bot.server(data['guild_id']).role(e) } : []
-      @values = { users: users, roles: roles }
+      server = @bot.servers[@interaction.server_id]
+      roles = @resolved.roles.map { |id, role| server&.role(id) || role }
+      @values = { users: @resolved.users.values, roles: roles }
     end
   end
 
@@ -510,14 +512,14 @@ module Discordrb::Events
 
   # Event for when a user interacts with a select channel component.
   class ChannelSelectEvent < ComponentEvent
-    # @return [Array<Channel>] Selected values.
+    # @return [Array<Channel>] the channels that were selected.
     attr_reader :values
 
     # @!visibility private
     def initialize(data, bot)
       super
 
-      @values = data['data']['values'].map { |e| bot.channel(e, bot.server(data['guild_id'])) }
+      @values = data['data']['values'].map { |id| @resolved.channels[id.to_i] }
     end
   end
 

--- a/lib/discordrb/events/interactions.rb
+++ b/lib/discordrb/events/interactions.rb
@@ -120,7 +120,7 @@ module Discordrb::Events
 
       resolved_data['channels']&.each do |id, data|
         data['guild_id'] = @interaction.server_id
-        @resolved[:channels][id.to_i] = @bot.ensure_channel(data)
+        @resolved[:channels][id.to_i] = Discordrb::Channel.new(data, @bot)
       end
 
       resolved_data['members']&.each do |id, data|


### PR DESCRIPTION
## Summary

Currently, select menu interactions always result in an error when used in a location where the bot was not authorized with the `bot` scope. This is because the code currently assumes that the bot is always a member of the server and has access to its channels, roles, etc.

## Fixed
Select menu interactions raising a `Discordrb::Errors::UnknownServer`
