### PR TITLE
feat: add DAVE E2EE voice support

### DIFF
--- a/lib/discordrb/voice/dave.rb
+++ b/lib/discordrb/voice/dave.rb
@@ -1,0 +1,255 @@
+# frozen_string_literal: true
+
+require 'ffi'
+
+module Discordrb::Voice
+  # :nodoc:
+  module DAVE
+    extend FFI::Library
+
+    class Error < StandardError; end
+    class EncryptionError < Error; end
+
+    libdave_path = ENV.fetch('DISCORDRB_LIBDAVE_PATH', nil)
+    ffi_lib([libdave_path, 'dave', 'libdave', 'libdave.dylib', 'libdave.so'].compact)
+
+    callback :mls_failure_callback, %i[string string pointer], :void
+
+    DAVE_CODEC_OPUS = 1
+    DAVE_MEDIA_TYPE_AUDIO = 0
+    DAVE_ENCRYPTOR_RESULT_CODE_SUCCESS = 0
+
+    attach_function :daveMaxSupportedProtocolVersion, [], :uint16
+    attach_function :daveFree, [:pointer], :void
+    attach_function :daveSessionCreate, %i[pointer string mls_failure_callback pointer], :pointer
+    attach_function :daveSessionDestroy, [:pointer], :void
+    attach_function :daveSessionInit, %i[pointer uint16 uint64 string], :void
+    attach_function :daveSessionReset, [:pointer], :void
+    attach_function :daveSessionSetProtocolVersion, %i[pointer uint16], :void
+    attach_function :daveSessionGetProtocolVersion, [:pointer], :uint16
+    attach_function :daveSessionSetExternalSender, %i[pointer pointer size_t], :void
+    attach_function :daveSessionProcessProposals, %i[pointer pointer size_t pointer size_t pointer pointer], :void
+    attach_function :daveSessionProcessCommit, %i[pointer pointer size_t], :pointer
+    attach_function :daveSessionProcessWelcome, %i[pointer pointer size_t pointer size_t], :pointer
+    attach_function :daveSessionGetMarshalledKeyPackage, %i[pointer pointer pointer], :void
+    attach_function :daveSessionGetKeyRatchet, %i[pointer string], :pointer
+    attach_function :daveKeyRatchetDestroy, [:pointer], :void
+    attach_function :daveCommitResultIsFailed, [:pointer], :bool
+    attach_function :daveCommitResultIsIgnored, [:pointer], :bool
+    attach_function :daveCommitResultDestroy, [:pointer], :void
+    attach_function :daveWelcomeResultDestroy, [:pointer], :void
+    attach_function :daveEncryptorCreate, [], :pointer
+    attach_function :daveEncryptorDestroy, [:pointer], :void
+    attach_function :daveEncryptorSetKeyRatchet, %i[pointer pointer], :void
+    attach_function :daveEncryptorSetPassthroughMode, %i[pointer bool], :void
+    attach_function :daveEncryptorAssignSsrcToCodec, %i[pointer uint32 int], :void
+    attach_function :daveEncryptorGetMaxCiphertextByteSize, %i[pointer int size_t], :size_t
+    attach_function :daveEncryptorEncrypt, %i[pointer int uint32 pointer size_t pointer size_t pointer], :int
+
+    class SessionHandle < FFI::AutoPointer # :nodoc:
+      def self.release(ptr)
+        DAVE.daveSessionDestroy(ptr)
+      end
+    end
+
+    class CommitResultHandle < FFI::AutoPointer # :nodoc:
+      def self.release(ptr)
+        DAVE.daveCommitResultDestroy(ptr)
+      end
+    end
+
+    class WelcomeResultHandle < FFI::AutoPointer # :nodoc:
+      def self.release(ptr)
+        DAVE.daveWelcomeResultDestroy(ptr)
+      end
+    end
+
+    class KeyRatchetHandle < FFI::AutoPointer # :nodoc:
+      def self.release(ptr)
+        DAVE.daveKeyRatchetDestroy(ptr)
+      end
+    end
+
+    class EncryptorHandle < FFI::AutoPointer # :nodoc:
+      def self.release(ptr)
+        DAVE.daveEncryptorDestroy(ptr)
+      end
+    end
+
+    def self.max_supported_protocol_version
+      daveMaxSupportedProtocolVersion
+    end
+
+    def self.read_allocated_bytes
+      buffer_ptr = FFI::MemoryPointer.new(:pointer)
+      length_ptr = FFI::MemoryPointer.new(:size_t)
+      yield buffer_ptr, length_ptr
+
+      data_ptr = buffer_ptr.read_pointer
+      return nil if data_ptr.null?
+
+      data = data_ptr.read_string_length(length_ptr.read_ulong_long)
+      daveFree(data_ptr)
+      data
+    end
+
+    def self.write_bytes(bytes)
+      return [FFI::Pointer::NULL, 0] if bytes.nil? || bytes.empty?
+
+      pointer = FFI::MemoryPointer.new(:uint8, bytes.bytesize)
+      pointer.put_bytes(0, bytes)
+      [pointer, bytes.bytesize]
+    end
+
+    def self.write_string_array(values)
+      values = Array(values)
+      return [FFI::Pointer::NULL, [], 0] if values.empty?
+
+      pointers = values.map { |value| FFI::MemoryPointer.from_string(value.to_s) }
+      array = FFI::MemoryPointer.new(:pointer, pointers.length)
+      pointers.each_with_index do |pointer, index|
+        array.put_pointer(index * FFI.type_size(:pointer), pointer)
+      end
+      [array, pointers, pointers.length]
+    end
+
+    class CommitResult # :nodoc:
+      def initialize(handle)
+        @handle = CommitResultHandle.new(handle)
+      end
+
+      def failed?
+        DAVE.daveCommitResultIsFailed(@handle)
+      end
+
+      def ignored?
+        DAVE.daveCommitResultIsIgnored(@handle)
+      end
+    end
+
+    class Session # :nodoc:
+      attr_reader :self_user_id
+
+      def initialize(protocol_version:, group_id:, self_user_id:, auth_session_id: nil, &failure_callback)
+        @self_user_id = self_user_id.to_s
+        @failure_callback = failure_callback || proc { |source, reason| raise Error, "#{source}: #{reason}" }
+        @native_failure_callback = proc do |source, reason, _user_data|
+          @failure_callback.call(source, reason)
+        end
+
+        handle = DAVE.daveSessionCreate(nil, auth_session_id, @native_failure_callback, nil)
+        raise Error, 'Failed to create DAVE session' if handle.null?
+
+        @handle = SessionHandle.new(handle)
+        DAVE.daveSessionInit(@handle, protocol_version, group_id, @self_user_id)
+      end
+
+      def reset
+        DAVE.daveSessionReset(@handle)
+      end
+
+      def protocol_version=(version)
+        DAVE.daveSessionSetProtocolVersion(@handle, version)
+      end
+
+      def protocol_version
+        DAVE.daveSessionGetProtocolVersion(@handle)
+      end
+
+      def external_sender=(payload)
+        pointer, length = DAVE.write_bytes(payload)
+        DAVE.daveSessionSetExternalSender(@handle, pointer, length)
+      end
+
+      def key_package
+        DAVE.read_allocated_bytes do |buffer_ptr, length_ptr|
+          DAVE.daveSessionGetMarshalledKeyPackage(@handle, buffer_ptr, length_ptr)
+        end
+      end
+
+      def process_proposals(payload, recognized_user_ids)
+        proposals_ptr, proposals_length = DAVE.write_bytes(payload)
+        user_ids_ptr, _user_id_pointers, user_ids_length = DAVE.write_string_array(recognized_user_ids)
+
+        DAVE.read_allocated_bytes do |buffer_ptr, length_ptr|
+          DAVE.daveSessionProcessProposals(
+            @handle,
+            proposals_ptr,
+            proposals_length,
+            user_ids_ptr,
+            user_ids_length,
+            buffer_ptr,
+            length_ptr
+          )
+        end
+      end
+
+      def process_commit(payload)
+        commit_ptr, commit_length = DAVE.write_bytes(payload)
+        handle = DAVE.daveSessionProcessCommit(@handle, commit_ptr, commit_length)
+        raise Error, 'Failed to process DAVE commit' if handle.null?
+
+        CommitResult.new(handle)
+      end
+
+      def process_welcome(payload, recognized_user_ids)
+        welcome_ptr, welcome_length = DAVE.write_bytes(payload)
+        user_ids_ptr, _user_id_pointers, user_ids_length = DAVE.write_string_array(recognized_user_ids)
+        handle = DAVE.daveSessionProcessWelcome(@handle, welcome_ptr, welcome_length, user_ids_ptr, user_ids_length)
+        raise Error, 'Failed to process DAVE welcome' if handle.null?
+
+        WelcomeResultHandle.new(handle)
+      end
+
+      def key_ratchet(user_id = @self_user_id)
+        handle = DAVE.daveSessionGetKeyRatchet(@handle, user_id.to_s)
+        raise Error, "Failed to create DAVE key ratchet for user #{user_id}" if handle.null?
+
+        KeyRatchetHandle.new(handle)
+      end
+    end
+
+    class Encryptor # :nodoc:
+      def initialize
+        handle = DAVE.daveEncryptorCreate
+        raise Error, 'Failed to create DAVE encryptor' if handle.null?
+
+        @handle = EncryptorHandle.new(handle)
+      end
+
+      def key_ratchet=(key_ratchet)
+        DAVE.daveEncryptorSetKeyRatchet(@handle, key_ratchet)
+      end
+
+      def passthrough_mode=(value)
+        DAVE.daveEncryptorSetPassthroughMode(@handle, value)
+      end
+
+      def assign_audio_ssrc(ssrc)
+        DAVE.daveEncryptorAssignSsrcToCodec(@handle, ssrc, DAVE_CODEC_OPUS)
+      end
+
+      def encrypt_audio_frame(ssrc, frame)
+        frame_ptr, frame_length = DAVE.write_bytes(frame)
+        max_size = DAVE.daveEncryptorGetMaxCiphertextByteSize(@handle, DAVE_MEDIA_TYPE_AUDIO, frame_length)
+        output = FFI::MemoryPointer.new(:uint8, max_size)
+        written = FFI::MemoryPointer.new(:size_t)
+
+        result = DAVE.daveEncryptorEncrypt(
+          @handle,
+          DAVE_MEDIA_TYPE_AUDIO,
+          ssrc,
+          frame_ptr,
+          frame_length,
+          output,
+          max_size,
+          written
+        )
+
+        raise EncryptionError, "DAVE encryption failed with code #{result}" unless result == DAVE_ENCRYPTOR_RESULT_CODE_SUCCESS
+
+        output.read_string_length(written.read_ulong_long)
+      end
+    end
+  end
+end

--- a/lib/discordrb/voice/dave.rb
+++ b/lib/discordrb/voice/dave.rb
@@ -14,10 +14,16 @@ module Discordrb::Voice
     ffi_lib([libdave_path, 'dave', 'libdave', 'libdave.dylib', 'libdave.so'].compact)
 
     callback :mls_failure_callback, %i[string string pointer], :void
+    callback :log_sink_callback, %i[int string int string], :void
 
     DAVE_CODEC_OPUS = 1
     DAVE_MEDIA_TYPE_AUDIO = 0
     DAVE_ENCRYPTOR_RESULT_CODE_SUCCESS = 0
+    DAVE_LOGGING_SEVERITY_VERBOSE = 0
+    DAVE_LOGGING_SEVERITY_INFO = 1
+    DAVE_LOGGING_SEVERITY_WARNING = 2
+    DAVE_LOGGING_SEVERITY_ERROR = 3
+    DAVE_LOGGING_SEVERITY_NONE = 4
 
     attach_function :daveMaxSupportedProtocolVersion, [], :uint16
     attach_function :daveFree, [:pointer], :void
@@ -45,6 +51,7 @@ module Discordrb::Voice
     attach_function :daveEncryptorAssignSsrcToCodec, %i[pointer uint32 int], :void
     attach_function :daveEncryptorGetMaxCiphertextByteSize, %i[pointer int size_t], :size_t
     attach_function :daveEncryptorEncrypt, %i[pointer int uint32 pointer size_t pointer size_t pointer], :int
+    attach_function :daveSetLogSinkCallback, [:log_sink_callback], :void
 
     class SessionHandle < FFI::AutoPointer # :nodoc:
       def self.release(ptr)
@@ -78,6 +85,65 @@ module Discordrb::Voice
 
     def self.max_supported_protocol_version
       daveMaxSupportedProtocolVersion
+    end
+
+    def self.log_level=(level)
+      @log_level = normalize_log_level(level)
+    end
+
+    def self.log_level
+      @log_level ||= normalize_log_level(ENV.fetch('DISCORDRB_LIBDAVE_LOG_LEVEL', 'warning'))
+    end
+
+    def self.install_log_sink!
+      return if @log_sink_installed
+
+      @log_sink_callback = proc do |severity, file, line, message|
+        handle_log_message(severity, file, line, message)
+      end
+      daveSetLogSinkCallback(@log_sink_callback)
+      @log_sink_installed = true
+    end
+
+    def self.normalize_log_level(level)
+      {
+        'verbose' => DAVE_LOGGING_SEVERITY_VERBOSE,
+        'debug' => DAVE_LOGGING_SEVERITY_VERBOSE,
+        'info' => DAVE_LOGGING_SEVERITY_INFO,
+        'warn' => DAVE_LOGGING_SEVERITY_WARNING,
+        'warning' => DAVE_LOGGING_SEVERITY_WARNING,
+        'error' => DAVE_LOGGING_SEVERITY_ERROR,
+        'none' => DAVE_LOGGING_SEVERITY_NONE,
+        'silent' => DAVE_LOGGING_SEVERITY_NONE
+      }.fetch(level.to_s.downcase, DAVE_LOGGING_SEVERITY_WARNING)
+    end
+
+    def self.handle_log_message(severity, file, line, message)
+      return if severity < log_level
+
+      logger = discordrb_logger
+      return unless logger
+
+      formatted_message = "DAVE: #{format_log_message(file, line, message)}"
+
+      case severity
+      when DAVE_LOGGING_SEVERITY_ERROR
+        logger.error(formatted_message)
+      when DAVE_LOGGING_SEVERITY_WARNING
+        logger.warn(formatted_message)
+      else
+        logger.debug(formatted_message)
+      end
+    rescue StandardError
+      nil
+    end
+
+    def self.format_log_message(_file, _line, message)
+      message.to_s.strip
+    end
+
+    def self.discordrb_logger
+      Discordrb::LOGGER if defined?(Discordrb::LOGGER)
     end
 
     def self.read_allocated_bytes
@@ -251,5 +317,7 @@ module Discordrb::Voice
         output.read_string_length(written.read_ulong_long)
       end
     end
+
+    install_log_sink!
   end
 end

--- a/lib/discordrb/voice/dave.rb
+++ b/lib/discordrb/voice/dave.rb
@@ -196,11 +196,14 @@ module Discordrb::Voice
     class Session # :nodoc:
       attr_reader :self_user_id
 
-      def initialize(protocol_version:, group_id:, self_user_id:, auth_session_id: nil, &failure_callback)
+      def initialize(protocol_version:, group_id:, self_user_id:, auth_session_id: nil)
         @self_user_id = self_user_id.to_s
-        @failure_callback = failure_callback || proc { |source, reason| raise Error, "#{source}: #{reason}" }
+        @last_failure = nil
+        # Store failure reason without raising; raising inside an FFI callback unwinds through C++ code
+        # via longjmp, skipping destructors and leaving the native session in a corrupted state.
+        # Callers check @last_failure after each FFI call and raise from safe Ruby context.
         @native_failure_callback = proc do |source, reason, _user_data|
-          @failure_callback.call(source, reason)
+          @last_failure = "#{source}: #{reason}"
         end
 
         handle = DAVE.daveSessionCreate(nil, auth_session_id, @native_failure_callback, nil)
@@ -234,10 +237,11 @@ module Discordrb::Voice
       end
 
       def process_proposals(payload, recognized_user_ids)
+        @last_failure = nil
         proposals_ptr, proposals_length = DAVE.write_bytes(payload)
         user_ids_ptr, _user_id_pointers, user_ids_length = DAVE.write_string_array(recognized_user_ids)
 
-        DAVE.read_allocated_bytes do |buffer_ptr, length_ptr|
+        result = DAVE.read_allocated_bytes do |buffer_ptr, length_ptr|
           DAVE.daveSessionProcessProposals(
             @handle,
             proposals_ptr,
@@ -248,20 +252,28 @@ module Discordrb::Voice
             length_ptr
           )
         end
+
+        raise Error, "MLS failure in proposals: #{@last_failure}" if @last_failure
+
+        result
       end
 
       def process_commit(payload)
+        @last_failure = nil
         commit_ptr, commit_length = DAVE.write_bytes(payload)
         handle = DAVE.daveSessionProcessCommit(@handle, commit_ptr, commit_length)
+        raise Error, "MLS failure in commit: #{@last_failure}" if @last_failure
         raise Error, 'Failed to process DAVE commit' if handle.null?
 
         CommitResult.new(handle)
       end
 
       def process_welcome(payload, recognized_user_ids)
+        @last_failure = nil
         welcome_ptr, welcome_length = DAVE.write_bytes(payload)
         user_ids_ptr, _user_id_pointers, user_ids_length = DAVE.write_string_array(recognized_user_ids)
         handle = DAVE.daveSessionProcessWelcome(@handle, welcome_ptr, welcome_length, user_ids_ptr, user_ids_length)
+        raise Error, "MLS failure in welcome: #{@last_failure}" if @last_failure
         raise Error, 'Failed to process DAVE welcome' if handle.null?
 
         WelcomeResultHandle.new(handle)

--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -452,6 +452,7 @@ module Discordrb::Voice
 
       raise 'libdave is unavailable - unable to create DAVE voice session' unless LIBDAVE_AVAILABLE
 
+      @bot.debug("DAVE: Voice gateway requires protocol version #{protocol_version}")
       @pending_dave_session = build_dave_session(protocol_version)
       send_dave_key_package(@pending_dave_session)
     end
@@ -479,31 +480,41 @@ module Discordrb::Voice
     end
 
     def send_dave_key_package(session)
+      @bot.debug('DAVE: Sending MLS key package')
       send_binary_opcode(Opcodes::DAVE_MLS_KEY_PACKAGE, session.key_package)
     end
 
     def process_dave_proposals(payload)
+      @bot.debug("DAVE: Processing MLS proposals (#{payload.bytesize} bytes)")
       commit_welcome = dave_control_session.process_proposals(payload, @dave_expected_user_ids.to_a)
       send_binary_opcode(Opcodes::DAVE_MLS_COMMIT_WELCOME, commit_welcome) if commit_welcome
     end
 
     def process_dave_commit(transition_id, commit)
+      @bot.debug("DAVE: Processing MLS commit for transition #{transition_id}")
       result = dave_control_session.process_commit(commit)
 
       if result.failed?
+        Discordrb::LOGGER.warn("DAVE: Received invalid MLS commit for transition #{transition_id}")
         send_dave_invalid_commit_welcome(transition_id)
         return
       end
 
-      return if result.ignored?
+      if result.ignored?
+        @bot.debug("DAVE: Ignored MLS commit for transition #{transition_id}")
+        return
+      end
 
       track_pending_transition(transition_id)
+      @bot.debug("DAVE: Transition #{transition_id} is ready")
       send_dave_ready_for_transition(transition_id)
     end
 
     def process_dave_welcome(transition_id, welcome)
+      @bot.debug("DAVE: Processing MLS welcome for transition #{transition_id}")
       dave_control_session.process_welcome(welcome, @dave_expected_user_ids.to_a)
       track_pending_transition(transition_id, activate_pending_session: true)
+      @bot.debug("DAVE: Transition #{transition_id} is ready")
       send_dave_ready_for_transition(transition_id)
     end
 
@@ -515,6 +526,7 @@ module Discordrb::Voice
       @pending_transition_id = data['transition_id']
       @pending_transition_protocol_version = data['protocol_version'].to_i
       @activate_pending_session ||= !@pending_dave_session.nil?
+      @bot.debug("DAVE: Preparing transition #{@pending_transition_id} for protocol version #{@pending_transition_protocol_version}")
 
       if @pending_transition_id.zero?
         handle_dave_execute_transition(@pending_transition_id)
@@ -526,6 +538,7 @@ module Discordrb::Voice
     def handle_dave_prepare_epoch(data)
       protocol_version = data['protocol_version'].to_i
       epoch = data['epoch'].to_i
+      @bot.debug("DAVE: Preparing epoch #{epoch} for protocol version #{protocol_version}")
 
       if epoch == 1
         @pending_dave_session = build_dave_session(protocol_version)
@@ -544,6 +557,7 @@ module Discordrb::Voice
         @udp.send(:deactivate_dave!)
         @dave_protocol_version = 0
         @media_ready = true
+        @bot.debug('DAVE: Disabled voice frame encryption')
         clear_pending_transition
         return
       end
@@ -556,6 +570,7 @@ module Discordrb::Voice
       @udp.send(:activate_dave!, dave_control_session, @bot.profile.id)
       @dave_protocol_version = dave_control_session.protocol_version
       @media_ready = true
+      @bot.debug("DAVE: Enabled voice frame encryption with protocol version #{@dave_protocol_version}")
       clear_pending_transition
     end
 

--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -203,6 +203,11 @@ module Discordrb::Voice
     # @return [VoiceUDP] the UDP voice connection over which the actual audio data is sent.
     attr_reader :udp
 
+    # @return [true, false] whether the voice WebSocket connection has died unexpectedly.
+    #   This is set when the underlying socket raises a connection error or the server closes
+    #   the connection while the session is still meant to be active.
+    attr_reader :connection_dead
+
     # Makes a new voice websocket client, but doesn't connect it (see {#connect} for that)
     # @param channel [Channel] The voice channel to connect to
     # @param bot [Bot] The regular bot to which this vWS is bound
@@ -221,6 +226,7 @@ module Discordrb::Voice
 
       @udp = VoiceUDP.new
       @media_ready = false
+      @connection_dead = false
       @dave_expected_user_ids = Set.new([@bot.profile.id.to_s])
       @dave_expected_user_ids.merge(@channel.users.map { |user| user.id.to_s })
     end
@@ -297,11 +303,17 @@ module Discordrb::Voice
         op: opcode,
         d: data
       }.to_json, :text)
+    rescue SystemCallError, IOError => e
+      @connection_dead = true
+      @bot.debug("VWS: send_opcode failed, marking connection dead (#{e.class}: #{e.message})")
     end
 
     def send_binary_opcode(opcode, payload = ''.b)
       @bot.debug("Sending voice binary opcode #{opcode} (#{payload.bytesize} bytes)")
       @client.send(opcode.chr + payload, :binary)
+    rescue SystemCallError, IOError => e
+      @connection_dead = true
+      @bot.debug("VWS: send_binary_opcode failed, marking connection dead (#{e.class}: #{e.message})")
     end
 
     # Event handlers; public for websocket-simple to work correctly
@@ -322,7 +334,7 @@ module Discordrb::Voice
         websocket_text_message(msg.data)
       end
     rescue StandardError => e
-      @connection_error ||= e.class
+      @connection_error ||= e
       raise
     end
 
@@ -388,7 +400,8 @@ module Discordrb::Voice
 
       case opcode
       when Discordrb::Voice::Opcodes::DAVE_MLS_EXTERNAL_SENDER
-        dave_control_session.external_sender = payload
+        @dave_external_sender = payload
+        (@pending_dave_session || @dave_session)&.external_sender = payload
       when Discordrb::Voice::Opcodes::DAVE_MLS_PROPOSALS
         process_dave_proposals(payload)
       when Discordrb::Voice::Opcodes::DAVE_MLS_COMMIT_WELCOME
@@ -446,7 +459,12 @@ module Discordrb::Voice
     private
 
     def ready_for_media?
-      raise @connection_error if @connection_error
+      if @connection_error
+        err = @connection_error
+        raise err if err.is_a?(Exception)
+        raise "VWS connection error: #{err}"
+      end
+      raise 'VWS connection closed before media was ready' if @connection_dead && !@media_ready
 
       @ready && @media_ready
     end
@@ -467,11 +485,13 @@ module Discordrb::Voice
     end
 
     def build_dave_session(protocol_version)
-      Discordrb::Voice::DAVE::Session.new(
+      session = Discordrb::Voice::DAVE::Session.new(
         protocol_version: protocol_version,
         group_id: @channel.id,
         self_user_id: @bot.profile.id
       )
+      session.external_sender = @dave_external_sender if @dave_external_sender
+      session
     end
 
     def update_expected_users(user_ids)
@@ -550,7 +570,18 @@ module Discordrb::Voice
       @bot.debug("DAVE: Preparing transition #{@pending_transition_id} for protocol version #{@pending_transition_protocol_version}")
 
       if @pending_transition_id.zero?
-        handle_dave_execute_transition(@pending_transition_id)
+        if @pending_dave_session.nil?
+          # No MLS negotiation in progress; execute immediately.
+          handle_dave_execute_transition(@pending_transition_id)
+        elsif @mls_commit_transition_id
+          # MLS commit already arrived before PREPARE_TRANSITION; execute with the committed ID.
+          handle_dave_execute_transition(@mls_commit_transition_id)
+        else
+          # MLS negotiation in progress but commit hasn't arrived yet.
+          # Discord won't send a separate EXECUTE_TRANSITION for id=0, so defer until
+          # track_pending_transition is called after the commit/welcome is processed.
+          @deferred_transition_execute = true
+        end
       elsif @pending_transition_protocol_version.zero?
         send_dave_ready_for_transition(@pending_transition_id)
       end
@@ -603,15 +634,27 @@ module Discordrb::Voice
     end
 
     def track_pending_transition(transition_id, activate_pending_session: false)
+      defer_execute = @deferred_transition_execute
+      # If no PREPARE_TRANSITION was received before this welcome arrives (the initial join
+      # flow never sends a PREPARE_TRANSITION for epoch 0), we should execute immediately
+      # rather than waiting for a deferred signal that will never come.
+      no_prior_prepare = @pending_transition_id.nil? && activate_pending_session
+      @mls_commit_transition_id = transition_id
       @pending_transition_id = transition_id
       @pending_transition_protocol_version ||= dave_control_session.protocol_version
       @activate_pending_session = @activate_pending_session || activate_pending_session || !@pending_dave_session.nil?
+      if defer_execute || no_prior_prepare
+        @deferred_transition_execute = false
+        handle_dave_execute_transition(transition_id)
+      end
     end
 
     def clear_pending_transition
       @pending_transition_id = nil
       @pending_transition_protocol_version = nil
       @activate_pending_session = false
+      @deferred_transition_execute = false
+      @mls_commit_transition_id = nil
     end
 
     def handle_invalid_dave_group(transition_id)
@@ -633,6 +676,8 @@ module Discordrb::Voice
     def heartbeat_loop
       @heartbeat_running = true
       while @heartbeat_running
+        break if @connection_dead
+
         if @heartbeat_interval
           sleep @heartbeat_interval / 1000.0
           send_heartbeat
@@ -653,11 +698,17 @@ module Discordrb::Voice
         method(:websocket_open),
         method(:websocket_message),
         proc do |e|
-          @connection_error ||= e if !@ready || !@media_ready
+          if !@ready || !@media_ready
+            @connection_error ||= e.is_a?(Exception) ? e : RuntimeError.new("VWS error: #{e.inspect}")
+          end
+          @connection_dead = true
           Discordrb::LOGGER.error "VWS error: #{e}"
         end,
         proc do |e|
-          @connection_error ||= e if !@ready || !@media_ready
+          if !@ready || !@media_ready
+            @connection_error ||= e.is_a?(Exception) ? e : RuntimeError.new("VWS closed: #{e.inspect}")
+          end
+          @connection_dead = true
           Discordrb::LOGGER.warn "VWS close: #{e}"
         end
       )

--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -373,6 +373,12 @@ module Discordrb::Voice
     end
 
     def websocket_binary_message(msg)
+      unless msg.bytesize >= 3
+        @bot.debug('VWS: Received malformed binary message (too short)')
+        return
+      end
+
+      @seq = msg.unpack1('n')
       opcode = msg.getbyte(2)
       payload = msg.byteslice(3..) || ''.b
       @bot.debug("Received VWS binary opcode #{opcode} (#{payload.bytesize} bytes)")
@@ -463,7 +469,7 @@ module Discordrb::Voice
         group_id: @channel.id,
         self_user_id: @bot.profile.id
       ) do |source, reason|
-        raise "DAVE MLS failure from #{source}: #{reason}"
+        raise Discordrb::Voice::DAVE::Error, "MLS failure from #{source}: #{reason}"
       end
     end
 
@@ -496,7 +502,7 @@ module Discordrb::Voice
 
       if result.failed?
         Discordrb::LOGGER.warn("DAVE: Received invalid MLS commit for transition #{transition_id}")
-        send_dave_invalid_commit_welcome(transition_id)
+        handle_invalid_dave_group(transition_id)
         return
       end
 
@@ -508,6 +514,9 @@ module Discordrb::Voice
       track_pending_transition(transition_id)
       @bot.debug("DAVE: Transition #{transition_id} is ready")
       send_dave_ready_for_transition(transition_id)
+    rescue Discordrb::Voice::DAVE::Error => e
+      @bot.warn("DAVE: Failed to process MLS commit for transition #{transition_id}: #{e.message}")
+      handle_invalid_dave_group(transition_id)
     end
 
     def process_dave_welcome(transition_id, welcome)
@@ -516,6 +525,9 @@ module Discordrb::Voice
       track_pending_transition(transition_id, activate_pending_session: true)
       @bot.debug("DAVE: Transition #{transition_id} is ready")
       send_dave_ready_for_transition(transition_id)
+    rescue Discordrb::Voice::DAVE::Error => e
+      @bot.warn("DAVE: Failed to process MLS welcome for transition #{transition_id}: #{e.message}")
+      handle_invalid_dave_group(transition_id)
     end
 
     def unpack_transition_payload(payload)
@@ -553,6 +565,13 @@ module Discordrb::Voice
     def handle_dave_execute_transition(transition_id)
       return unless @pending_transition_id.nil? || transition_id == @pending_transition_id
 
+      if @dave_recovering
+        @dave_recovering = false
+        clear_pending_transition
+        @bot.debug("DAVE: Ignoring stale execute transition #{transition_id} during recovery")
+        return
+      end
+
       if @pending_transition_protocol_version.to_i.zero?
         @udp.send(:deactivate_dave!)
         @dave_protocol_version = 0
@@ -584,6 +603,14 @@ module Discordrb::Voice
       @pending_transition_id = nil
       @pending_transition_protocol_version = nil
       @activate_pending_session = false
+    end
+
+    def handle_invalid_dave_group(transition_id)
+      protocol_version = dave_control_session.protocol_version
+      @pending_dave_session = build_dave_session(protocol_version)
+      @dave_recovering = true
+      send_dave_invalid_commit_welcome(transition_id)
+      send_dave_key_package(@pending_dave_session)
     end
 
     def send_dave_ready_for_transition(transition_id)

--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -322,7 +322,7 @@ module Discordrb::Voice
         websocket_text_message(msg.data)
       end
     rescue StandardError => e
-      @connection_error ||= e
+      @connection_error ||= e.class
       raise
     end
 

--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -19,6 +19,12 @@ rescue LoadError
   LIBSODIUM_AVAILABLE = false
 end
 
+begin
+  LIBDAVE_AVAILABLE = require 'discordrb/voice/dave'
+rescue LoadError, FFI::NotFoundError
+  LIBDAVE_AVAILABLE = false
+end
+
 module Discordrb::Voice
   # Signifies to Discord that encryption should be used
   # @deprecated Discord now supports multiple encryption options.
@@ -64,6 +70,8 @@ module Discordrb::Voice
       @ip = ip
       @port = port
       @ssrc = ssrc
+
+      @dave_encryptor&.assign_audio_ssrc(@ssrc)
     end
 
     # Waits for a UDP discovery reply, and returns the sent data.
@@ -84,6 +92,8 @@ module Discordrb::Voice
     def send_audio(buf, sequence, time)
       # Header of the audio packet
       header = generate_header(sequence, time)
+
+      buf = encrypt_frame(buf)
 
       nonce = generate_nonce
       buf = encrypt_audio(buf, header, nonce)
@@ -114,6 +124,32 @@ module Discordrb::Voice
     end
 
     private
+
+    def activate_dave!(session, user_id)
+      @dave_encryptor ||= Discordrb::Voice::DAVE::Encryptor.new
+      @dave_encryptor.assign_audio_ssrc(@ssrc) if @ssrc
+      @dave_encryptor.passthrough_mode = false
+
+      @dave_key_ratchet = session.key_ratchet(user_id)
+      @dave_encryptor.key_ratchet = @dave_key_ratchet
+      @dave_active = true
+    end
+
+    def deactivate_dave!
+      @dave_encryptor&.passthrough_mode = true
+      @dave_active = false
+      @dave_key_ratchet = nil
+    end
+
+    def dave_active?
+      @dave_active
+    end
+
+    def encrypt_frame(buf)
+      return buf unless dave_active?
+
+      @dave_encryptor.encrypt_audio_frame(@ssrc, buf)
+    end
 
     # Encrypts audio data using libsodium
     # @param buf [String] The encoded audio data to be encrypted
@@ -184,6 +220,9 @@ module Discordrb::Voice
       @endpoint = endpoint
 
       @udp = VoiceUDP.new
+      @media_ready = false
+      @dave_expected_user_ids = Set.new([@bot.profile.id.to_s])
+      @dave_expected_user_ids.merge(@channel.users.map { |user| user.id.to_s })
     end
 
     # Send a connection init packet (op 0)
@@ -192,14 +231,18 @@ module Discordrb::Voice
     # @param session_id [String] The voice session ID
     # @param token [String] The Discord authentication token
     def send_init(server_id, bot_user_id, session_id, token)
+      data = {
+        server_id: server_id,
+        user_id: bot_user_id,
+        session_id: session_id,
+        token: token
+      }
+
+      data[:max_dave_protocol_version] = Discordrb::Voice::DAVE.max_supported_protocol_version if LIBDAVE_AVAILABLE
+
       send_opcode(
         Opcodes::IDENTIFY,
-        {
-          server_id: server_id,
-          user_id: bot_user_id,
-          session_id: session_id,
-          token: token
-        }
+        data
       )
     end
 
@@ -253,7 +296,12 @@ module Discordrb::Voice
       @client.send({
         op: opcode,
         d: data
-      }.to_json)
+      }.to_json, :text)
+    end
+
+    def send_binary_opcode(opcode, payload = ''.b)
+      @bot.debug("Sending voice binary opcode #{opcode} (#{payload.bytesize} bytes)")
+      @client.send(opcode.chr + payload, :binary)
     end
 
     # Event handlers; public for websocket-simple to work correctly
@@ -268,9 +316,19 @@ module Discordrb::Voice
 
     # @!visibility private
     def websocket_message(msg)
+      if msg.type == :binary
+        websocket_binary_message(msg.data)
+      else
+        websocket_text_message(msg.data)
+      end
+    rescue StandardError => e
+      @connection_error ||= e
+      raise
+    end
+
+    def websocket_text_message(msg)
       @bot.debug("Received VWS message! #{msg}")
       packet = JSON.parse(msg)
-
       @seq = packet['seq'] if packet['seq']
 
       case packet['op']
@@ -292,13 +350,46 @@ module Discordrb::Voice
         # Reset the sequence when starting a new session
         @seq = 0
 
-        @ready = true
         @udp.secret_key = @ws_data['secret_key'].pack('C*')
         @udp.mode = @ws_data['mode']
+        setup_dave(@ws_data['dave_protocol_version'].to_i)
+        @ready = true
+        @media_ready = !dave_required?
       when Discordrb::Voice::Opcodes::HELLO
         # Opcode 8 contains the heartbeat interval.
         @heartbeat_interval = packet['d']['heartbeat_interval']
         send_heartbeat
+      when Discordrb::Voice::Opcodes::CLIENT_CONNECT
+        update_expected_users(packet.dig('d', 'user_ids'))
+      when Discordrb::Voice::Opcodes::CLIENT_DISCONNECT
+        remove_expected_user(packet.dig('d', 'user_id'))
+      when Discordrb::Voice::Opcodes::DAVE_PREPARE_TRANSITION
+        handle_dave_prepare_transition(packet['d'])
+      when Discordrb::Voice::Opcodes::DAVE_EXECUTE_TRANSITION
+        handle_dave_execute_transition(packet['d']['transition_id'])
+      when Discordrb::Voice::Opcodes::DAVE_PREPARE_EPOCH
+        handle_dave_prepare_epoch(packet['d'])
+      end
+    end
+
+    def websocket_binary_message(msg)
+      opcode = msg.getbyte(2)
+      payload = msg.byteslice(3..) || ''.b
+      @bot.debug("Received VWS binary opcode #{opcode} (#{payload.bytesize} bytes)")
+
+      case opcode
+      when Discordrb::Voice::Opcodes::DAVE_MLS_EXTERNAL_SENDER
+        dave_control_session.external_sender = payload
+      when Discordrb::Voice::Opcodes::DAVE_MLS_PROPOSALS
+        process_dave_proposals(payload)
+      when Discordrb::Voice::Opcodes::DAVE_MLS_COMMIT_WELCOME
+        @bot.warn('Ignoring unexpected DAVE commit/welcome echo from voice gateway')
+      when Discordrb::Voice::Opcodes::DAVE_MLS_ANNOUNCE_COMMIT_TRANSITION
+        transition_id, commit = unpack_transition_payload(payload)
+        process_dave_commit(transition_id, commit)
+      when Discordrb::Voice::Opcodes::DAVE_MLS_WELCOME
+        transition_id, welcome = unpack_transition_payload(payload)
+        process_dave_welcome(transition_id, welcome)
       end
     end
 
@@ -335,7 +426,7 @@ module Discordrb::Voice
       @bot.debug('Waiting for op 4 now')
 
       # Wait for op 4, then finish
-      sleep 0.05 until @ready
+      sleep 0.05 until ready_for_media?
     end
 
     # Disconnects the websocket and kills the thread
@@ -344,6 +435,149 @@ module Discordrb::Voice
     end
 
     private
+
+    def ready_for_media?
+      raise @connection_error if @connection_error
+
+      @ready && @media_ready
+    end
+
+    def dave_required?
+      @dave_protocol_version&.positive?
+    end
+
+    def setup_dave(protocol_version)
+      @dave_protocol_version = protocol_version
+      return unless dave_required?
+
+      raise 'libdave is unavailable - unable to create DAVE voice session' unless LIBDAVE_AVAILABLE
+
+      @pending_dave_session = build_dave_session(protocol_version)
+      send_dave_key_package(@pending_dave_session)
+    end
+
+    def build_dave_session(protocol_version)
+      Discordrb::Voice::DAVE::Session.new(
+        protocol_version: protocol_version,
+        group_id: @channel.id,
+        self_user_id: @bot.profile.id
+      ) do |source, reason|
+        raise "DAVE MLS failure from #{source}: #{reason}"
+      end
+    end
+
+    def update_expected_users(user_ids)
+      Array(user_ids).each { |user_id| @dave_expected_user_ids << user_id.to_s }
+    end
+
+    def remove_expected_user(user_id)
+      @dave_expected_user_ids.delete(user_id.to_s)
+    end
+
+    def dave_control_session
+      @pending_dave_session || @dave_session || raise('DAVE session is not initialized')
+    end
+
+    def send_dave_key_package(session)
+      send_binary_opcode(Opcodes::DAVE_MLS_KEY_PACKAGE, session.key_package)
+    end
+
+    def process_dave_proposals(payload)
+      commit_welcome = dave_control_session.process_proposals(payload, @dave_expected_user_ids.to_a)
+      send_binary_opcode(Opcodes::DAVE_MLS_COMMIT_WELCOME, commit_welcome) if commit_welcome
+    end
+
+    def process_dave_commit(transition_id, commit)
+      result = dave_control_session.process_commit(commit)
+
+      if result.failed?
+        send_dave_invalid_commit_welcome(transition_id)
+        return
+      end
+
+      return if result.ignored?
+
+      track_pending_transition(transition_id)
+      send_dave_ready_for_transition(transition_id)
+    end
+
+    def process_dave_welcome(transition_id, welcome)
+      dave_control_session.process_welcome(welcome, @dave_expected_user_ids.to_a)
+      track_pending_transition(transition_id, activate_pending_session: true)
+      send_dave_ready_for_transition(transition_id)
+    end
+
+    def unpack_transition_payload(payload)
+      [payload.unpack1('n'), payload.byteslice(2..) || ''.b]
+    end
+
+    def handle_dave_prepare_transition(data)
+      @pending_transition_id = data['transition_id']
+      @pending_transition_protocol_version = data['protocol_version'].to_i
+      @activate_pending_session ||= !@pending_dave_session.nil?
+
+      if @pending_transition_id.zero?
+        handle_dave_execute_transition(@pending_transition_id)
+      elsif @pending_transition_protocol_version.zero?
+        send_dave_ready_for_transition(@pending_transition_id)
+      end
+    end
+
+    def handle_dave_prepare_epoch(data)
+      protocol_version = data['protocol_version'].to_i
+      epoch = data['epoch'].to_i
+
+      if epoch == 1
+        @pending_dave_session = build_dave_session(protocol_version)
+        @pending_transition_protocol_version = protocol_version
+        send_dave_key_package(@pending_dave_session)
+      else
+        dave_control_session.protocol_version = protocol_version
+        @pending_transition_protocol_version = protocol_version
+      end
+    end
+
+    def handle_dave_execute_transition(transition_id)
+      return unless @pending_transition_id.nil? || transition_id == @pending_transition_id
+
+      if @pending_transition_protocol_version.to_i.zero?
+        @udp.send(:deactivate_dave!)
+        @dave_protocol_version = 0
+        @media_ready = true
+        clear_pending_transition
+        return
+      end
+
+      if @activate_pending_session || (@dave_session.nil? && @pending_dave_session)
+        @dave_session = @pending_dave_session
+        @pending_dave_session = nil
+      end
+
+      @udp.send(:activate_dave!, dave_control_session, @bot.profile.id)
+      @dave_protocol_version = dave_control_session.protocol_version
+      @media_ready = true
+      clear_pending_transition
+    end
+
+    def track_pending_transition(transition_id, activate_pending_session: false)
+      @pending_transition_id = transition_id
+      @pending_transition_protocol_version ||= dave_control_session.protocol_version
+      @activate_pending_session = @activate_pending_session || activate_pending_session || !@pending_dave_session.nil?
+    end
+
+    def clear_pending_transition
+      @pending_transition_id = nil
+      @pending_transition_protocol_version = nil
+      @activate_pending_session = false
+    end
+
+    def send_dave_ready_for_transition(transition_id)
+      send_opcode(Opcodes::DAVE_TRANSITION_READY, { transition_id: transition_id })
+    end
+
+    def send_dave_invalid_commit_welcome(transition_id)
+      send_opcode(Opcodes::DAVE_MLS_INVALID_COMMIT_WELCOME, { transition_id: transition_id })
+    end
 
     def heartbeat_loop
       @heartbeat_running = true
@@ -367,8 +601,14 @@ module Discordrb::Voice
         host,
         method(:websocket_open),
         method(:websocket_message),
-        proc { |e| Discordrb::LOGGER.error "VWS error: #{e}" },
-        proc { |e| Discordrb::LOGGER.warn "VWS close: #{e}" }
+        proc do |e|
+          @connection_error ||= e if !@ready || !@media_ready
+          Discordrb::LOGGER.error "VWS error: #{e}"
+        end,
+        proc do |e|
+          @connection_error ||= e if !@ready || !@media_ready
+          Discordrb::LOGGER.warn "VWS close: #{e}"
+        end
       )
 
       @bot.debug('VWS connected')

--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -360,7 +360,10 @@ module Discordrb::Voice
         @heartbeat_interval = packet['d']['heartbeat_interval']
         send_heartbeat
       when Discordrb::Voice::Opcodes::CLIENT_CONNECT
-        update_expected_users(packet.dig('d', 'user_ids'))
+        # The voice gateway uses 'user_ids' (plural) for DAVE-enabled sessions, but fall back
+        # to the legacy singular 'user_id' key in case only one ID is sent.
+        user_ids = packet.dig('d', 'user_ids') || Array(packet.dig('d', 'user_id'))
+        update_expected_users(user_ids)
       when Discordrb::Voice::Opcodes::CLIENT_DISCONNECT
         remove_expected_user(packet.dig('d', 'user_id'))
       when Discordrb::Voice::Opcodes::DAVE_PREPARE_TRANSITION
@@ -389,7 +392,7 @@ module Discordrb::Voice
       when Discordrb::Voice::Opcodes::DAVE_MLS_PROPOSALS
         process_dave_proposals(payload)
       when Discordrb::Voice::Opcodes::DAVE_MLS_COMMIT_WELCOME
-        @bot.warn('Ignoring unexpected DAVE commit/welcome echo from voice gateway')
+        Discordrb::LOGGER.warn('DAVE: Ignoring unexpected DAVE commit/welcome echo from voice gateway')
       when Discordrb::Voice::Opcodes::DAVE_MLS_ANNOUNCE_COMMIT_TRANSITION
         transition_id, commit = unpack_transition_payload(payload)
         process_dave_commit(transition_id, commit)
@@ -468,9 +471,7 @@ module Discordrb::Voice
         protocol_version: protocol_version,
         group_id: @channel.id,
         self_user_id: @bot.profile.id
-      ) do |source, reason|
-        raise Discordrb::Voice::DAVE::Error, "MLS failure from #{source}: #{reason}"
-      end
+      )
     end
 
     def update_expected_users(user_ids)
@@ -492,8 +493,16 @@ module Discordrb::Voice
 
     def process_dave_proposals(payload)
       @bot.debug("DAVE: Processing MLS proposals (#{payload.bytesize} bytes)")
+      # Sync with current channel members as a fallback for cases where CLIENT_CONNECT
+      # arrives after the proposals (Discord gateway ordering is not always guaranteed).
+      @channel.users.each { |u| @dave_expected_user_ids << u.id.to_s }
       commit_welcome = dave_control_session.process_proposals(payload, @dave_expected_user_ids.to_a)
       send_binary_opcode(Opcodes::DAVE_MLS_COMMIT_WELCOME, commit_welcome) if commit_welcome
+    rescue Discordrb::Voice::DAVE::Error => e
+      Discordrb::LOGGER.warn("DAVE: Failed to process MLS proposals: #{e.message}, recovering")
+      protocol_version = dave_control_session.protocol_version
+      @pending_dave_session = build_dave_session(protocol_version)
+      send_dave_key_package(@pending_dave_session)
     end
 
     def process_dave_commit(transition_id, commit)
@@ -515,7 +524,7 @@ module Discordrb::Voice
       @bot.debug("DAVE: Transition #{transition_id} is ready")
       send_dave_ready_for_transition(transition_id)
     rescue Discordrb::Voice::DAVE::Error => e
-      @bot.warn("DAVE: Failed to process MLS commit for transition #{transition_id}: #{e.message}")
+      Discordrb::LOGGER.warn("DAVE: Failed to process MLS commit for transition #{transition_id}: #{e.message}")
       handle_invalid_dave_group(transition_id)
     end
 
@@ -526,7 +535,7 @@ module Discordrb::Voice
       @bot.debug("DAVE: Transition #{transition_id} is ready")
       send_dave_ready_for_transition(transition_id)
     rescue Discordrb::Voice::DAVE::Error => e
-      @bot.warn("DAVE: Failed to process MLS welcome for transition #{transition_id}: #{e.message}")
+      Discordrb::LOGGER.warn("DAVE: Failed to process MLS welcome for transition #{transition_id}: #{e.message}")
       handle_invalid_dave_group(transition_id)
     end
 

--- a/lib/discordrb/websocket.rb
+++ b/lib/discordrb/websocket.rb
@@ -35,7 +35,7 @@ module Discordrb
           if msg.code
             instance.close_handler.call(msg)
           else
-            instance.message_handler.call(msg.data)
+            instance.message_handler.call(msg)
           end
         end
         ws.on(:close) { |err| instance.close_handler.call(err) }
@@ -45,8 +45,9 @@ module Discordrb
 
     # Send data over this WebSocket
     # @param data [String] What to send
-    def send(data)
-      @client.send(data)
+    # @param type [Symbol] The websocket frame type.
+    def send(data, type = :text)
+      @client.send(data, type: type)
     end
 
     # Close the WebSocket connection

--- a/spec/voice_network_spec.rb
+++ b/spec/voice_network_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module Discordrb
+  module Voice
+  end
+end
+
+require 'discordrb/voice/network'
+
+RSpec.describe Discordrb::Voice::VoiceWS do
+  let(:profile) { instance_double('Profile', id: 123) }
+  let(:server) { instance_double('Server', id: 456) }
+  let(:member) { instance_double('Member', id: 789) }
+  let(:channel) { instance_double('Channel', server: server, users: [member], id: 555) }
+  let(:bot) { instance_double('Bot', profile: profile) }
+  let(:client) { instance_double(Discordrb::WebSocket) }
+  let(:udp) { instance_double(Discordrb::Voice::VoiceUDP) }
+
+  subject(:voice_ws) { described_class.new(channel, bot, 'token', 'session', 'endpoint') }
+
+  before do
+    allow(bot).to receive(:debug)
+    allow(bot).to receive(:warn)
+
+    voice_ws.instance_variable_set(:@client, client)
+    voice_ws.instance_variable_set(:@udp, udp)
+
+    allow(udp).to receive(:secret_key=)
+    allow(udp).to receive(:mode=)
+    allow(udp).to receive(:send_discovery)
+    allow(udp).to receive(:connect)
+    allow(udp).to receive(:send)
+  end
+
+  describe '#send_init' do
+    it 'advertises the maximum DAVE protocol version when libdave is available' do
+      stub_const('Discordrb::Voice::LIBDAVE_AVAILABLE', true)
+      stub_const('Discordrb::Voice::DAVE', double(max_supported_protocol_version: 1))
+
+      expect(client).to receive(:send) do |payload, type|
+        expect(type).to eq(:text)
+
+        data = JSON.parse(payload)
+        expect(data).to include('op' => Discordrb::Voice::Opcodes::IDENTIFY)
+        expect(data.fetch('d')).to include(
+          'server_id' => 456,
+          'user_id' => 123,
+          'session_id' => 'session',
+          'token' => 'token',
+          'max_dave_protocol_version' => 1
+        )
+      end
+
+      voice_ws.send_init(456, 123, 'session', 'token')
+    end
+  end
+
+  describe 'DAVE binary message handling' do
+    let(:session) { instance_double('DAVE::Session') }
+
+    before do
+      voice_ws.instance_variable_set(:@pending_dave_session, session)
+    end
+
+    it 'passes external sender payloads to the DAVE session' do
+      expect(session).to receive(:external_sender=).with('sender-package')
+
+      voice_ws.send(
+        :websocket_binary_message,
+        "#{[0, 1, Discordrb::Voice::Opcodes::DAVE_MLS_EXTERNAL_SENDER].pack('C*')}sender-package"
+      )
+    end
+
+    it 'sends commit/welcome data returned from proposal processing as a binary opcode' do
+      expect(session).to receive(:process_proposals).with('proposal-bytes', array_including('123', '789')).and_return('commit')
+      expect(client).to receive(:send).with("#{Discordrb::Voice::Opcodes::DAVE_MLS_COMMIT_WELCOME.chr}commit", :binary)
+
+      voice_ws.send(
+        :websocket_binary_message,
+        "#{[0, 1, Discordrb::Voice::Opcodes::DAVE_MLS_PROPOSALS].pack('C*')}proposal-bytes"
+      )
+    end
+  end
+
+  describe 'DAVE transitions' do
+    let(:session) { instance_double('DAVE::Session', protocol_version: 1) }
+    let(:commit_result) { instance_double('DAVE::CommitResult', failed?: false, ignored?: false) }
+
+    before do
+      voice_ws.instance_variable_set(:@dave_session, session)
+      voice_ws.instance_variable_set(:@pending_transition_protocol_version, 1)
+      allow(session).to receive(:process_commit).with('commit-bytes').and_return(commit_result)
+    end
+
+    it 'marks a processed commit ready and activates DAVE on execute' do
+      expect(client).to receive(:send) do |payload, type|
+        expect(type).to eq(:text)
+
+        data = JSON.parse(payload)
+        expect(data).to include('op' => Discordrb::Voice::Opcodes::DAVE_TRANSITION_READY)
+        expect(data.fetch('d')).to include('transition_id' => 7)
+      end
+
+      voice_ws.send(
+        :websocket_binary_message,
+        "#{[0, 1, Discordrb::Voice::Opcodes::DAVE_MLS_ANNOUNCE_COMMIT_TRANSITION].pack('C*')}#{[7].pack('n')}commit-bytes"
+      )
+
+      expect(udp).to receive(:send).with(:activate_dave!, session, 123)
+      voice_ws.send(:handle_dave_execute_transition, 7)
+    end
+  end
+end

--- a/spec/voice_network_spec.rb
+++ b/spec/voice_network_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Discordrb::Voice::VoiceWS do
 
   before do
     allow(bot).to receive(:debug)
-    allow(bot).to receive(:warn)
 
     voice_ws.instance_variable_set(:@client, client)
     voice_ws.instance_variable_set(:@udp, udp)
@@ -55,6 +54,28 @@ RSpec.describe Discordrb::Voice::VoiceWS do
     end
   end
 
+  describe 'CLIENT_CONNECT handling' do
+    it 'adds users from the plural user_ids key to the expected user set' do
+      voice_ws.send(:websocket_text_message, {
+        op: Discordrb::Voice::Opcodes::CLIENT_CONNECT,
+        d: { user_ids: ['111', '222'] }
+      }.to_json)
+
+      expected = voice_ws.instance_variable_get(:@dave_expected_user_ids)
+      expect(expected).to include('111', '222')
+    end
+
+    it 'adds users from the legacy singular user_id key to the expected user set' do
+      voice_ws.send(:websocket_text_message, {
+        op: Discordrb::Voice::Opcodes::CLIENT_CONNECT,
+        d: { user_id: '333' }
+      }.to_json)
+
+      expected = voice_ws.instance_variable_get(:@dave_expected_user_ids)
+      expect(expected).to include('333')
+    end
+  end
+
   describe 'DAVE binary message handling' do
     let(:session) { instance_double('DAVE::Session') }
 
@@ -80,6 +101,30 @@ RSpec.describe Discordrb::Voice::VoiceWS do
         :websocket_binary_message,
         "#{[0, 1, Discordrb::Voice::Opcodes::DAVE_MLS_PROPOSALS].pack('C*')}proposal-bytes"
       )
+    end
+
+    it 'recovers gracefully when proposal processing fails for an unrecognized user' do
+      new_session = instance_double('DAVE::Session')
+      allow(session).to receive(:process_proposals).and_raise(Discordrb::Voice::DAVE::Error, 'MLS failure in proposals: ValidateProposalMessage: Unexpected user ID in add proposal')
+      allow(session).to receive(:protocol_version).and_return(1)
+
+      stub_const('Discordrb::Voice::LIBDAVE_AVAILABLE', true)
+      allow(Discordrb::Voice::DAVE::Session).to receive(:new).and_return(new_session)
+      allow(new_session).to receive(:key_package).and_return('key-package')
+      logger = instance_double('Logger')
+      stub_const('Discordrb::LOGGER', logger)
+      allow(logger).to receive(:warn)
+
+      expect(client).to receive(:send).with(
+        "#{Discordrb::Voice::Opcodes::DAVE_MLS_KEY_PACKAGE.chr}key-package", :binary
+      )
+
+      voice_ws.send(
+        :websocket_binary_message,
+        "#{[0, 1, Discordrb::Voice::Opcodes::DAVE_MLS_PROPOSALS].pack('C*')}proposal-bytes"
+      )
+
+      expect(voice_ws.instance_variable_get(:@dave_recovering)).to be_falsy
     end
   end
 

--- a/spec/voice_network_spec.rb
+++ b/spec/voice_network_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Discordrb::Voice::VoiceWS do
     end
 
     it 'sends commit/welcome data returned from proposal processing as a binary opcode' do
+      expect(bot).to receive(:debug).with("DAVE: Processing MLS proposals (#{'proposal-bytes'.bytesize} bytes)")
       expect(session).to receive(:process_proposals).with('proposal-bytes', array_including('123', '789')).and_return('commit')
       expect(client).to receive(:send).with("#{Discordrb::Voice::Opcodes::DAVE_MLS_COMMIT_WELCOME.chr}commit", :binary)
 
@@ -93,6 +94,8 @@ RSpec.describe Discordrb::Voice::VoiceWS do
     end
 
     it 'marks a processed commit ready and activates DAVE on execute' do
+      expect(bot).to receive(:debug).with('DAVE: Processing MLS commit for transition 7').ordered
+      expect(bot).to receive(:debug).with('DAVE: Transition 7 is ready').ordered
       expect(client).to receive(:send) do |payload, type|
         expect(type).to eq(:text)
 
@@ -107,6 +110,7 @@ RSpec.describe Discordrb::Voice::VoiceWS do
       )
 
       expect(udp).to receive(:send).with(:activate_dave!, session, 123)
+      expect(bot).to receive(:debug).with('DAVE: Enabled voice frame encryption with protocol version 1')
       voice_ws.send(:handle_dave_execute_transition, 7)
     end
   end

--- a/spec/voice_network_spec.rb
+++ b/spec/voice_network_spec.rb
@@ -158,5 +158,86 @@ RSpec.describe Discordrb::Voice::VoiceWS do
       expect(bot).to receive(:debug).with('DAVE: Enabled voice frame encryption with protocol version 1')
       voice_ws.send(:handle_dave_execute_transition, 7)
     end
+
+    context 'initial join (DAVE_MLS_WELCOME without preceding PREPARE_TRANSITION)' do
+      let(:pending_session) { instance_double('DAVE::Session', protocol_version: 1) }
+      let(:welcome_result) { instance_double('DAVE::CommitResult', failed?: false, ignored?: false) }
+
+      before do
+        voice_ws.instance_variable_set(:@pending_dave_session, pending_session)
+        voice_ws.instance_variable_set(:@pending_transition_protocol_version, 1)
+        allow(pending_session).to receive(:process_welcome)
+        allow(pending_session).to receive(:protocol_version).and_return(1)
+        allow(client).to receive(:send) # DAVE_TRANSITION_READY
+      end
+
+      it 'activates DAVE immediately when a welcome arrives without a prior PREPARE_TRANSITION' do
+        expect(udp).to receive(:send).with(:activate_dave!, pending_session, 123)
+        expect(bot).to receive(:debug).with(a_string_including('Enabled voice frame encryption'))
+
+        voice_ws.send(
+          :websocket_binary_message,
+          "#{[0, 1, Discordrb::Voice::Opcodes::DAVE_MLS_WELCOME].pack('C*')}#{[0].pack('n')}welcome-bytes"
+        )
+
+        expect(voice_ws.instance_variable_get(:@media_ready)).to be true
+        # State must be clean so subsequent epoch handling isn't poisoned by stale commit ID
+        expect(voice_ws.instance_variable_get(:@mls_commit_transition_id)).to be_nil
+        expect(voice_ws.instance_variable_get(:@pending_transition_id)).to be_nil
+      end
+    end
+
+    context 'deferred DAVE_PREPARE_TRANSITION(id=0) execution' do
+      let(:pending_session) { instance_double('DAVE::Session', protocol_version: 1) }
+      let(:pending_commit_result) { instance_double('DAVE::CommitResult', failed?: false, ignored?: false) }
+
+      before do
+        voice_ws.instance_variable_set(:@pending_dave_session, pending_session)
+        voice_ws.instance_variable_set(:@pending_transition_id, 0)
+        voice_ws.instance_variable_set(:@activate_pending_session, true)
+        allow(pending_session).to receive(:process_commit).and_return(pending_commit_result)
+        allow(pending_session).to receive(:protocol_version).and_return(1)
+      end
+
+      it 'executes the transition after the commit arrives when PREPARE_TRANSITION arrives first' do
+        # PREPARE_TRANSITION(id=0) arrives while pending session exists → deferred
+        voice_ws.send(:handle_dave_prepare_transition, { 'transition_id' => 0, 'protocol_version' => 1 })
+        expect(voice_ws.instance_variable_get(:@deferred_transition_execute)).to be true
+        expect(voice_ws.instance_variable_get(:@media_ready)).to be false
+
+        # Commit arrives → should trigger deferred execute and set @media_ready.
+        # process_dave_commit also sends DAVE_TRANSITION_READY after track_pending_transition.
+        allow(client).to receive(:send)
+        expect(udp).to receive(:send).with(:activate_dave!, pending_session, 123)
+        expect(bot).to receive(:debug).with(a_string_including('Enabled voice frame encryption'))
+
+        voice_ws.send(
+          :websocket_binary_message,
+          "#{[0, 1, Discordrb::Voice::Opcodes::DAVE_MLS_ANNOUNCE_COMMIT_TRANSITION].pack('C*')}#{[0].pack('n')}commit-bytes"
+        )
+
+        expect(voice_ws.instance_variable_get(:@media_ready)).to be true
+        expect(voice_ws.instance_variable_get(:@deferred_transition_execute)).to be false
+      end
+
+      it 'executes the transition immediately when commit arrives before PREPARE_TRANSITION' do
+        # Commit arrives first
+        expect(client).to receive(:send) # DAVE_TRANSITION_READY
+        voice_ws.send(
+          :websocket_binary_message,
+          "#{[0, 1, Discordrb::Voice::Opcodes::DAVE_MLS_ANNOUNCE_COMMIT_TRANSITION].pack('C*')}#{[0].pack('n')}commit-bytes"
+        )
+        expect(voice_ws.instance_variable_get(:@mls_commit_transition_id)).to eq(0)
+        expect(voice_ws.instance_variable_get(:@media_ready)).to be false
+
+        # PREPARE_TRANSITION(id=0) arrives after commit → should execute immediately
+        expect(udp).to receive(:send).with(:activate_dave!, pending_session, 123)
+        expect(bot).to receive(:debug).with(a_string_including('Enabled voice frame encryption'))
+
+        voice_ws.send(:handle_dave_prepare_transition, { 'transition_id' => 0, 'protocol_version' => 1 })
+
+        expect(voice_ws.instance_variable_get(:@media_ready)).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
# Summary

Adds DAVE E2EE voice protocol support through ffi [discord/libdave](https://github.com/discord/libdave) bindings. DAVE support is only enabled when the libdave native libraries are found and can be loaded, so it is not a new hard dependency unless bot operators want to use voice features.

For testing on macos, i provide a libdave homebrew cask so you can `brew tap coderobe/libdave && brew install libdave` and this change should pick it up and enable it automatically.

The path to the libdave shared library can be overridden by setting `DISCORDRB_LIBDAVE_PATH`, and additional libdave-internal debug log verbosity can be tuned with `DISCORDRB_LIBDAVE_LOG_LEVEL` (defaults to `warning`).

---

## Added
`discordrb/voice/dave`: DAVE E2EE protocol support