### PR TITLE
feat: spoiler channels

### DIFF
--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -90,13 +90,13 @@ module Discordrb::API::Server
 
   # Create a channel
   # https://discord.com/developers/docs/resources/guild#create-guild-channel
-  def create_channel(token, server_id, name, type, topic, bitrate, user_limit, permission_overwrites, parent_id, nsfw, rate_limit_per_user, position, reason = nil)
+  def create_channel(token, server_id, name, type, topic, bitrate, user_limit, permission_overwrites, parent_id, nsfw, rate_limit_per_user, position, reason = nil, flags = nil)
     Discordrb::API.request(
       :guilds_sid_channels,
       server_id,
       :post,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/channels",
-      { name: name, type: type, topic: topic, bitrate: bitrate, user_limit: user_limit, permission_overwrites: permission_overwrites, parent_id: parent_id, nsfw: nsfw, rate_limit_per_user: rate_limit_per_user, position: position }.to_json,
+      { name: name, type: type, topic: topic, bitrate: bitrate, user_limit: user_limit, permission_overwrites: permission_overwrites, parent_id: parent_id, nsfw: nsfw, rate_limit_per_user: rate_limit_per_user, position: position, flags: flags }.to_json,
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -30,7 +30,8 @@ module Discordrb
     FLAGS = {
       pinned: 1 << 1,
       require_tag: 1 << 4,
-      hide_download_options: 1 << 15
+      hide_download_options: 1 << 15,
+      spoiler: 1 << 21
     }.freeze
 
     # Map of forum layouts.
@@ -423,9 +424,21 @@ module Discordrb
     # Get the time at when this channel was created at.
     # @return [Time] The time at when the channel was created.
     def creation_time
-      return @create_timestamp if @create_timestamp
+      @create_timestamp || super
+    end
 
-      Time.at(((@id >> 22) + Discordrb::DISCORD_EPOCH) / 1000.0)
+    # Check if the channel is a spoiler channel.
+    # @return [true, false] Whether or not this channel is marked as a spoiler channel.
+    def spoiler?
+      return false if nsfw?
+
+      # Somehow, this flags can be set on individual threads that don't
+      # have a spoiler parent as well, through the raw API (as of 7/25/2026).
+      if thread?
+        @flags.anybits?(FLAGS[:spoiler]) || parent&.spoiler?
+      else
+        @flags.anybits?(FLAGS[:spoiler])
+      end
     end
 
     # Sets whether this channel is NSFW

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -727,17 +727,19 @@ module Discordrb
     # @param parent [Channel, String, Integer] parent category, or its ID, for this channel to be created in.
     # @param nsfw [true, false] whether this channel should be created as nsfw
     # @param rate_limit_per_user [Integer] how many seconds users need to wait in between messages.
+    # @param flags [Integer, Symbol, Array<Symbol, Integer>, nil] The flags to set for the channel. Only `:spoiler` is supported.
     # @param reason [String] The reason the for the creation of this channel.
     # @return [Channel] the created channel.
-    # @raise [ArgumentError] if type is not 0 (text), 2 (voice), 4 (category), 5 (news), or 6 (store)
-    def create_channel(name, type = 0, topic: nil, bitrate: nil, user_limit: nil, permission_overwrites: nil, parent: nil, nsfw: false, rate_limit_per_user: nil, position: nil, reason: nil)
-      type = Channel::TYPES[type] if type.is_a?(Symbol)
-      raise ArgumentError, 'Channel type must be either 0 (text), 2 (voice), 4 (category), news (5), or store (6)!' unless [0, 2, 4, 5, 6].include?(type)
+    # @raise [ArgumentError] if the type of channel specified is not valid.
+    def create_channel(name, type = 0, topic: nil, bitrate: nil, user_limit: nil, permission_overwrites: nil, parent: nil, nsfw: false, rate_limit_per_user: nil, position: nil, flags: nil, reason: nil)
+      type = Channel::TYPES[type.to_sym] unless type.is_a?(Numeric)
+      invalid_types = Channel::TYPES.values_at(:dm, :group, :store, :news_thread, :public_thread, :private_thread, :directory)
+      raise ArgumentError, 'Invalid channel type' if invalid_types.include?(type)
 
+      flags = flags ? [*flags].reduce(0) { |mask, bit| mask | (Channel::FLAGS[bit] || bit.to_i) } : 0
       permission_overwrites.map! { |e| e.is_a?(Overwrite) ? e.to_hash : e } if permission_overwrites.is_a?(Array)
-      parent_id = parent.respond_to?(:resolve_id) ? parent.resolve_id : nil
-      response = API::Server.create_channel(@bot.token, @id, name, type, topic, bitrate, user_limit, permission_overwrites, parent_id, nsfw, rate_limit_per_user, position, reason)
-      Channel.new(JSON.parse(response), @bot)
+      response = API::Server.create_channel(@bot.token, @id, name, type, topic, bitrate, user_limit, permission_overwrites, parent&.resolve_id, nsfw, rate_limit_per_user, position, reason, flags)
+      @bot.gateway.intents.anybits?(INTENTS[:servers]) ? Channel.new(JSON.parse(response), @bot) : @bot.ensure_channel(JSON.parse(response))
     end
 
     # Creates a role on this server which can then be modified. It will be initialized


### PR DESCRIPTION
# Summary

Adds support for spoiler channels.

## Added
`Channel#spoiler?`
`Channel::FLAGS[:spoiler]`
`flags:` KWARG to `Server#create_channel`

## Changed
In `Server#create_channel`, there's a set of channel types that are allowed to be created (other types throw an error). I've inverted this to be a set of channel types that cannot be created. This means that when Discord adds a new channel type, it'll implicitly be creatable