### PR TITLE
feat: tidier gateway messages

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1817,6 +1817,12 @@ module Discordrb
       @gateway.notify_ready
     end
 
+    # Raise an event every time the websocket connection is resumed (t = "RESUMED")
+    def notify_resumed
+      raise_event(ResumedEvent.new(self))
+      LOGGER.out('Resumed')
+    end
+
     def raise_event(event)
       debug("Raised a #{event.class}")
       handle_awaits(event)

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -79,6 +79,16 @@ module Discordrb
       register_event(HeartbeatEvent, attributes, block)
     end
 
+    # This **event** is raised every time the bot successfully resumes a Gateway session. This happens roughly
+    # between every 30 minutes to 6 hours.
+    # @param attributes [Hash] Event attributes, none in this particular case.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [ResumedEvent] The event that was raised.
+    # @return [ResumedEventHandler] the event handler that was registered.
+    def resumed(attributes = {}, &block)
+      register_event(ResumedEvent, attributes, block)
+    end
+
     # This **event** is raised when somebody starts typing in a channel the bot is also in. The official Discord
     # client would display the typing indicator for five seconds after receiving this event. If the user continues
     # typing after five seconds, the event will be re-raised.

--- a/lib/discordrb/events/lifetime.rb
+++ b/lib/discordrb/events/lifetime.rb
@@ -28,4 +28,10 @@ module Discordrb::Events
 
   # Event handler for {HeartbeatEvent}
   class HeartbeatEventHandler < TrueEventHandler; end
+
+  # @see Discordrb::EventContainer#resumed
+  class ResumedEvent < LifetimeEvent; end
+
+  # Event handler for {ResumedEvent}
+  class ResumedEventHandler < TrueEventHandler; end
 end

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -494,7 +494,7 @@ module Discordrb
         break unless @should_reconnect
 
         if @instant_reconnect
-          LOGGER.info('Instant reconnection flag was set - reconnecting right away')
+          LOGGER.out('Instant reconnection flag was set - reconnecting right away')
           @instant_reconnect = false
         else
           wait_for_reconnect
@@ -743,7 +743,7 @@ module Discordrb
         # The RESUMED event is received after a successful op 6 (resume). It does nothing except tell the bot the
         # connection is initiated (like READY would). Starting with v5, it doesn't set a new heartbeat interval anymore
         # since that is handled by op 10 (HELLO).
-        LOGGER.info 'Resumed'
+        LOGGER.out('Resumed')
         return
       end
 
@@ -836,7 +836,8 @@ module Discordrb
         LOGGER.error('The websocket connection has closed due to an error!')
         LOGGER.log_exception(e)
       else
-        LOGGER.error("The websocket connection has closed: #{e&.inspect || '(no information)'}")
+        e = e&.inspect
+        LOGGER.error("The websocket connection has closed: #{e}") if e
       end
     end
 

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -743,7 +743,7 @@ module Discordrb
         # The RESUMED event is received after a successful op 6 (resume). It does nothing except tell the bot the
         # connection is initiated (like READY would). Starting with v5, it doesn't set a new heartbeat interval anymore
         # since that is handled by op 10 (HELLO).
-        LOGGER.out('Resumed')
+        @bot.__send__(:notify_resumed)
         return
       end
 


### PR DESCRIPTION
## Summary
Currently, if you have a long-lived bot, your logs will get insanely cluttered. Reconnects are a normal part of Discord. The gateway automatically disconnects you around every 30 minutes or so for load balancing reasons. There's no reason (in my opinion) to justify logging this information by default when the log mode is set to `:normal`.