### PR TITLE
fix: ruby version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you enjoy using the library, consider getting involved with the community to 
 
 ## Dependencies
 
-- Ruby >= 3.2 supported
+- Ruby >= 3.3 supported
 - An installed build system for native extensions (on Windows, make sure you download the "Ruby+Devkit" version of [RubyInstaller](https://rubyinstaller.org/downloads/))
 
 ### Voice dependencies


### PR DESCRIPTION
## Summary
Our minimum supported ruby version is 3.3, but in the README, it's accidentally listed as 3.2.