### PR TITLE
feat: channel obfuscation

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1512,16 +1512,19 @@ module Discordrb
         raise_event(event)
       when :CHANNEL_CREATE
         create_channel(data)
+        return if @channels[data['id'].to_i]&.obfuscated?
 
         event = ChannelCreateEvent.new(data, self)
         raise_event(event)
       when :CHANNEL_UPDATE
         update_channel(data)
+        return if @channels[data['id'].to_i]&.obfuscated?
 
         event = ChannelUpdateEvent.new(data, self)
         raise_event(event)
       when :CHANNEL_DELETE
         delete_channel(data)
+        return if data['flags'].to_i.anybits?(Channel::FLAGS[:obfuscated])
 
         event = ChannelDeleteEvent.new(data, self)
         raise_event(event)

--- a/lib/discordrb/cache.rb
+++ b/lib/discordrb/cache.rb
@@ -177,10 +177,13 @@ module Discordrb
     # Ensures a given channel object is cached and if not, cache it from the given data hash.
     # @param data [Hash] A data hash representing a channel.
     # @param server [Server, nil] The server the channel is on, if known.
+    # @param unhide [true, false, nil] Whether to deobfuscate the channel if it was recieved
+    #   from an interaction and the channel is already cached.
     # @return [Channel] the channel represented by the data hash.
-    def ensure_channel(data, server = nil)
-      if @channels.include?(data['id'].to_i)
-        @channels[data['id'].to_i]
+    def ensure_channel(data, server = nil, unhide = nil)
+      if (channel = @channels[data['id'].to_i])
+        channel.update_data(data) if unhide && channel.obfuscated?
+        channel
       else
         @channels[data['id'].to_i] = Channel.new(data, self, server)
       end

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -29,8 +29,9 @@ module Discordrb
     # Map of channel flags.
     FLAGS = {
       pinned: 1 << 1,
-      require_tag: 1 << 4,
-      hide_download_options: 1 << 15
+      requires_tag: 1 << 4,
+      hide_download_options: 1 << 15,
+      obfuscated: 1 << 17
     }.freeze
 
     # Map of forum layouts.
@@ -173,6 +174,7 @@ module Discordrb
 
       @id = data['id'].to_i
       @type = data['type'] || 0
+      @flags = data['flags'] || 0
       @topic = data['topic']
       @bitrate = data['bitrate']
       @user_limit = data['user_limit']
@@ -192,7 +194,7 @@ module Discordrb
           @owner_id = data['owner_id']
         end
       else
-        @name = data['name']
+        @name = obfuscated? ? '' : data['name']
         @server_id = server&.id || data['guild_id'].to_i
         @server = server
       end
@@ -217,7 +219,6 @@ module Discordrb
         @member_flags = member['flags']
       end
 
-      @flags = data['flags'] || 0
       @voice_region = data['rtc_region']
       @video_quality_mode = data['video_quality_mode']
       @last_message_id = data['last_message_id']&.to_i
@@ -233,6 +234,21 @@ module Discordrb
       process_last_pin_timestamp(data['last_pin_timestamp'])
       process_permission_overwrites(data['permission_overwrites'])
       process_default_reaction_emoji(data['default_reaction_emoji'])
+    end
+
+    # @!method pinned?
+    #   @return [true, false] whether or not the thread has been pinned in the forum channel.
+    # @!method requires_tag?
+    #   @return [true, false] whether or not threads created in the forum channel require a tag to be set.
+    # @!method hide_download_options?
+    #   @return [true, false] whether or not the media channel has hidden the download options.
+    # @!method obfuscated?
+    #   @return [true, false] whether or not the channel's attributes are hidden because the bot does not
+    #      have the required permissions to view the channel.
+    FLAGS.each do |name, value|
+      define_method("#{name}?") do
+        @flags.anybits?(value)
+      end
     end
 
     # @return [Server, nil] the server this channel is on. If this channel is a PM channel, it will be nil.
@@ -447,9 +463,11 @@ module Discordrb
     #   @param type [Symbol] the kind of overwrite to return
     #   @return [Array<Overwrite>]
     def permission_overwrites(type = nil)
-      return @permission_overwrites unless type
-
-      @permission_overwrites.values.select { |e| e.type == type }
+      if type
+        obfuscated? ? [] : @permission_overwrites&.filter_map { |_, e| e if e.type == type } || []
+      else
+        obfuscated? ? {} : @permission_overwrites || {}
+      end
     end
 
     alias_method :overwrites, :permission_overwrites
@@ -1321,8 +1339,9 @@ module Discordrb
       @type = new_data['type'] || 0
       @topic = new_data['topic']
       @bitrate = new_data['bitrate']
-      @name = new_data['name'] || @name
+      @flags = new_data['flags'] || 0
       @user_limit = new_data['user_limit']
+      @name = obfuscated? ? '' : new_data['name']
 
       @position = new_data['position']
       @parent_id = new_data['parent_id']&.to_i
@@ -1332,7 +1351,6 @@ module Discordrb
       @member_count = new_data['member_count']
 
       @total_message_sent = new_data['total_message_sent'] || 0
-      @flags = new_data['flags'] || 0
       @voice_region = new_data['rtc_region']
       @video_quality_mode = new_data['video_quality_mode']
       @last_message_id = new_data['last_message_id']&.to_i

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -108,7 +108,7 @@ module Discordrb
       @data = data['data']
       @server_id = data['guild_id']&.to_i
       @channel_id = data['channel_id']&.to_i
-      @channel = bot.ensure_channel(data['channel']) if data['channel']
+      @channel = bot.ensure_channel(data['channel'], nil, true) if data['channel']
       @user = if data['member']
                 data['member']['guild_id'] = @server_id
                 Discordrb::Member.new(data['member'], bot.servers[@server_id], bot)

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -173,7 +173,7 @@ module Discordrb
       return true if defined_permission?(:administrator, channel)
 
       # Otherwise, defer to defined_permission
-      defined_permission?(action, channel)
+      channel&.obfuscated? && current_bot? ? false : defined_permission?(action, channel)
     end
 
     # Checks whether this user has a particular permission defined (i.e. not implicit, through for example


### PR DESCRIPTION
## Summary

In a few months, channels that your bot cannot view will hide their attributes (e.g. topic, name, overwrites, etc.)

## Added
`Channel#obfuscated?`
`Channel::FLAGS[:obfuscated]`

## Changed
- Calculate permissions correctly for obfuscated channels
- Return an empty object when accessing overwrites for an obfuscated channel
- Don't raise events for obfuscated channels (or maybe not depending on what people think?)