### PR TITLE
feat: file type filters

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -124,15 +124,22 @@ module Discordrb::API::Channel
     raise
   end
 
-  # Send a file as a message to a channel
-  # https://discord.com/developers/docs/resources/channel#upload-file
+  # @deprecated Please migrate to using {.send_attachment}.
   def upload_file(token, channel_id, file, caption: nil, tts: false)
+    send_attachment(token, channel_id, file, tts: tts, description: caption)
+  end
+
+  # Send a message to a channel. In the future, this will be obselete as
+  #   {.create_message} will eventually support passing these attributes per-file.
+  def send_attachment(token, channel_id, file, tts: nil, description: nil, spoiler: nil)
+    body = { id: 0, description: description, is_spoiler: spoiler }.compact
+
     Discordrb::API.request(
       :channels_cid_messages_mid,
       channel_id,
       :post,
       "#{Discordrb::API.api_base}/channels/#{channel_id}/messages",
-      { file: file, content: caption, tts: tts },
+      { 'files[0]' => file, payload_json: { tts: tts, attachments: [body] }.to_json },
       Authorization: token
     )
   end

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -465,25 +465,17 @@ module Discordrb
     # @note This executes in a blocking way, so if you're sending long files, be wary of delays.
     # @param channel [Channel, String, Integer] The channel, or its ID, to send something to.
     # @param file [File] The file that should be sent.
-    # @param caption [string] The caption for the file.
-    # @param tts [true, false] Whether or not this file's caption should be sent using Discord text-to-speech.
-    # @param filename [String] Overrides the filename of the uploaded file
-    # @param spoiler [true, false] Whether or not this file should appear as a spoiler.
+    # @param caption [string, nil] The description of the file.
+    # @param tts [true, false, nil] Whether or not this file's caption should be sent using Discord text-to-speech.
+    # @param filename [String, nil] Overrides the filename of the uploaded file.
+    # @param spoiler [true, false, nil] Whether or not this file should appear as a spoiler.
     # @example Send a file from disk
     #   bot.send_file(83281822225530880, File.open('rubytaco.png', 'r'))
     def send_file(channel, file, caption: nil, tts: false, filename: nil, spoiler: nil)
-      if file.respond_to?(:read)
-        if spoiler
-          filename ||= File.basename(file.path)
-          filename = "SPOILER_#{filename}" unless filename.start_with? 'SPOILER_'
-        end
-        # https://github.com/rest-client/rest-client/blob/v2.0.2/lib/restclient/payload.rb#L160
-        file.define_singleton_method(:original_filename) { filename } if filename
-        file.define_singleton_method(:path) { filename } if filename
-      end
+      # https://github.com/rest-client/rest-client/blob/v2.0.2/lib/restclient/payload.rb#L160
+      file.define_singleton_method(:original_filename) { filename } if filename && file.respond_to?(:read)
 
-      channel = channel.resolve_id
-      response = API::Channel.upload_file(token, channel, file, caption: caption, tts: tts)
+      response = API::Channel.send_attachment(token, channel.resolve_id, file, description: caption, tts:, spoiler:)
       Message.new(JSON.parse(response), self)
     end
 

--- a/lib/discordrb/data/attachment.rb
+++ b/lib/discordrb/data/attachment.rb
@@ -98,21 +98,19 @@ module Discordrb
       @clip_creation_time = Time.iso8601(data['clip_created_at']) if data['clip_created_at']
     end
 
+    # Check if the attachment is an image.
     # @return [true, false] whether this file is an image file.
     def image?
       !(@width.nil? || @height.nil?)
     end
 
-    # @return [true, false] whether this file is tagged as a spoiler.
-    def spoiler?
-      @filename.start_with?('SPOILER_') || @flags.anybits?(FLAGS[:spoiler])
-    end
-
+    # Get the message associated with the attachment.
     # @return [Message, nil] the message this attachment object belongs to.
     def message
       @message unless @message.is_a?(Snapshot)
     end
 
+    # Get the message snapshot associated with the attachment.
     # @return [Snapshot, nil] the message snapshot this attachment object belongs to.
     def snapshot
       @message unless @message.is_a?(Message)
@@ -124,8 +122,10 @@ module Discordrb
     #   @return [true, false] whether or not the attachment is the thumbnail of a thread in a media channel.
     # @!method animated?
     #   @return [true, false] whether or not the attachment is considered to be an animated image.
+    # @!method spoiler?
+    #   @return [true, false] whether or not the attachment is marked as a spoiler.
     FLAGS.each do |name, value|
-      define_method("#{name}?") { @flags.anybits?(value) } if name != :spoiler
+      define_method("#{name}?") { @flags.anybits?(value) }
     end
   end
 end

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -627,7 +627,7 @@ module Discordrb
         attachment: 11
       }.freeze
 
-      # Channel types that can be provided to #channel
+      # Channel types that can be provided to {#channel}.
       CHANNEL_TYPES = {
         text: 0,
         dm: 1,
@@ -639,7 +639,10 @@ module Discordrb
         news_thread: 10,
         public_thread: 11,
         private_thread: 12,
-        stage: 13
+        stage: 13,
+        directory: 14,
+        forum: 15,
+        media: 16
       }.freeze
 
       # @return [Array<Hash>]
@@ -769,9 +772,11 @@ module Discordrb
       # @param name [String, Symbol] The name of the argument.
       # @param description [String] A description of the argument.
       # @param required [true, false] Whether this option must be provided.
+      # @param types [Array<String, Symbol>] The file extensions or file groups to
+      #   restrict the option to. This restriction is **only** a client-side check.
       # @return (see #option)
-      def attachment(name, description, required: nil)
-        option(TYPES[:attachment], name, description, required: required)
+      def attachment(name, description, required: nil, types: nil)
+        option(TYPES[:attachment], name, description, required: required, file_types: types)
       end
 
       # @!visibility private
@@ -785,15 +790,16 @@ module Discordrb
       # @param max_length [Integer] A maximum length for string option value.
       # @param channel_types [Array<Integer>] Channel types that can be provides for channel options.
       # @param autocomplete [true, false] Whether this option can dynamically show options.
+      # @param file_types [Array<String, Symbol>] The file types to restrict this option to in the client.
       # @return Hash
       def option(type, name, description, required: nil, choices: nil, options: nil, min_value: nil, max_value: nil,
-                 min_length: nil, max_length: nil, channel_types: nil, autocomplete: nil)
+                 min_length: nil, max_length: nil, channel_types: nil, autocomplete: nil, file_types: nil)
         opt = { type: type, name: name, description: description }
         choices = choices.map { |option_name, value| { name: option_name, value: value } } if choices
 
         opt.merge!({ required: required, choices: choices, options: options, min_value: min_value,
                      max_value: max_value, min_length: min_length, max_length: max_length,
-                     channel_types: channel_types, autocomplete: autocomplete }.compact)
+                     channel_types: channel_types, autocomplete: autocomplete, file_types: file_types }.compact)
 
         @options << opt
         opt

--- a/lib/discordrb/webhooks/modal.rb
+++ b/lib/discordrb/webhooks/modal.rb
@@ -203,8 +203,10 @@ class Discordrb::Webhooks::Modal
     # @param min_values [Integer, nil] The minimum amount of files a user must upload.
     # @param max_values [Integer, nil] The maximum amount of files a user has to upload.
     # @param required [true, false, nil] Whether or not a file must be uploaded to the component.
-    def file_upload(custom_id:, id: nil, min_values: nil, max_values: nil, required: nil)
-      @component = { type: COMPONENT_TYPES[:file_upload], custom_id: custom_id, id: id, min_values: min_values, max_values: max_values, required: required }.compact
+    # @param types [Array<String, Symbol>, nil] The types of files that a user can upload. This can be a file extension or one of:
+    #  `image`, `video`, or `audio`. This is only a **client-side restriction**, meaning that you must continue to ensure that the file is valid.
+    def file_upload(custom_id:, id: nil, min_values: nil, max_values: nil, required: nil, types: nil)
+      @component = { type: COMPONENT_TYPES[:file_upload], custom_id: custom_id, id: id, min_values: min_values, max_values: max_values, required: required, file_types: types }.compact
     end
 
     # Add a standalone checkbox component to the label component.

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -224,59 +224,26 @@ describe Discordrb::Bot do
   end
 
   describe '#send_file' do
-    let(:channel) { double(:channel, resolve_id: double) }
+    let(:channel) { double(:channel, resolve_id: 381_891_448_884_428_801) }
 
-    it 'defines original_filename when filename is passed' do
-      original_filename = double(:original_filename)
-      file = double(:file, original_filename: original_filename, read: true)
-      new_filename = double('new filename')
+    it 'defines the original_filename method when an override path is passed' do
+      file = double(:file, original_filename: 'ruby.png', read: true)
 
-      allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
       allow(Discordrb::Message).to receive(:new)
+      allow(Discordrb::API::Channel).to receive(:send_attachment).and_return('{}')
 
-      bot.send_file(channel, file, filename: new_filename)
-      expect(file.original_filename).to eq new_filename
+      bot.send_file(channel.resolve_id, file, filename: 'crystal.png')
+      expect(file.original_filename).to eq('crystal.png')
     end
 
-    it 'does not define original_filename when filename is nil' do
-      original_filename = double(:original_filename)
-      file = double(:file, read: true, original_filename: original_filename)
+    it 'Does not defines the original_filename method when the filename is `nil`' do
+      file = double(:file, original_filename: 'ruby.png', read: true)
 
-      allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
       allow(Discordrb::Message).to receive(:new)
+      allow(Discordrb::API::Channel).to receive(:send_attachment).and_return('{}')
 
-      bot.send_file(channel, file)
-      expect(file.original_filename).to eq original_filename
-    end
-
-    it 'prepends "SPOILER_" when spoiler is truthy and the filename does not start with "SPOILER_"' do
-      file = double(:file, read: true)
-
-      allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
-      allow(Discordrb::Message).to receive(:new)
-
-      bot.send_file(channel, file, filename: 'file.txt', spoiler: true)
-      expect(file.original_filename).to eq 'SPOILER_file.txt'
-    end
-
-    it 'does not prepend "SPOILER_" if the filename starts with "SPOILER_"' do
-      file = double(:file, read: true, path: 'SPOILER_file.txt')
-
-      allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
-      allow(Discordrb::Message).to receive(:new)
-
-      bot.send_file(channel, file, spoiler: true)
-      expect(file.original_filename).to eq 'SPOILER_file.txt'
-    end
-
-    it 'uses the original filename when spoiler is truthy and filename is nil' do
-      file = double(:file, read: true, path: 'file.txt')
-
-      allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
-      allow(Discordrb::Message).to receive(:new)
-
-      bot.send_file(channel, file, spoiler: true)
-      expect(file.original_filename).to eq 'SPOILER_file.txt'
+      bot.send_file(channel.resolve_id, file)
+      expect(file.original_filename).to eq('ruby.png')
     end
   end
 


### PR DESCRIPTION
## Summary

Adds the new `file_types` option for modals and slash commands. Should be noted that this is only a client-side check, and that you should still need to validate the contents of the file.