### PR TITLE
feat: use byte sniffing

### DIFF
--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -126,17 +126,44 @@ module Discordrb
     end
   end
 
-  # A utility method to base64 encode a file like object using its mime type.
-  # @param file [File, #read] A file like object that responds to #read.
-  # @return [String] The file object encoded as base64 image data.
+  # A utility method to base64 encode a file like-object into a data URI.
+  # @param file [File, #read] A file like object that responds to `#read`.
+  # @return [String] The file object represented in its Base64 data URI form.
+  # @raise [ArgumentError] If the file-like object does not respond to `#read`.
   def self.encode64(file)
-    path_method = %i[original_filename path local_path].find { |method| file.respond_to?(method) }
+    raise ArgumentError, 'File or file-like object must respond to {#read}' unless file.respond_to?(:read)
 
-    raise ArgumentError, 'File object must respond to original_filename, path, or local path.' unless path_method
-    raise ArgumentError, 'File object must respond to read.' unless file.respond_to?(:read)
+    "data:#{sniff_mime_type(file)};base64,#{Base64.encode64(file.read).strip}"
+  end
 
-    mime_type = MIME::Types.type_for(file.__send__(path_method)).first&.to_s || 'image/jpeg'
-    "data:#{mime_type};base64,#{Base64.encode64(file.read).strip}"
+  # A utility method to determine the content type of a file.
+  # @param file [File, #read] A file-like object that responds to `#read`.
+  # @return [String] The content type of the file. The only content types that are
+  #   currently supported include: `audio/ogg`, `image/png`, `image/gif`, `image/webp`,
+  #   `audio/mpeg`, `image/avif`, `image/jpeg`, and `application/json`.
+  # @raise [ArgumentError] If the content type of the file was unable to be determined.
+  def self.sniff_mime_type(file)
+    bytes = file.read(12).tap { file.rewind }
+
+    if bytes.start_with?('OggS'.b)
+      'audio/ogg'
+    elsif bytes.start_with?("\x89PNG\r\n\x1A\n".b)
+      'image/png'
+    elsif bytes.start_with?('GIF87a'.b, 'GIF89a'.b)
+      'image/gif'
+    elsif bytes.start_with?('RIFF'.b) && bytes[8, 4] == 'WEBP'.b
+      'image/webp'
+    elsif bytes.start_with?("\xFF\xFB".b, "\xFF\xF3".b, "\xFF\xF2".b, 'ID3'.b)
+      'audio/mpeg'
+    elsif bytes[4, 4] == 'ftyp'.b && ['avif'.b, 'avis'.b].include?(bytes[8, 4])
+      'image/avif'
+    elsif bytes.start_with?("\xFF\xD8\xFF".b) || ['JFIF'.b, 'Exif'.b].include?(bytes[6, 4])
+      'image/jpeg'
+    elsif bytes.start_with?('{'.b)
+      'application/json'
+    else
+      raise ArgumentError, 'Unable to determine the exact content type of the provided file.'
+    end
   end
 end
 

--- a/lib/discordrb/data/interaction.rb
+++ b/lib/discordrb/data/interaction.rb
@@ -243,6 +243,7 @@ module Discordrb
     # @param poll [Hash, Poll::Builder, Poll, nil] The poll that should be attached to this message.
     # @return [InteractionMessage] The updated response message.
     # @yieldparam builder [Webhooks::Builder] An optional message builder. Arguments passed to the method overwrite builder data.
+    # @yieldparam view [Webhooks::View] A builder for creating interaction components.
     def edit_response(content: nil, embeds: nil, allowed_mentions: nil, flags: 0, components: nil, attachments: nil, has_components: false, poll: nil)
       flags |= (1 << 15) if has_components
 
@@ -274,6 +275,7 @@ module Discordrb
     # @param has_components [true, false] Whether this message includes any V2 components. Enabling this disables sending content, polls, and embeds.
     # @param poll [Hash, Poll::Builder, Poll, nil] The poll that should be attached to this message.
     # @yieldparam builder [Webhooks::Builder] An optional message builder. Arguments passed to the method overwrite builder data.
+    # @yieldparam view [Webhooks::View] A builder for creating interaction components.
     def send_message(content: nil, embeds: nil, tts: false, allowed_mentions: nil, flags: 0, ephemeral: false, components: nil, attachments: nil, has_components: false, poll: nil)
       flags |= 64 if ephemeral
       flags |= (1 << 15) if has_components
@@ -302,6 +304,7 @@ module Discordrb
     # @param has_components [true, false] Whether this message includes any V2 components. Enabling this disables sending content, polls, and embeds.
     # @param poll [Hash, Poll::Builder, Poll, nil] The poll that should be attached to this message.
     # @yieldparam builder [Webhooks::Builder] An optional message builder. Arguments passed to the method overwrite builder data.
+    # @yieldparam view [Webhooks::View] A builder for creating interaction components.
     def edit_message(message, content: nil, embeds: nil, allowed_mentions: nil, components: nil, attachments: nil, flags: 0, has_components: false, poll: nil)
       builder = Discordrb::Webhooks::Builder.new
       view = Discordrb::Webhooks::View.new

--- a/spec/data/webhook_spec.rb
+++ b/spec/data/webhook_spec.rb
@@ -166,8 +166,9 @@ describe Discordrb::Webhook do
   describe '#avatarise' do
     context 'avatar responds to read' do
       it 'returns encoded' do
-        avatar = double('avatar', read: 'text', path: '/foo')
-        expect(webhook.send(:avatarise, avatar)).to eq 'data:image/jpeg;base64,dGV4dA=='
+        avatar = double('avatar', read: "\xFF\xD8\xFF".b, path: '/foo')
+        allow(avatar).to receive(:rewind)
+        expect(webhook.send(:avatarise, avatar)).to eq 'data:image/jpeg;base64,/9j/'
       end
     end
 


### PR DESCRIPTION
## Summary

I understand that this is kinda out of the blue, and that this makes the code slightly more complex/approachable since you're dealing with file signatures and the like, but i have a kinda decent reason for wanting to change this

- Unfortunately, if we ever want to support stickers (specifically allowing them to be uploaded to servers), we need to provide the exact content type of the sticker file. Unlike every-other endpoint that accepts file uploads, the sticker endpoint is strict and rejects `application/octet-stream` or a content type that doesn't match the contents of a file.

- If you provide something like a `Tempfile` or `StringIO` to something like `Server#create_emoji` it's currently always fallback to a `image/jpeg` content type. While this is okay right now because Discord basically ignores the content-type your provide in the base64 string, they could decide to make it strict at anytime (like stickers). You could technically do something like below, to provide the content type, I think it's pretty janky to expect people to be defining singleton methods:

- If we ever decide to ditch `rest-client`, we won't be able to use the `mime-types` gem (unless we want to make it an explicit dependency) since it's a transitive dependency from `rest-client`.

- All of the file types that Discord supports are well-documented and easy to find: https://en.wikipedia.org/wiki/List_of_file_signatures


```ruby
string_io.define_singleton_method(:original_filename) { "foo.#{my_extension}" }
```

## Added
`Discordrb.sniff_mime_type` (thanks [discord.py](https://github.com/Rapptz/discord.py/blob/main/discord/utils.py#L623))

## Fixed
I snuck in the doc fixes related to the component builder not being documented on a few interaction methods.
